### PR TITLE
ci: GitHub Actions PR validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  typecheck-api:
+    name: Typecheck API
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: api/package-lock.json
+      - run: npm ci
+      - run: npx tsc --noEmit
+
+  typecheck-frontend:
+    name: Typecheck Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx svelte-kit sync
+      - run: npx tsc --noEmit
+
+  build-frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+    needs: typecheck-frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+
+  build-api:
+    name: Build API
+    runs-on: ubuntu-latest
+    needs: typecheck-api
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: api/package-lock.json
+      - run: npm ci
+      - run: npm run build
+
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    needs: [build-frontend, build-api]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          dockerfile: Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build API image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./api
+          dockerfile: api/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@sveltejs/adapter-node": "^5.0.1",
         "@sveltejs/kit": "^2.5.5",
         "@sveltejs/vite-plugin-svelte": "^3.1.0",
+        "@types/node": "^25.6.0",
         "svelte": "^4.2.18",
         "svelte-check": "^3.7.1",
         "tslib": "^2.6.2",
@@ -1083,6 +1084,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@types/pug": {
       "version": "2.0.10",
@@ -2267,6 +2278,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@sveltejs/adapter-node": "^5.0.1",
     "@sveltejs/kit": "^2.5.5",
     "@sveltejs/vite-plugin-svelte": "^3.1.0",
+    "@types/node": "^25.6.0",
     "svelte": "^4.2.18",
     "svelte-check": "^3.7.1",
     "tslib": "^2.6.2",


### PR DESCRIPTION
## Summary
- Typecheck API (`tsc --noEmit`) on every PR
- Typecheck + build frontend on every PR
- Docker image builds for both services (validates Dockerfiles don't drift)
- GHA cache for `node_modules` and Docker layers (fast subsequent runs)

## Pipeline
```
typecheck-api  ──► build-api  ──┐
                                ├──► docker-build
typecheck-frontend ──► build-frontend ──┘
```

## Test plan
- [ ] Push a TS error → typecheck job fails, blocks PR
- [ ] Clean PR → all 5 jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)