### PR TITLE
feat(dns): provider abstraction layer + Technitium in compose

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -6,24 +6,17 @@ import {
   CoolifyUpdateApplicationPayload,
 } from '../services/coolify';
 import { mapSite, mapDeploy } from '../services/mapper';
-import { createTechnitiumClient } from '../services/technitium';
-import {
-  mapRecord,
-  shouldIncludeRecord,
-  buildAddParams,
-  buildUpdateParams,
-  buildDeleteParams,
-  decodeId,
-} from '../services/technitiumMapper';
 import { probeSite } from '../services/healthProbe';
+import { createDnsProvider, DnsOperationError } from '../services/dns';
 
 const router = Router();
 
-const useMock = !process.env.COOLIFY_API_URL;
+const useCoolifyMock = !process.env.COOLIFY_API_URL;
+const dnsProvider = createDnsProvider();
 
 // ── GET /api/sites — list all sites ──────────────────────────────────────────
 router.get('/', async (_req: Request, res: Response) => {
-  if (useMock) {
+  if (useCoolifyMock) {
     res.status(200).json(SITES);
     return;
   }
@@ -46,7 +39,7 @@ router.get('/', async (_req: Request, res: Response) => {
 
 // ── GET /api/sites/:slug — single site detail ─────────────────────────────────
 router.get('/:slug', async (req: Request, res: Response) => {
-  if (useMock) {
+  if (useCoolifyMock) {
     const site = getSite(req.params.slug);
     if (!site) {
       res.status(404).json({ error: 'Site not found' });
@@ -87,7 +80,7 @@ router.get('/:slug', async (req: Request, res: Response) => {
 router.post('/', async (req: Request, res: Response) => {
   // Mock mode accepts the frontend's simplified shape: name, domain, gitRepo, gitBranch.
   // Coolify mode requires the full CoolifyCreateApplicationPayload fields.
-  if (useMock) {
+  if (useCoolifyMock) {
     const { name, domain, gitRepo, gitBranch } = req.body as {
       name?: string;
       domain?: string;
@@ -149,7 +142,7 @@ router.post('/', async (req: Request, res: Response) => {
 
 // ── DELETE /api/sites/:slug — delete a site ───────────────────────────────────
 router.delete('/:slug', async (req: Request, res: Response) => {
-  if (useMock) {
+  if (useCoolifyMock) {
     const removed = removeSite(req.params.slug);
     if (!removed) {
       res.status(404).json({ error: 'Site not found' });
@@ -186,7 +179,7 @@ router.patch('/:slug', async (req: Request, res: Response) => {
     res.status(400).json({ error: 'Request body must include at least one field to update' });
     return;
   }
-  if (useMock) {
+  if (useCoolifyMock) {
     const site = getSite(req.params.slug);
     if (!site) {
       res.status(404).json({ error: 'Site not found' });
@@ -224,144 +217,70 @@ router.patch('/:slug', async (req: Request, res: Response) => {
 // ── GET /api/sites/:slug/dns — DNS records for a site ────────────────────────
 router.get('/:slug/dns', async (req: Request, res: Response) => {
   const site = getSite(req.params.slug);
-  if (!site) {
-    res.status(404).json({ error: 'Site not found' });
-    return;
-  }
-  const technitium = createTechnitiumClient();
-  if (!technitium) {
-    res.setHeader('x-data-source', 'mock');
-    res.status(200).json(site.dnsRecords);
-    return;
-  }
+  if (!site) { res.status(404).json({ error: 'Site not found' }); return; }
   try {
-    const { zone, records } = await technitium.getRecords(site.domain);
-    const mapped = records
-      .filter((r) => shouldIncludeRecord(r, zone.name))
-      .map((r) => mapRecord(r, zone.name));
-    res.status(200).json(mapped);
+    const records = await dnsProvider.getRecords(site.domain);
+    res.status(200).json(records);
   } catch (err) {
-    console.warn(`[technitium] GET records for ${site.domain} failed, falling back to mock:`, (err as Error).message);
-    res.setHeader('x-data-source', 'mock');
-    res.status(200).json(site.dnsRecords);
+    console.warn('[dns] getRecords failed:', err instanceof DnsOperationError ? err.originalCause : err);
+    res.status(500).json({ error: 'DNS operation failed' });
   }
 });
 
 // ── POST /api/sites/:slug/dns — add a DNS record ─────────────────────────────
 router.post('/:slug/dns', async (req: Request, res: Response) => {
   const site = getSite(req.params.slug);
-  if (!site) {
-    res.status(404).json({ error: 'Site not found' });
-    return;
-  }
+  if (!site) { res.status(404).json({ error: 'Site not found' }); return; }
   const body = req.body as Partial<DnsRecord>;
   if (!body.type || !body.name || !body.value || !body.ttl) {
     res.status(400).json({ error: 'Missing required fields: type, name, value, ttl' });
     return;
   }
-  const technitium = createTechnitiumClient();
-  if (!technitium) {
-    res.status(503).json({ error: 'DNS integration unavailable — TECHNITIUM_URL not configured' });
-    return;
-  }
   try {
-    const record: DnsRecord = {
-      id: '',
+    const record = await dnsProvider.addRecord(site.domain, {
       type: body.type,
       name: body.name,
       value: body.value,
       ttl: body.ttl,
       ...(body.priority !== undefined ? { priority: body.priority } : {}),
-    };
-    // Build full domain: name '@' means apex (site.domain), otherwise prepend subdomain
-    const domain = record.name === '@' ? site.domain : `${record.name}.${site.domain}`;
-    const params = buildAddParams(domain, record);
-    const raw = await technitium.addRecord(domain, params);
-    const { zone } = await technitium.getRecords(site.domain);
-    res.status(201).json(mapRecord(raw, zone.name));
+    });
+    res.status(201).json(record);
   } catch (err) {
-    console.warn(`[technitium] POST add record for ${site.domain} failed:`, (err as Error).message);
-    res.status(502).json({ error: 'Failed to add DNS record via Technitium' });
+    console.warn('[dns] addRecord failed:', err instanceof DnsOperationError ? err.originalCause : err);
+    res.status(500).json({ error: 'DNS operation failed' });
   }
 });
 
 // ── PUT /api/sites/:slug/dns/:id — update a DNS record ───────────────────────
 router.put('/:slug/dns/:id', async (req: Request, res: Response) => {
   const site = getSite(req.params.slug);
-  if (!site) {
-    res.status(404).json({ error: 'Site not found' });
-    return;
-  }
-  const technitium = createTechnitiumClient();
-  if (!technitium) {
-    res.status(503).json({ error: 'DNS integration unavailable — TECHNITIUM_URL not configured' });
-    return;
-  }
-  let identity: { domain: string; type: string; value: string };
+  if (!site) { res.status(404).json({ error: 'Site not found' }); return; }
   try {
-    identity = decodeId(req.params.id);
-  } catch {
-    res.status(400).json({ error: 'Invalid record ID' });
-    return;
-  }
-  try {
-    const existing: DnsRecord = {
-      id: req.params.id,
-      type: identity.type as DnsRecord['type'],
-      name: identity.domain,
-      value: identity.value,
-      ttl: 3600,
-    };
-    const updates = req.body as Partial<DnsRecord>;
-    const params = buildUpdateParams(identity.domain, existing, updates);
-    const raw = await technitium.updateRecord(identity.domain, params);
-    const { zone } = await technitium.getRecords(site.domain);
-    res.status(200).json(mapRecord(raw, zone.name));
+    const updates = req.body as Partial<Omit<DnsRecord, 'id'>>;
+    const record = await dnsProvider.updateRecord(site.domain, req.params.id, updates);
+    res.status(200).json(record);
   } catch (err) {
-    console.warn(`[technitium] PUT update record ${req.params.id} failed:`, (err as Error).message);
-    res.status(502).json({ error: 'Failed to update DNS record via Technitium' });
+    console.warn('[dns] updateRecord failed:', err instanceof DnsOperationError ? err.originalCause : err);
+    res.status(500).json({ error: 'DNS operation failed' });
   }
 });
 
 // ── DELETE /api/sites/:slug/dns/:id — delete a DNS record ────────────────────
 router.delete('/:slug/dns/:id', async (req: Request, res: Response) => {
   const site = getSite(req.params.slug);
-  if (!site) {
-    res.status(404).json({ error: 'Site not found' });
-    return;
-  }
-  const technitium = createTechnitiumClient();
-  if (!technitium) {
-    res.status(503).json({ error: 'DNS integration unavailable — TECHNITIUM_URL not configured' });
-    return;
-  }
-  let identity: { domain: string; type: string; value: string };
+  if (!site) { res.status(404).json({ error: 'Site not found' }); return; }
   try {
-    identity = decodeId(req.params.id);
-  } catch {
-    res.status(400).json({ error: 'Invalid record ID' });
-    return;
-  }
-  try {
-    const record: DnsRecord = {
-      id: req.params.id,
-      type: identity.type as DnsRecord['type'],
-      name: identity.domain,
-      value: identity.value,
-      ttl: 0,
-    };
-    const params = buildDeleteParams(identity.domain, record);
-    await technitium.deleteRecord(identity.domain, params);
+    await dnsProvider.deleteRecord(site.domain, req.params.id);
     res.status(204).send();
   } catch (err) {
-    console.warn(`[technitium] DELETE record ${req.params.id} failed:`, (err as Error).message);
-    res.status(502).json({ error: 'Failed to delete DNS record via Technitium' });
+    console.warn('[dns] deleteRecord failed:', err instanceof DnsOperationError ? err.originalCause : err);
+    res.status(500).json({ error: 'DNS operation failed' });
   }
 });
 
 // ── GET /api/sites/:slug/deployments — deployment history ────────────────────
 router.get('/:slug/deployments', async (req: Request, res: Response) => {
-  if (useMock) {
+  if (useCoolifyMock) {
     const site = getSite(req.params.slug);
     if (!site) {
       res.status(404).json({ error: 'Site not found' });
@@ -390,7 +309,7 @@ router.get('/:slug/deployments', async (req: Request, res: Response) => {
 
 // ── POST /api/sites/:slug/deploy — trigger a deploy ──────────────────────────
 router.post('/:slug/deploy', async (req: Request, res: Response) => {
-  if (useMock) {
+  if (useCoolifyMock) {
     const site = getSite(req.params.slug);
     if (!site) {
       res.status(404).json({ error: 'Site not found' });
@@ -411,7 +330,7 @@ router.post('/:slug/deploy', async (req: Request, res: Response) => {
 
 // ── GET /api/sites/:slug/deployments/:id/log — deploy log lines ───────────────
 router.get('/:slug/deployments/:id/log', async (req: Request, res: Response) => {
-  if (useMock) {
+  if (useCoolifyMock) {
     const site = getSite(req.params.slug);
     if (!site) {
       res.status(404).json({ error: 'Site not found' });

--- a/api/src/services/dns/DnsProvider.ts
+++ b/api/src/services/dns/DnsProvider.ts
@@ -1,0 +1,15 @@
+import type { DnsRecord } from '../../data/mock';
+
+export interface DnsProvider {
+  /** Fetch all records for a domain. */
+  getRecords(domain: string): Promise<DnsRecord[]>;
+
+  /** Add a record. Returns the created record with a stable id. */
+  addRecord(domain: string, record: Omit<DnsRecord, 'id'>): Promise<DnsRecord>;
+
+  /** Update an existing record by id. Returns the updated record. */
+  updateRecord(domain: string, id: string, updates: Partial<Omit<DnsRecord, 'id'>>): Promise<DnsRecord>;
+
+  /** Delete a record by id. */
+  deleteRecord(domain: string, id: string): Promise<void>;
+}

--- a/api/src/services/dns/MockProvider.ts
+++ b/api/src/services/dns/MockProvider.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from 'node:crypto';
+import type { DnsProvider } from './DnsProvider';
+import type { DnsRecord } from '../../data/mock';
+import { SITES } from '../../data/mock';
+
+export class MockProvider implements DnsProvider {
+  async getRecords(domain: string): Promise<DnsRecord[]> {
+    return this.findSiteByDomain(domain)?.dnsRecords ?? [];
+  }
+
+  async addRecord(domain: string, record: Omit<DnsRecord, 'id'>): Promise<DnsRecord> {
+    const created: DnsRecord = { id: randomUUID(), ...record };
+    const site = this.findSiteByDomain(domain);
+    if (site) site.dnsRecords.push(created);
+    return created;
+  }
+
+  async updateRecord(
+    domain: string,
+    id: string,
+    updates: Partial<Omit<DnsRecord, 'id'>>
+  ): Promise<DnsRecord> {
+    const site = this.findSiteByDomain(domain);
+    if (site) {
+      const idx = site.dnsRecords.findIndex((r) => r.id === id);
+      if (idx !== -1) {
+        site.dnsRecords[idx] = { ...site.dnsRecords[idx], ...updates };
+        return site.dnsRecords[idx];
+      }
+    }
+    // Record not found — return a synthetic updated record
+    return { id, type: 'A', name: '@', value: '0.0.0.0', ttl: 3600, ...updates } as DnsRecord;
+  }
+
+  async deleteRecord(domain: string, id: string): Promise<void> {
+    const site = this.findSiteByDomain(domain);
+    if (site) {
+      const idx = site.dnsRecords.findIndex((r) => r.id === id);
+      if (idx !== -1) site.dnsRecords.splice(idx, 1);
+    }
+  }
+
+  private findSiteByDomain(domain: string) {
+    return SITES.find((s) => s.domain === domain);
+  }
+}

--- a/api/src/services/dns/TechnitiumProvider.ts
+++ b/api/src/services/dns/TechnitiumProvider.ts
@@ -1,0 +1,81 @@
+import type { DnsProvider } from './DnsProvider';
+import type { DnsRecord } from '../../data/mock';
+import { TechnitiumClient } from '../technitium';
+import {
+  mapRecord,
+  shouldIncludeRecord,
+  buildAddParams,
+  buildUpdateParams,
+  buildDeleteParams,
+  decodeId,
+} from '../technitiumMapper';
+import { DnsOperationError } from './errors';
+
+export class TechnitiumProvider implements DnsProvider {
+  constructor(private readonly client: TechnitiumClient) {}
+
+  async getRecords(domain: string): Promise<DnsRecord[]> {
+    try {
+      const { zone, records } = await this.client.getRecords(domain);
+      return records
+        .filter((r) => shouldIncludeRecord(r, zone.name))
+        .map((r) => mapRecord(r, zone.name));
+    } catch (err) {
+      throw new DnsOperationError('Failed to retrieve DNS records', err);
+    }
+  }
+
+  async addRecord(domain: string, record: Omit<DnsRecord, 'id'>): Promise<DnsRecord> {
+    try {
+      const fullDomain = record.name === '@' ? domain : `${record.name}.${domain}`;
+      const dnsRecord: DnsRecord = { id: '', ...record };
+      const params = buildAddParams(fullDomain, dnsRecord);
+      const raw = await this.client.addRecord(fullDomain, params);
+      const { zone } = await this.client.getRecords(domain);
+      return mapRecord(raw, zone.name);
+    } catch (err) {
+      throw new DnsOperationError('Failed to add DNS record', err);
+    }
+  }
+
+  async updateRecord(
+    domain: string,
+    id: string,
+    updates: Partial<Omit<DnsRecord, 'id'>>
+  ): Promise<DnsRecord> {
+    try {
+      const identity = decodeId(id);
+      const existing: DnsRecord = {
+        id,
+        type: identity.type as DnsRecord['type'],
+        name: identity.domain,
+        value: identity.value,
+        ttl: 3600,
+      };
+      const merged = { ...existing, ...updates };
+      const params = buildUpdateParams(identity.domain, existing, updates);
+      const raw = await this.client.updateRecord(identity.domain, params);
+      const { zone } = await this.client.getRecords(domain);
+      return mapRecord(raw, zone.name);
+    } catch (err) {
+      throw new DnsOperationError('Failed to update DNS record', err);
+    }
+  }
+
+  async deleteRecord(domain: string, id: string): Promise<void> {
+    try {
+      const identity = decodeId(id);
+      const record: DnsRecord = {
+        id,
+        type: identity.type as DnsRecord['type'],
+        name: identity.domain,
+        value: identity.value,
+        ttl: 0,
+      };
+      const params = buildDeleteParams(identity.domain, record);
+      await this.client.deleteRecord(identity.domain, params);
+    } catch (err) {
+      throw new DnsOperationError('Failed to delete DNS record', err);
+    }
+  }
+}

--- a/api/src/services/dns/errors.ts
+++ b/api/src/services/dns/errors.ts
@@ -1,0 +1,13 @@
+/**
+ * Generic DNS operation error. The `cause` holds the provider-specific
+ * error for server-side logging; it is NEVER exposed to API callers.
+ */
+export class DnsOperationError extends Error {
+  readonly originalCause: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'DnsOperationError';
+    this.originalCause = cause;
+  }
+}

--- a/api/src/services/dns/index.ts
+++ b/api/src/services/dns/index.ts
@@ -1,0 +1,44 @@
+import type { DnsProvider } from './DnsProvider';
+import { TechnitiumProvider } from './TechnitiumProvider';
+import { MockProvider } from './MockProvider';
+import { createTechnitiumClient } from '../technitium';
+
+export type { DnsProvider } from './DnsProvider';
+export { DnsOperationError } from './errors';
+
+let _instance: DnsProvider | null = null;
+
+/**
+ * Returns the singleton DnsProvider.
+ *
+ * Selection:
+ *   DNS_MOCK=true                          → MockProvider (explicit override)
+ *   TECHNITIUM_URL + TECHNITIUM_TOKEN set  → TechnitiumProvider
+ *   Otherwise                              → MockProvider (graceful fallback)
+ *
+ * Caller never knows which provider is active.
+ */
+export function createDnsProvider(): DnsProvider {
+  if (_instance) return _instance;
+
+  if (process.env.DNS_MOCK === 'true') {
+    console.log('[dns] Mock mode forced via DNS_MOCK=true');
+    _instance = new MockProvider();
+    return _instance;
+  }
+
+  const client = createTechnitiumClient();
+  if (client) {
+    console.log('[dns] Technitium provider active');
+    _instance = new TechnitiumProvider(client);
+  } else {
+    console.log('[dns] No DNS credentials configured — using mock provider');
+    _instance = new MockProvider();
+  }
+  return _instance;
+}
+
+/** Reset singleton — for testing only. */
+export function resetDnsProvider(): void {
+  _instance = null;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,9 @@ services:
       GITHUB_TOKEN: "${GITHUB_TOKEN}"
       COOLIFY_API_URL: "${COOLIFY_API_URL:-}"
       COOLIFY_API_TOKEN: "${COOLIFY_API_TOKEN:-}"
-      TECHNITIUM_URL: "${TECHNITIUM_URL:-}"
+      TECHNITIUM_URL: "${TECHNITIUM_URL:-http://technitium:5380}"
       TECHNITIUM_TOKEN: "${TECHNITIUM_TOKEN:-}"
+      DNS_MOCK: "${DNS_MOCK:-}"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api.rule=PathPrefix(`/api`)"
@@ -61,6 +62,17 @@ services:
       - hermithost-net
     restart: unless-stopped
 
+  # ── Technitium DNS Server ──────────────────────────────────────
+  technitium:
+    image: technitium/dns-server:latest
+    restart: unless-stopped
+    ports:
+      - "5380:5380"
+    volumes:
+      - technitium-config:/etc/dns
+    networks:
+      - hermithost-net
+
 networks:
   hermithost-net:
     driver: bridge
@@ -68,3 +80,4 @@ networks:
 volumes:
   hermithost-sites:
   traefik-acme:
+  technitium-config:


### PR DESCRIPTION
## Summary
- `DnsProvider` interface — `getRecords/addRecord/updateRecord/deleteRecord` returning only `DnsRecord` types; no provider details escape
- `TechnitiumProvider` — wraps existing `TechnitiumClient` + mapper; all errors caught as `DnsOperationError`
- `MockProvider` — full CRUD over in-memory `SITES` array; real `updateRecord`/`deleteRecord` implementations
- Factory singleton (`createDnsProvider`) — selects Technitium or Mock based on env; callers never branch on provider
- `sites.ts` DNS routes rewritten — no `x-data-source` headers, no 503s, no Technitium names in responses
- `useMock` → `useCoolifyMock` — Coolify and DNS mock flags now independent
- `docker-compose.yml` — Technitium service added (`technitium/dns-server:latest`), `technitium-config` volume, `TECHNITIUM_URL` defaults to `http://technitium:5380`

## Test plan
- [ ] `npm run build` passes clean (0 errors)
- [ ] DNS routes return records without `x-data-source` header
- [ ] No `503` responses from DNS routes in any config
- [ ] `docker compose up` starts Technitium at `localhost:5380`
- [ ] With `TECHNITIUM_TOKEN` set, DNS CRUD hits live Technitium
- [ ] With `DNS_MOCK=true`, MockProvider used regardless of Technitium config
- [ ] Error responses say `"DNS operation failed"` only — no provider names