### PR TITLE
feat: Technitium DNS integration layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ CORS_ORIGIN=http://localhost:5113
 # Coolify integration (leave empty to use mock data)
 COOLIFY_API_URL=http://192.168.3.250:8000/api/v1
 COOLIFY_API_TOKEN=your-coolify-api-token-here
+
+# Technitium DNS integration (leave empty to use mock data)
+TECHNITIUM_URL=http://192.168.3.250:5380
+TECHNITIUM_TOKEN=your-technitium-api-token-here

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -33,6 +33,12 @@ app.listen(PORT, () => {
   } else {
     console.log('[coolify] No COOLIFY_API_URL set — running in mock data mode');
   }
+  const technitiumUrl = process.env.TECHNITIUM_URL;
+  if (technitiumUrl) {
+    console.log(`[technitium] Integration active — base URL: ${technitiumUrl}`);
+  } else {
+    console.log('[technitium] No TECHNITIUM_URL set — DNS in mock mode');
+  }
 });
 
 export default app;

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -2,6 +2,15 @@ import { Router, Request, Response } from 'express';
 import { SITES, getSite, DnsRecord } from '../data/mock';
 import { createCoolifyClient } from '../services/coolify';
 import { mapSite, mapDeploy } from '../services/mapper';
+import { createTechnitiumClient } from '../services/technitium';
+import {
+  mapRecord,
+  shouldIncludeRecord,
+  buildAddParams,
+  buildUpdateParams,
+  buildDeleteParams,
+  decodeId,
+} from '../services/technitiumMapper';
 
 const router = Router();
 
@@ -59,21 +68,33 @@ router.get('/:slug', async (req: Request, res: Response) => {
 });
 
 // ── GET /api/sites/:slug/dns — DNS records for a site ────────────────────────
