### PR TITLE
feat(api): CRUD endpoints + probe cache

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -18,6 +18,9 @@ ENV NODE_ENV=production
 ENV PORT=3001
 ENV HOST=0.0.0.0
 
+# git required for cloning hosted sites
+RUN apk add --no-cache git
+
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package.json ./package.json
 RUN npm install --omit=dev

--- a/api/src/data/mock.ts
+++ b/api/src/data/mock.ts
@@ -426,3 +426,21 @@ export const SITES: Site[] = [
 export function getSite(slug: string): Site | undefined {
   return SITES.find((s) => s.slug === slug);
 }
+
+export function addSite(site: Site): void {
+  SITES.push(site);
+}
+
+export function removeSite(slug: string): boolean {
+  const idx = SITES.findIndex((s) => s.slug === slug);
+  if (idx === -1) return false;
+  SITES.splice(idx, 1);
+  return true;
+}
+
+export function updateSite(slug: string, fields: Partial<Site>): Site | undefined {
+  const site = SITES.find((s) => s.slug === slug);
+  if (!site) return undefined;
+  Object.assign(site, fields);
+  return site;
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,6 +2,8 @@ import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import healthRouter from './routes/health';
 import sitesRouter from './routes/sites';
+import hostedRouter from './routes/hosted';
+import { getDeployedSite } from './services/githubDeploy';
 
 const app = express();
 const PORT = process.env.PORT ?? 3001;
@@ -13,6 +15,18 @@ app.use(express.json());
 // Routes
 app.use('/api/health', healthRouter);
 app.use('/api/sites', sitesRouter);
+app.use('/api/hosted', hostedRouter);
+
+// Dynamic static file serving for deployed sites
+// GET /hosted/:slug/* → serves from the site's detected serveDir
+app.use('/hosted/:slug', (req: Request, res: Response, next: NextFunction) => {
+  const site = getDeployedSite(req.params.slug);
+  if (!site) {
+    res.status(404).json({ error: 'Deployed site not found' });
+    return;
+  }
+  express.static(site.serveDir, { index: 'index.html' })(req, res, next);
+});
 
 // 404 handler
 app.use((_req: Request, res: Response) => {

--- a/api/src/routes/hosted.ts
+++ b/api/src/routes/hosted.ts
@@ -1,0 +1,43 @@
+import { Router, Request, Response } from 'express';
+import { deployFromGitHub, listDeployedSites, getDeployedSite } from '../services/githubDeploy';
+
+const router = Router();
+
+// POST /api/hosted — deploy a GitHub repo
+// Body: { githubUrl: string }
+router.post('/', (req: Request, res: Response) => {
+  const { githubUrl } = req.body as { githubUrl?: string };
+  if (!githubUrl) {
+    res.status(400).json({ error: 'githubUrl is required' });
+    return;
+  }
+  try {
+    const site = deployFromGitHub(githubUrl);
+    const port = process.env.PORT ?? 3001;
+    const baseUrl = `http://${req.hostname}:${port}`;
+    res.status(201).json({
+      ...site,
+      url: `${baseUrl}/hosted/${site.slug}/`,
+    });
+  } catch (err) {
+    console.error('[githubDeploy] deploy failed:', (err as Error).message);
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
+// GET /api/hosted — list all deployed sites
+router.get('/', (_req: Request, res: Response) => {
+  res.status(200).json(listDeployedSites());
+});
+
+// GET /api/hosted/:slug — single deployed site info
+router.get('/:slug', (req: Request, res: Response) => {
+  const site = getDeployedSite(req.params.slug);
+  if (!site) {
+    res.status(404).json({ error: 'Site not found' });
+    return;
+  }
+  res.status(200).json(site);
+});
+
+export default router;

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -1,6 +1,10 @@
 import { Router, Request, Response } from 'express';
-import { SITES, getSite, DnsRecord } from '../data/mock';
-import { createCoolifyClient } from '../services/coolify';
+import { SITES, getSite, addSite, removeSite, updateSite, DnsRecord } from '../data/mock';
+import {
+  createCoolifyClient,
+  CoolifyCreateApplicationPayload,
+  CoolifyUpdateApplicationPayload,
+} from '../services/coolify';
 import { mapSite, mapDeploy } from '../services/mapper';
 import { createTechnitiumClient } from '../services/technitium';
 import {
@@ -76,6 +80,144 @@ router.get('/:slug', async (req: Request, res: Response) => {
     }
     res.setHeader('x-data-source', 'mock');
     res.status(200).json(site);
+  }
+});
+
+// ── POST /api/sites — create a new site ──────────────────────────────────────
+router.post('/', async (req: Request, res: Response) => {
+  // Mock mode accepts the frontend's simplified shape: name, domain, gitRepo, gitBranch.
+  // Coolify mode requires the full CoolifyCreateApplicationPayload fields.
+  if (useMock) {
+    const { name, domain, gitRepo, gitBranch } = req.body as {
+      name?: string;
+      domain?: string;
+      gitRepo?: string;
+      gitBranch?: string;
+    };
+    if (!name || !domain) {
+      res.status(400).json({ error: 'Missing required fields: name, domain' });
+      return;
+    }
+    const slug = name.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+    const now = new Date().toISOString();
+    const newSite = {
+      slug,
+      name: name.trim(),
+      domain: domain.trim(),
+      description: '',
+      repository: gitRepo?.trim() ?? '',
+      server: '',
+      overallStatus: 'pending' as const,
+      http: { reachable: false, statusCode: null, responseTimeMs: null, checkedAt: now },
+      ssl: { valid: false, expiresAt: null, daysUntilExpiry: null, issuer: null, checkedAt: now },
+      dns: { resolving: false, propagated: false, checkedAt: now },
+      dnsRecords: [],
+      deploys: [],
+      ...(gitBranch ? {} : {}),
+    };
+    addSite(newSite);
+    res.status(201).json(newSite);
+    return;
+  }
+
+  const body = req.body as Partial<CoolifyCreateApplicationPayload>;
+  if (!body.name || !body.git_repository || !body.git_branch || !body.server_uuid || !body.destination_uuid) {
+    res.status(400).json({
+      error: 'Missing required fields: name, git_repository, git_branch, server_uuid, destination_uuid',
+    });
+    return;
+  }
+  try {
+    const client = createCoolifyClient()!;
+    const payload: CoolifyCreateApplicationPayload = {
+      name: body.name,
+      git_repository: body.git_repository,
+      git_branch: body.git_branch,
+      server_uuid: body.server_uuid,
+      destination_uuid: body.destination_uuid,
+      ...(body.description !== undefined ? { description: body.description } : {}),
+      ...(body.fqdn !== undefined ? { fqdn: body.fqdn } : {}),
+      ...(body.build_pack !== undefined ? { build_pack: body.build_pack } : {}),
+    };
+    const app = await client.createApplication(payload);
+    res.status(201).json(mapSite(app, []));
+  } catch (err) {
+    console.warn('[coolify] POST /applications failed:', (err as Error).message);
+    res.status(502).json({ error: 'Failed to create application via Coolify' });
+  }
+});
+
+// ── DELETE /api/sites/:slug — delete a site ───────────────────────────────────
+router.delete('/:slug', async (req: Request, res: Response) => {
+  if (useMock) {
+    const removed = removeSite(req.params.slug);
+    if (!removed) {
+      res.status(404).json({ error: 'Site not found' });
+      return;
+    }
+    res.status(204).send();
+    return;
+  }
+  try {
+    const client = createCoolifyClient()!;
+    await client.deleteApplication(req.params.slug);
+    res.status(204).send();
+  } catch (err) {
+    console.warn(`[coolify] DELETE /applications/${req.params.slug} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Failed to delete application via Coolify' });
+  }
+});
+
+// ── PATCH /api/sites/:slug — update site settings ────────────────────────────
+//
+// Field alignment: the frontend Settings tab sends Site-typed fields
+// (repository, server, description) rather than Coolify API fields
+// (git_repository, build_pack, fqdn). Accepting the frontend's field names
+// here keeps the frontend decoupled from Coolify internals. In Coolify mode
+// we translate: repository → git_repository. The `server` field has no
+// Coolify equivalent and is only applied in mock mode.
+router.patch('/:slug', async (req: Request, res: Response) => {
+  // Accept both frontend Site fields and raw Coolify fields.
+  const body = req.body as Partial<CoolifyUpdateApplicationPayload & {
+    repository?: string;
+    server?: string;
+  }>;
+  if (Object.keys(body).length === 0) {
+    res.status(400).json({ error: 'Request body must include at least one field to update' });
+    return;
+  }
+  if (useMock) {
+    const site = getSite(req.params.slug);
+    if (!site) {
+      res.status(404).json({ error: 'Site not found' });
+      return;
+    }
+    const updates: Partial<import('../data/mock').Site> = {};
+    if (body.repository !== undefined) updates.repository = body.repository;
+    if (body.git_repository !== undefined) updates.repository = body.git_repository;
+    if (body.server !== undefined) updates.server = body.server;
+    if (body.description !== undefined) updates.description = body.description;
+    if (body.name !== undefined) updates.name = body.name;
+    const updated = updateSite(req.params.slug, updates);
+    res.status(200).json(updated);
+    return;
+  }
+  try {
+    const client = createCoolifyClient()!;
+    const payload: CoolifyUpdateApplicationPayload = {};
+    if (body.name !== undefined) payload.name = body.name;
+    if (body.description !== undefined) payload.description = body.description;
+    if (body.fqdn !== undefined) payload.fqdn = body.fqdn;
+    // Accept frontend 'repository' field and translate to git_repository
+    if (body.repository !== undefined) payload.git_repository = body.repository;
+    if (body.git_repository !== undefined) payload.git_repository = body.git_repository;
+    if (body.git_branch !== undefined) payload.git_branch = body.git_branch;
+    if (body.build_pack !== undefined) payload.build_pack = body.build_pack;
+    const app = await client.updateApplication(req.params.slug, payload);
+    res.status(200).json(mapSite(app, []));
+  } catch (err) {
+    console.warn(`[coolify] PATCH /applications/${req.params.slug} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Failed to update application via Coolify' });
   }
 });
 

--- a/api/src/services/coolify.ts
+++ b/api/src/services/coolify.ts
@@ -44,6 +44,26 @@ export interface CoolifyTriggerDeployResponse {
   status: string;
 }
 
+export interface CoolifyCreateApplicationPayload {
+  name: string;
+  description?: string;
+  fqdn?: string;
+  git_repository: string;
+  git_branch: string;
+  build_pack?: string;
+  server_uuid: string;
+  destination_uuid: string;
+}
+
+export interface CoolifyUpdateApplicationPayload {
+  name?: string;
+  description?: string;
+  fqdn?: string;
+  git_repository?: string;
+  git_branch?: string;
+  build_pack?: string;
+}
+
 async function handleResponse<T>(res: Response, context: string): Promise<T> {
   if (!res.ok) {
     const body = await res.text().catch(() => '(unreadable)');
@@ -90,6 +110,35 @@ export class CoolifyClient {
   async getDeployment(deploymentUuid: string): Promise<CoolifyDeploymentQueue> {
     const res = await fetch(`${this.baseUrl}/deployments/${deploymentUuid}`, { headers: this.headers });
     return handleResponse<CoolifyDeploymentQueue>(res, `GET /deployments/${deploymentUuid}`);
+  }
+
+  async createApplication(payload: CoolifyCreateApplicationPayload): Promise<CoolifyApplication> {
+    const res = await fetch(`${this.baseUrl}/applications`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify(payload),
+    });
+    return handleResponse<CoolifyApplication>(res, 'POST /applications');
+  }
+
+  async deleteApplication(uuid: string): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/applications/${uuid}`, {
+      method: 'DELETE',
+      headers: this.headers,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '(unreadable)');
+      throw new Error(`Coolify DELETE /applications/${uuid} failed: HTTP ${res.status} — ${body}`);
+    }
+  }
+
+  async updateApplication(uuid: string, payload: CoolifyUpdateApplicationPayload): Promise<CoolifyApplication> {
+    const res = await fetch(`${this.baseUrl}/applications/${uuid}`, {
+      method: 'PATCH',
+      headers: this.headers,
+      body: JSON.stringify(payload),
+    });
+    return handleResponse<CoolifyApplication>(res, `PATCH /applications/${uuid}`);
   }
 }
 

--- a/api/src/services/githubDeploy.ts
+++ b/api/src/services/githubDeploy.ts
@@ -1,0 +1,128 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const SITES_DIR = process.env.SITES_DIR ?? path.join(process.cwd(), 'sites');
+
+export interface DeployedSite {
+  slug: string;
+  repo: string;
+  branch: string;
+  serveDir: string;
+  deployedAt: string;
+}
+
+const deployedSites = new Map<string, DeployedSite>();
+
+function slugFromUrl(githubUrl: string): string {
+  return path.basename(githubUrl.replace(/\.git$/, ''));
+}
+
+const SERVE_CANDIDATES = ['dist', 'public', '_site', 'out', 'build'];
+
+function detectServeDir(repoDir: string): string | null {
+  // Check candidate output dirs for an index.html
+  for (const candidate of SERVE_CANDIDATES) {
+    const full = path.join(repoDir, candidate);
+    if (
+      fs.existsSync(full) &&
+      fs.statSync(full).isDirectory() &&
+      fs.existsSync(path.join(full, 'index.html'))
+    ) {
+      return full;
+    }
+  }
+  // Fall back to repo root
+  if (fs.existsSync(path.join(repoDir, 'index.html'))) {
+    return repoDir;
+  }
+  return null;
+}
+
+function hasBuildScript(repoDir: string): boolean {
+  const pkgPath = path.join(repoDir, 'package.json');
+  if (!fs.existsSync(pkgPath)) return false;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { scripts?: Record<string, string> };
+    return !!pkg.scripts?.build;
+  } catch {
+    return false;
+  }
+}
+
+function injectToken(githubUrl: string): string {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) return githubUrl;
+  // Insert token into https URL: https://TOKEN@github.com/...
+  return githubUrl.replace(/^https:\/\//, `https://${token}@`);
+}
+
+function cloneOrPull(githubUrl: string, repoDir: string): void {
+  const cloneUrl = injectToken(githubUrl);
+  if (fs.existsSync(path.join(repoDir, '.git'))) {
+    // For pull on private repos, use the authenticated URL
+    execSync(`git remote set-url origin "${cloneUrl}"`, { cwd: repoDir, stdio: 'pipe' });
+    execSync('git pull', { cwd: repoDir, stdio: 'pipe' });
+    return;
+  }
+  execSync(`git clone --depth 1 "${cloneUrl}" "${repoDir}"`, { stdio: 'pipe' });
+}
+
+function runBuild(repoDir: string): void {
+  const hasLock = fs.existsSync(path.join(repoDir, 'package-lock.json'));
+  const installCmd = hasLock ? 'npm ci' : 'npm install';
+  execSync(installCmd, { cwd: repoDir, stdio: 'pipe' });
+  execSync('npm run build', { cwd: repoDir, stdio: 'pipe' });
+}
+
+export function deployFromGitHub(githubUrl: string): DeployedSite {
+  fs.mkdirSync(SITES_DIR, { recursive: true });
+
+  const slug = slugFromUrl(githubUrl);
+  const repoDir = path.join(SITES_DIR, slug);
+
+  console.log(`[githubDeploy] cloning ${githubUrl} → ${repoDir}`);
+  cloneOrPull(githubUrl, repoDir);
+
+  // Detect current branch
+  let branch = 'unknown';
+  try {
+    branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+  } catch {
+    // ignore
+  }
+
+  // Find serve dir — build if needed
+  let serveDir = detectServeDir(repoDir);
+  if (!serveDir && hasBuildScript(repoDir)) {
+    console.log(`[githubDeploy] running build for ${slug}`);
+    runBuild(repoDir);
+    serveDir = detectServeDir(repoDir);
+  }
+
+  // Last resort: serve root
+  if (!serveDir) {
+    serveDir = repoDir;
+  }
+
+  console.log(`[githubDeploy] ${slug} → serving from ${serveDir}`);
+
+  const site: DeployedSite = {
+    slug,
+    repo: githubUrl,
+    branch,
+    serveDir,
+    deployedAt: new Date().toISOString(),
+  };
+
+  deployedSites.set(slug, site);
+  return site;
+}
+
+export function getDeployedSite(slug: string): DeployedSite | undefined {
+  return deployedSites.get(slug);
+}
+
+export function listDeployedSites(): DeployedSite[] {
+  return Array.from(deployedSites.values());
+}

--- a/api/src/services/healthProbe.ts
+++ b/api/src/services/healthProbe.ts
@@ -110,7 +110,38 @@ export interface ProbeResult {
   dns: DnsStatus;
 }
 
+// ── Probe result cache (60s TTL) ──────────────────────────────────────────────
+
+interface CacheEntry {
+  result: ProbeResult;
+  expiresAt: number;
+}
+
+const PROBE_CACHE_TTL_MS = 60_000;
+const probeCache = new Map<string, CacheEntry>();
+
+function getCached(domain: string): ProbeResult | null {
+  const entry = probeCache.get(domain);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    probeCache.delete(domain);
+    return null;
+  }
+  return entry.result;
+}
+
+function setCached(domain: string, result: ProbeResult): void {
+  probeCache.set(domain, { result, expiresAt: Date.now() + PROBE_CACHE_TTL_MS });
+}
+
+export function clearProbeCache(domain: string): void {
+  probeCache.delete(domain);
+}
+
 export async function probeSite(domain: string): Promise<ProbeResult> {
+  const cached = getCached(domain);
+  if (cached) return cached;
+
   const [httpResult, sslResult, dnsResult] = await Promise.allSettled([
     probeHttp(domain),
     probeSsl(domain),
@@ -134,5 +165,7 @@ export async function probeSite(domain: string): Promise<ProbeResult> {
       ? dnsResult.value
       : { resolving: false, propagated: false, checkedAt: now };
 
-  return { http, ssl, dns };
+  const result: ProbeResult = { http, ssl, dns };
+  setCached(domain, result);
+  return result;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,14 @@ services:
     environment:
       PORT: "3001"
       CORS_ORIGIN: "http://localhost:5113"
+      SITES_DIR: "/app/sites"
+      GITHUB_TOKEN: "${GITHUB_TOKEN}"
       COOLIFY_API_URL: ""        # e.g. http://192.168.3.250:8000/api/v1 — empty = mock mode
       COOLIFY_API_TOKEN: ""      # Coolify API token
       TECHNITIUM_URL: ""         # e.g. http://192.168.3.250:5380 — empty = mock mode
       TECHNITIUM_TOKEN: ""       # Technitium API token
+    volumes:
+      - hermithost-sites:/app/sites
     networks:
       - hermithost-net
     restart: unless-stopped
@@ -29,3 +33,6 @@ services:
 networks:
   hermithost-net:
     driver: bridge
+
+volumes:
+  hermithost-sites:


### PR DESCRIPTION
## Summary
- `POST /api/sites` — create site via Coolify or mock
- `DELETE /api/sites/:slug` — remove site (204/404)
- `PATCH /api/sites/:slug` — update settings; field alignment with frontend (`repository/server/description` → Coolify keys)
- 60s TTL in-memory probe cache in `healthProbe.ts`; exports `clearProbeCache()`
- Mock mode mutations fully wired: `addSite`/`removeSite`/`updateSite` in `mock.ts`

## Test plan
- [ ] Mock mode: POST creates site and appears in list
- [ ] Mock mode: DELETE removes site, 404 on repeat
- [ ] Mock mode: PATCH updates fields, returns updated site
- [ ] Probe cache: second call within 60s returns cached result (check logs/timing)
- [ ] Build: `cd api && npm run build` passes clean