### PR TITLE
feat: live HTTP/SSL/DNS health probes on site detail

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -11,6 +11,7 @@ import {
   buildDeleteParams,
   decodeId,
 } from '../services/technitiumMapper';
+import { probeSite } from '../services/healthProbe';
 
 const router = Router();
 
@@ -47,14 +48,25 @@ router.get('/:slug', async (req: Request, res: Response) => {
       res.status(404).json({ error: 'Site not found' });
       return;
     }
-    res.status(200).json(site);
+    const probe = site.domain ? await probeSite(site.domain).catch(() => null) : null;
+    res.status(200).json(probe ? { ...site, ...probe } : site);
     return;
   }
   try {
     const client = createCoolifyClient()!;
     const app = await client.getApplication(req.params.slug);
-    const deployments = await client.listDeployments(app.uuid).catch(() => []);
-    res.status(200).json(mapSite(app, deployments));
+    const domain = app.fqdn
+      ? app.fqdn.split(',')[0].trim().replace(/^https?:\/\//, '')
+      : '';
+
+    const [deployments, probe] = await Promise.all([
+      client.listDeployments(app.uuid).catch(() => []),
+      domain
+        ? probeSite(domain).catch(() => null)
+        : Promise.resolve(null),
+    ]);
+
+    res.status(200).json(mapSite(app, deployments, probe));
   } catch (err) {
     console.warn(`[coolify] GET /applications/${req.params.slug} failed, falling back to mock:`, (err as Error).message);
     const site = getSite(req.params.slug);

--- a/api/src/services/healthProbe.ts
+++ b/api/src/services/healthProbe.ts
@@ -1,0 +1,138 @@
+// Live HTTP, SSL, and DNS health probes for a given domain.
+// All probes use Node built-ins only — no npm packages required.
+
+import * as tls from 'node:tls';
+import * as dns from 'node:dns';
+import { performance } from 'node:perf_hooks';
+
+import type { HttpStatus, SslStatus, DnsStatus } from '../data/mock';
+
+// ── HTTP probe ────────────────────────────────────────────────────────────────
+
+async function probeHttp(domain: string): Promise<HttpStatus> {
+  const checkedAt = new Date().toISOString();
+  const start = performance.now();
+  try {
+    const res = await fetch(`https://${domain}`, {
+      signal: AbortSignal.timeout(5000),
+      redirect: 'follow',
+    });
+    const responseTimeMs = Math.round(performance.now() - start);
+    return {
+      reachable: true,
+      statusCode: res.status,
+      responseTimeMs,
+      checkedAt,
+    };
+  } catch {
+    return {
+      reachable: false,
+      statusCode: null,
+      responseTimeMs: null,
+      checkedAt,
+    };
+  }
+}
+
+// ── SSL probe ─────────────────────────────────────────────────────────────────
+
+function probeSsl(domain: string): Promise<SslStatus> {
+  const checkedAt = new Date().toISOString();
+  return new Promise((resolve) => {
+    let settled = false;
+
+    const fail = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve({ valid: false, expiresAt: null, daysUntilExpiry: null, issuer: null, checkedAt });
+    };
+
+    const socket = tls.connect(
+      { host: domain, port: 443, servername: domain },
+      () => {
+        if (settled) return;
+        settled = true;
+        try {
+          const cert = socket.getPeerCertificate();
+          const authorized = socket.authorized === true;
+          const expires = new Date(cert.valid_to);
+          const now = Date.now();
+          const daysUntilExpiry = Math.floor((expires.getTime() - now) / 86_400_000);
+          const expiresAt = expires.toISOString();
+          const issuer: string | null =
+            cert.issuer && typeof (cert.issuer as Record<string, unknown>).O === 'string'
+              ? (cert.issuer as Record<string, string>).O
+              : null;
+          resolve({
+            valid: authorized && daysUntilExpiry > 0,
+            expiresAt,
+            daysUntilExpiry,
+            issuer,
+            checkedAt,
+          });
+        } catch {
+          resolve({ valid: false, expiresAt: null, daysUntilExpiry: null, issuer: null, checkedAt });
+        } finally {
+          socket.destroy();
+        }
+      }
+    );
+
+    socket.setTimeout(5000, () => {
+      socket.destroy();
+      fail();
+    });
+
+    socket.on('error', () => {
+      socket.destroy();
+      fail();
+    });
+  });
+}
+
+// ── DNS probe ─────────────────────────────────────────────────────────────────
+
+async function probeDns(domain: string): Promise<DnsStatus> {
+  const checkedAt = new Date().toISOString();
+  try {
+    await dns.promises.resolve4(domain);
+    return { resolving: true, propagated: true, checkedAt };
+  } catch {
+    return { resolving: false, propagated: false, checkedAt };
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export interface ProbeResult {
+  http: HttpStatus;
+  ssl: SslStatus;
+  dns: DnsStatus;
+}
+
+export async function probeSite(domain: string): Promise<ProbeResult> {
+  const [httpResult, sslResult, dnsResult] = await Promise.allSettled([
+    probeHttp(domain),
+    probeSsl(domain),
+    probeDns(domain),
+  ]);
+
+  const now = new Date().toISOString();
+
+  const http: HttpStatus =
+    httpResult.status === 'fulfilled'
+      ? httpResult.value
+      : { reachable: false, statusCode: null, responseTimeMs: null, checkedAt: now };
+
+  const ssl: SslStatus =
+    sslResult.status === 'fulfilled'
+      ? sslResult.value
+      : { valid: false, expiresAt: null, daysUntilExpiry: null, issuer: null, checkedAt: now };
+
+  const dns: DnsStatus =
+    dnsResult.status === 'fulfilled'
+      ? dnsResult.value
+      : { resolving: false, propagated: false, checkedAt: now };
+
+  return { http, ssl, dns };
+}

--- a/api/src/services/mapper.ts
+++ b/api/src/services/mapper.ts
@@ -14,6 +14,7 @@ import type {
   SslStatus,
   DnsStatus,
 } from '../data/mock';
+import type { ProbeResult } from './healthProbe';
 
 // ── Status mappers ────────────────────────────────────────────────────────────
 
@@ -140,7 +141,8 @@ export function mapDeploy(
 
 export function mapSite(
   app: CoolifyApplication,
-  deployments: CoolifyDeploymentQueue[]
+  deployments: CoolifyDeploymentQueue[],
+  probe: ProbeResult | null = null
 ): Site {
   const deploys: Deploy[] = deployments.map((d) =>
     mapDeploy(d, app.git_branch)
@@ -148,6 +150,10 @@ export function mapSite(
 
   const latestDeployment = deployments[0];
   const serverName = latestDeployment?.server_name ?? 'unknown';
+
+  const http: HttpStatus = probe ? probe.http : stubHttpStatus(app.status);
+  const ssl: SslStatus = probe ? probe.ssl : stubSslStatus();
+  const dns: DnsStatus = probe ? probe.dns : stubDnsStatus();
 
   return {
     slug: app.uuid,
@@ -157,9 +163,9 @@ export function mapSite(
     repository: app.git_repository,
     server: serverName,
     overallStatus: mapAppStatus(app.status),
-    http: stubHttpStatus(app.status),
-    ssl: stubSslStatus(),
-    dns: stubDnsStatus(),
+    http,
+    ssl,
+    dns,
     // TODO: populate from Technitium integration
     dnsRecords: [],
     deploys,


### PR DESCRIPTION
## Summary
- `healthProbe.ts` — `probeSite(domain)` runs 3 probes via `Promise.allSettled`:
  - **HTTP**: native `fetch` + `AbortSignal.timeout(5000)`, measures `responseTimeMs`
  - **SSL**: `node:tls` socket, reads `getPeerCertificate()` for expiry + issuer, 5s timeout
  - **DNS**: `dns.promises.resolve4` 
- `GET /api/sites/:slug` runs probe in parallel with deploy fetch (both mock and Coolify modes)
- `GET /api/sites` list — no probe (preserves performance for multi-site dashboards)
- Probe errors fall back to stubs silently

## Test plan
- [ ] `tsc --noEmit` clean
- [ ] Docker build clean
- [ ] `GET /api/sites/:slug` returns `checkedAt` with current timestamp (not mock date)
- [ ] Real domain returns live HTTP statusCode + SSL expiry days
- [ ] Unreachable domain returns `reachable: false` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)