-// TODO: replace with Technitium API call
-// GET http://<technitium-host>:5380/api/zones/records/get?token=<token>&domain=<domain>
-router.get('/:slug/dns', (req: Request, res: Response) => {
+router.get('/:slug/dns', async (req: Request, res: Response) => {
   const site = getSite(req.params.slug);
   if (!site) {
     res.status(404).json({ error: 'Site not found' });
     return;
   }
-  res.status(200).json(site.dnsRecords);
+  const technitium = createTechnitiumClient();
+  if (!technitium) {
+    res.setHeader('x-data-source', 'mock');
+    res.status(200).json(site.dnsRecords);
+    return;
+  }
+  try {
+    const { zone, records } = await technitium.getRecords(site.domain);
+    const mapped = records
+      .filter((r) => shouldIncludeRecord(r, zone.name))
+      .map((r) => mapRecord(r, zone.name));
+    res.status(200).json(mapped);
+  } catch (err) {
+    console.warn(`[technitium] GET records for ${site.domain} failed, falling back to mock:`, (err as Error).message);
+    res.setHeader('x-data-source', 'mock');
+    res.status(200).json(site.dnsRecords);
+  }
 });
 
-// ── POST /api/sites/:slug/dns — add a DNS record (stub) ──────────────────────
-// TODO: replace with Technitium API call
-// POST http://<technitium-host>:5380/api/zones/records/add?token=<token>
-router.post('/:slug/dns', (req: Request, res: Response) => {
+// ── POST /api/sites/:slug/dns — add a DNS record ─────────────────────────────
+router.post('/:slug/dns', async (req: Request, res: Response) => {
   const site = getSite(req.params.slug);
   if (!site) {
     res.status(404).json({ error: 'Site not found' });
@@ -84,50 +105,104 @@ router.post('/:slug/dns', (req: Request, res: Response) => {
     res.status(400).json({ error: 'Missing required fields: type, name, value, ttl' });
     return;
   }
-  const created: DnsRecord = {
-    id: `r-${Date.now()}`,
-    type: body.type,
-    name: body.name,
-    value: body.value,
-    ttl: body.ttl,
-    ...(body.priority !== undefined ? { priority: body.priority } : {})
-  };
-  res.status(201).json(created);
+  const technitium = createTechnitiumClient();
+  if (!technitium) {
+    res.status(503).json({ error: 'DNS integration unavailable — TECHNITIUM_URL not configured' });
+    return;
+  }
+  try {
+    const record: DnsRecord = {
+      id: '',
+      type: body.type,
+      name: body.name,
+      value: body.value,
+      ttl: body.ttl,
+      ...(body.priority !== undefined ? { priority: body.priority } : {}),
+    };
+    // Build full domain: name '@' means apex (site.domain), otherwise prepend subdomain
+    const domain = record.name === '@' ? site.domain : `${record.name}.${site.domain}`;
+    const params = buildAddParams(domain, record);
+    const raw = await technitium.addRecord(domain, params);
+    const { zone } = await technitium.getRecords(site.domain);
+    res.status(201).json(mapRecord(raw, zone.name));
+  } catch (err) {
+    console.warn(`[technitium] POST add record for ${site.domain} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Failed to add DNS record via Technitium' });
+  }
 });
 
-// ── PUT /api/sites/:slug/dns/:id — update a DNS record (stub) ────────────────
-// TODO: replace with Technitium API call
-// POST http://<technitium-host>:5380/api/zones/records/update?token=<token>
-router.put('/:slug/dns/:id', (req: Request, res: Response) => {
+// ── PUT /api/sites/:slug/dns/:id — update a DNS record ───────────────────────
+router.put('/:slug/dns/:id', async (req: Request, res: Response) => {
   const site = getSite(req.params.slug);
   if (!site) {
     res.status(404).json({ error: 'Site not found' });
     return;
   }
-  const existing = site.dnsRecords.find((r) => r.id === req.params.id);
-  if (!existing) {
-    res.status(404).json({ error: 'DNS record not found' });
+  const technitium = createTechnitiumClient();
+  if (!technitium) {
+    res.status(503).json({ error: 'DNS integration unavailable — TECHNITIUM_URL not configured' });
     return;
   }
-  const updated: DnsRecord = { ...existing, ...(req.body as Partial<DnsRecord>), id: existing.id };
-  res.status(200).json(updated);
+  let identity: { domain: string; type: string; value: string };
+  try {
+    identity = decodeId(req.params.id);
+  } catch {
+    res.status(400).json({ error: 'Invalid record ID' });
+    return;
+  }
+  try {
+    const existing: DnsRecord = {
+      id: req.params.id,
+      type: identity.type as DnsRecord['type'],
+      name: identity.domain,
+      value: identity.value,
+      ttl: 3600,
+    };
+    const updates = req.body as Partial<DnsRecord>;
+    const params = buildUpdateParams(identity.domain, existing, updates);
+    const raw = await technitium.updateRecord(identity.domain, params);
+    const { zone } = await technitium.getRecords(site.domain);
+    res.status(200).json(mapRecord(raw, zone.name));
+  } catch (err) {
+    console.warn(`[technitium] PUT update record ${req.params.id} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Failed to update DNS record via Technitium' });
+  }
 });
 
-// ── DELETE /api/sites/:slug/dns/:id — delete a DNS record (stub) ─────────────
-// TODO: replace with Technitium API call
-// GET http://<technitium-host>:5380/api/zones/records/delete?token=<token>&domain=<domain>&type=<type>&value=<value>
-router.delete('/:slug/dns/:id', (req: Request, res: Response) => {
+// ── DELETE /api/sites/:slug/dns/:id — delete a DNS record ────────────────────
+router.delete('/:slug/dns/:id', async (req: Request, res: Response) => {
   const site = getSite(req.params.slug);
   if (!site) {
     res.status(404).json({ error: 'Site not found' });
     return;
   }
-  const existing = site.dnsRecords.find((r) => r.id === req.params.id);
-  if (!existing) {
-    res.status(404).json({ error: 'DNS record not found' });
+  const technitium = createTechnitiumClient();
+  if (!technitium) {
+    res.status(503).json({ error: 'DNS integration unavailable — TECHNITIUM_URL not configured' });
     return;
   }
-  res.status(204).send();
+  let identity: { domain: string; type: string; value: string };
+  try {
+    identity = decodeId(req.params.id);
+  } catch {
+    res.status(400).json({ error: 'Invalid record ID' });
+    return;
+  }
+  try {
+    const record: DnsRecord = {
+      id: req.params.id,
+      type: identity.type as DnsRecord['type'],
+      name: identity.domain,
+      value: identity.value,
+      ttl: 0,
+    };
+    const params = buildDeleteParams(identity.domain, record);
+    await technitium.deleteRecord(identity.domain, params);
+    res.status(204).send();
+  } catch (err) {
+    console.warn(`[technitium] DELETE record ${req.params.id} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Failed to delete DNS record via Technitium' });
+  }
 });
 
 // ── GET /api/sites/:slug/deployments — deployment history ────────────────────

--- a/api/src/services/technitium.ts
+++ b/api/src/services/technitium.ts
@@ -1,0 +1,179 @@
+// Technitium DNS Server API client — typed, using Node 18+ native fetch only.
+// Auth is passed as a query parameter on every request per Technitium's API design.
+// All endpoints use POST with application/x-www-form-urlencoded bodies.
+
+export interface TechnitiumZone {
+  name: string;
+  type: string;
+  disabled: boolean;
+  internal: boolean;
+  dnssecStatus: string;
+}
+
+export interface TechnitiumRData {
+  // A / AAAA
+  ipAddress?: string;
+  // CNAME
+  cName?: string;
+  // MX
+  preference?: number;
+  exchange?: string;
+  // TXT
+  text?: string;
+  // NS
+  nameServer?: string;
+  // SRV
+  priority?: number;
+  weight?: number;
+  port?: number;
+  target?: string;
+}
+
+export interface TechnitiumRecord {
+  disabled: boolean;
+  name: string;
+  type: string;
+  ttl: number;
+  rData: TechnitiumRData;
+}
+
+export interface TechnitiumGetRecordsResponse {
+  response: {
+    zone: TechnitiumZone;
+    records: TechnitiumRecord[];
+  };
+  status: string;
+  errorMessage?: string;
+}
+
+export interface TechnitiumMutateResponse {
+  response: {
+    addedRecord?: TechnitiumRecord;
+    updatedRecord?: TechnitiumRecord;
+  };
+  status: string;
+  errorMessage?: string;
+}
+
+export interface TechnitiumDeleteResponse {
+  status: string;
+  errorMessage?: string;
+}
+
+export interface TechnitiumGetRecordsResult {
+  zone: TechnitiumZone;
+  records: TechnitiumRecord[];
+}
+
+async function handleResponse<T extends { status: string; errorMessage?: string }>(
+  res: Response,
+  context: string
+): Promise<T> {
+  if (!res.ok) {
+    const body = await res.text().catch(() => '(unreadable)');
+    throw new Error(`Technitium ${context} failed: HTTP ${res.status} — ${body}`);
+  }
+  const data = (await res.json()) as T;
+  if (data.status === 'error') {
+    throw new Error(`Technitium ${context} error: ${data.errorMessage ?? 'unknown error'}`);
+  }
+  return data;
+}
+
+export class TechnitiumClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly postHeaders: Record<string, string>;
+
+  constructor(baseUrl: string, token: string) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.token = token;
+    this.postHeaders = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    };
+  }
+
+  private buildParams(fields: Record<string, string | number | boolean>): URLSearchParams {
+    const params = new URLSearchParams();
+    params.set('token', this.token);
+    for (const [key, value] of Object.entries(fields)) {
+      params.set(key, String(value));
+    }
+    return params;
+  }
+
+  async getRecords(domain: string): Promise<TechnitiumGetRecordsResult> {
+    const body = this.buildParams({ domain, listZone: 'true' });
+    const res = await fetch(`${this.baseUrl}/api/zone/getRecords`, {
+      method: 'POST',
+      headers: this.postHeaders,
+      body,
+    });
+    const data = await handleResponse<TechnitiumGetRecordsResponse>(res, 'POST /api/zone/getRecords');
+    return {
+      zone: data.response.zone,
+      records: data.response.records,
+    };
+  }
+
+  async addRecord(
+    domain: string,
+    params: URLSearchParams
+  ): Promise<TechnitiumRecord> {
+    params.set('token', this.token);
+    params.set('domain', domain);
+    const res = await fetch(`${this.baseUrl}/api/zones/records/add`, {
+      method: 'POST',
+      headers: this.postHeaders,
+      body: params,
+    });
+    const data = await handleResponse<TechnitiumMutateResponse>(res, 'POST /api/zones/records/add');
+    if (!data.response.addedRecord) {
+      throw new Error('Technitium add record: response missing addedRecord');
+    }
+    return data.response.addedRecord;
+  }
+
+  async updateRecord(
+    domain: string,
+    params: URLSearchParams
+  ): Promise<TechnitiumRecord> {
+    params.set('token', this.token);
+    params.set('domain', domain);
+    const res = await fetch(`${this.baseUrl}/api/zones/records/update`, {
+      method: 'POST',
+      headers: this.postHeaders,
+      body: params,
+    });
+    const data = await handleResponse<TechnitiumMutateResponse>(res, 'POST /api/zones/records/update');
+    const updated = data.response.updatedRecord ?? data.response.addedRecord;
+    if (!updated) {
+      throw new Error('Technitium update record: response missing record');
+    }
+    return updated;
+  }
+
+  async deleteRecord(
+    domain: string,
+    params: URLSearchParams
+  ): Promise<void> {
+    params.set('token', this.token);
+    params.set('domain', domain);
+    const res = await fetch(`${this.baseUrl}/api/zones/records/delete`, {
+      method: 'POST',
+      headers: this.postHeaders,
+      body: params,
+    });
+    await handleResponse<TechnitiumDeleteResponse>(res, 'POST /api/zones/records/delete');
+  }
+}
+
+export function createTechnitiumClient(
+  baseUrl?: string,
+  token?: string
+): TechnitiumClient | null {
+  const url = baseUrl ?? process.env.TECHNITIUM_URL;
+  const tok = token ?? process.env.TECHNITIUM_TOKEN;
+  if (!url || !tok) return null;
+  return new TechnitiumClient(url, tok);
+}

--- a/api/src/services/technitiumMapper.ts
+++ b/api/src/services/technitiumMapper.ts
@@ -1,0 +1,234 @@
+// Maps Technitium raw API types → HermitHost internal DnsRecord type.
+
+import type { TechnitiumRecord } from './technitium';
+import type { DnsRecord, DnsRecordType } from '../data/mock';
+
+// ── ID encoding ───────────────────────────────────────────────────────────────
+// Technitium has no record UUIDs; encode {domain, type, value} as base64url
+// so delete/update can recover the identity params from just the ID.
+
+interface RecordIdentity {
+  domain: string;
+  type: string;
+  value: string;
+}
+
+export function encodeId(identity: RecordIdentity): string {
+  return Buffer.from(JSON.stringify(identity)).toString('base64url');
+}
+
+export function decodeId(id: string): RecordIdentity {
+  try {
+    const json = Buffer.from(id, 'base64url').toString('utf8');
+    return JSON.parse(json) as RecordIdentity;
+  } catch {
+    throw new Error(`Invalid DNS record ID: ${id}`);
+  }
+}
+
+// ── Name normalization ────────────────────────────────────────────────────────
+// Strip the zone suffix from the record name to get a relative name.
+// If name equals zone name exactly, return '@' (apex).
+
+function normalizeRecordName(recordName: string, zoneName: string): string {
+  if (recordName === zoneName) return '@';
+  const suffix = `.${zoneName}`;
+  if (recordName.endsWith(suffix)) {
+    return recordName.slice(0, -suffix.length);
+  }
+  return recordName;
+}
+
+// ── Value extraction from rData ───────────────────────────────────────────────
+
+function extractValue(raw: TechnitiumRecord): string {
+  const r = raw.rData;
+  switch (raw.type) {
+    case 'A':
+    case 'AAAA':
+      return r.ipAddress ?? '';
+    case 'CNAME':
+      return r.cName ?? '';
+    case 'MX':
+      return r.exchange ?? '';
+    case 'TXT':
+      return r.text ?? '';
+    case 'NS':
+      return r.nameServer ?? '';
+    case 'SRV':
+      return r.target ?? '';
+    default:
+      return '';
+  }
+}
+
+// ── Supported record type guard ───────────────────────────────────────────────
+
+const SUPPORTED_TYPES: ReadonlySet<string> = new Set([
+  'A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'SRV',
+]);
+
+function isSupportedType(type: string): type is DnsRecordType {
+  return SUPPORTED_TYPES.has(type);
+}
+
+// ── Filter predicate ──────────────────────────────────────────────────────────
+// Filter out: disabled records, SOA records, internal NS records (apex NS = zone's own NS)
+
+export function shouldIncludeRecord(raw: TechnitiumRecord, zoneName: string): boolean {
+  if (raw.disabled) return false;
+  if (raw.type === 'SOA') return false;
+  // Internal apex NS records (zone's own authority NS records)
+  if (raw.type === 'NS' && raw.name === zoneName) return false;
+  if (!isSupportedType(raw.type)) return false;
+  return true;
+}
+
+// ── Record mapper ─────────────────────────────────────────────────────────────
+
+export function mapRecord(raw: TechnitiumRecord, zoneName: string): DnsRecord {
+  const value = extractValue(raw);
+  const identity: RecordIdentity = { domain: raw.name, type: raw.type, value };
+  const id = encodeId(identity);
+  const name = normalizeRecordName(raw.name, zoneName);
+
+  const record: DnsRecord = {
+    id,
+    type: raw.type as DnsRecordType,
+    name,
+    value,
+    ttl: raw.rData.ipAddress !== undefined || raw.type === 'A' || raw.type === 'AAAA'
+      ? raw.ttl
+      : raw.ttl,
+  };
+
+  // Priority: MX uses rData.preference; SRV uses rData.priority
+  if (raw.type === 'MX' && raw.rData.preference !== undefined) {
+    record.priority = raw.rData.preference;
+  } else if (raw.type === 'SRV' && raw.rData.priority !== undefined) {
+    record.priority = raw.rData.priority;
+  }
+
+  return record;
+}
+
+// ── Add params builder ────────────────────────────────────────────────────────
+
+export function buildAddParams(domain: string, record: DnsRecord): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set('domain', domain);
+  params.set('type', record.type);
+  params.set('ttl', String(record.ttl));
+
+  switch (record.type) {
+    case 'A':
+    case 'AAAA':
+      params.set('ipAddress', record.value);
+      break;
+    case 'CNAME':
+      params.set('cName', record.value);
+      break;
+    case 'MX':
+      params.set('exchange', record.value);
+      params.set('preference', String(record.priority ?? 10));
+      break;
+    case 'TXT':
+      params.set('text', record.value);
+      break;
+    case 'NS':
+      params.set('nameServer', record.value);
+      break;
+    case 'SRV':
+      // SRV value is target; caller must supply priority/weight/port separately
+      // via record fields — priority is on the record, weight/port are not modeled
+      // in DnsRecord so we default them to 0
+      params.set('target', record.value);
+      params.set('priority', String(record.priority ?? 0));
+      params.set('weight', '0');
+      params.set('port', '0');
+      break;
+  }
+
+  return params;
+}
+
+// ── Update params builder ─────────────────────────────────────────────────────
+
+export function buildUpdateParams(
+  domain: string,
+  existing: DnsRecord,
+  updates: Partial<DnsRecord>
+): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set('domain', domain);
+  params.set('type', existing.type);
+  params.set('ttl', String(updates.ttl ?? existing.ttl));
+
+  switch (existing.type) {
+    case 'A':
+    case 'AAAA':
+      params.set('ipAddress', existing.value);
+      params.set('newIpAddress', updates.value ?? existing.value);
+      break;
+    case 'CNAME':
+      params.set('cName', existing.value);
+      params.set('newCname', updates.value ?? existing.value);
+      break;
+    case 'MX':
+      params.set('preference', String(existing.priority ?? 10));
+      params.set('exchange', existing.value);
+      params.set('newPreference', String(updates.priority ?? existing.priority ?? 10));
+      params.set('newExchange', updates.value ?? existing.value);
+      break;
+    case 'TXT':
+      params.set('text', existing.value);
+      params.set('newText', updates.value ?? existing.value);
+      break;
+    case 'NS':
+      params.set('nameServer', existing.value);
+      params.set('newNameServer', updates.value ?? existing.value);
+      break;
+    case 'SRV':
+      params.set('target', existing.value);
+      params.set('priority', String(existing.priority ?? 0));
+      params.set('newTarget', updates.value ?? existing.value);
+      params.set('newPriority', String(updates.priority ?? existing.priority ?? 0));
+      break;
+  }
+
+  return params;
+}
+
+// ── Delete params builder ─────────────────────────────────────────────────────
+
+export function buildDeleteParams(domain: string, record: DnsRecord): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set('domain', domain);
+  params.set('type', record.type);
+
+  switch (record.type) {
+    case 'A':
+    case 'AAAA':
+      params.set('ipAddress', record.value);
+      break;
+    case 'CNAME':
+      params.set('cName', record.value);
+      break;
+    case 'MX':
+      params.set('preference', String(record.priority ?? 10));
+      params.set('exchange', record.value);
+      break;
+    case 'TXT':
+      params.set('text', record.value);
+      break;
+    case 'NS':
+      params.set('nameServer', record.value);
+      break;
+    case 'SRV':
+      params.set('target', record.value);
+      params.set('priority', String(record.priority ?? 0));
+      break;
+  }
+
+  return params;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       CORS_ORIGIN: "http://localhost:5113"
       COOLIFY_API_URL: ""        # e.g. http://192.168.3.250:8000/api/v1 — empty = mock mode
       COOLIFY_API_TOKEN: ""      # Coolify API token
+      TECHNITIUM_URL: ""         # e.g. http://192.168.3.250:5380 — empty = mock mode
+      TECHNITIUM_TOKEN: ""       # Technitium API token
     networks:
       - hermithost-net
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- `TechnitiumClient` — native fetch, URLSearchParams POST, all CRUD methods
- `technitiumMapper.ts` — maps Technitium records → internal `DnsRecord`; base64url composite IDs (`domain:type:value`) make CRUD reversible without a record UUID
- DNS read (`GET /dns`) falls back to mock with `x-data-source: mock` header
- DNS writes (add/update/delete) return 503 when Technitium unavailable
- Filters out SOA, disabled, and internal NS records
- Startup log confirms mode

## Activation
```
TECHNITIUM_URL=http://192.168.3.250:5380
TECHNITIUM_TOKEN=<token-from-technitium-dashboard>
```

## Known limitation
`PUT` (update) reconstructs existing record from decoded ID rather than fetching live first. TTL defaults to 3600 for existing stub — validate against live Technitium instance; may need `getRecords` pre-fetch if Technitium requires exact current TTL to locate record.

## Test plan
- [ ] `tsc --noEmit` clean in `api/`
- [ ] Docker stack builds + starts
- [ ] API logs `[technitium] No TECHNITIUM_URL set — DNS in mock mode`
- [ ] `GET /api/sites/:slug/dns` returns mock DNS records

🤖 Generated with [Claude Code](https://claude.com/claude-code)