### PR TITLE
fix(infra): static Traefik routing for macOS Docker Desktop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,8 @@ services:
     restart: unless-stopped
     command:
       - "--api.insecure=true"
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--providers.docker.network=hermithost-net"
+      - "--providers.file.filename=/etc/traefik/routes.yml"
+      - "--providers.file.watch=true"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
     ports:
@@ -15,7 +14,7 @@ services:
       - "${TRAEFIK_HTTPS_PORT:-8443}:443"
       - "8081:8080"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik/routes.yml:/etc/traefik/routes.yml:ro
       - traefik-acme:/acme
     networks:
       - hermithost-net
@@ -25,12 +24,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.frontend.rule=PathPrefix(`/`)"
-      - "traefik.http.routers.frontend.priority=1"
-      - "traefik.http.routers.frontend.entrypoints=web,websecure"
-      - "traefik.http.services.frontend.loadbalancer.server.port=3000"
+    environment:
+      ORIGIN: "http://traefik:80"
     networks:
       - hermithost-net
     restart: unless-stopped
@@ -50,12 +45,6 @@ services:
       TECHNITIUM_URL: "${TECHNITIUM_URL:-http://technitium:5380}"
       TECHNITIUM_TOKEN: "${TECHNITIUM_TOKEN:-}"
       DNS_MOCK: "${DNS_MOCK:-}"
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.api.rule=PathPrefix(`/api`)"
-      - "traefik.http.routers.api.priority=10"
-      - "traefik.http.routers.api.entrypoints=web,websecure"
-      - "traefik.http.services.api.loadbalancer.server.port=3001"
     volumes:
       - hermithost-sites:/app/sites
     networks:

--- a/traefik/routes.yml
+++ b/traefik/routes.yml
@@ -1,0 +1,28 @@
+http:
+  routers:
+    api:
+      rule: "PathPrefix(`/api`)"
+      priority: 10
+      entryPoints:
+        - web
+        - websecure
+      service: api
+
+    frontend:
+      rule: "PathPrefix(`/`)"
+      priority: 1
+      entryPoints:
+        - web
+        - websecure
+      service: frontend
+
+  services:
+    api:
+      loadBalancer:
+        servers:
+          - url: "http://api:3001"
+
+    frontend:
+      loadBalancer:
+        servers:
+          - url: "http://frontend:3000"


### PR DESCRIPTION
## Problem
Traefik v3 Docker provider fails on macOS Docker Desktop — socket API returns empty error response, routes never discovered, 404 on all paths.

## Fix
- Switch Traefik from Docker provider to file provider (`traefik/routes.yml`)
- Static routes: `PathPrefix(/api)` → `api:3001`, `PathPrefix(/)` → `frontend:3000`
- Add `ORIGIN=http://traefik:80` to frontend service — fixes SvelteKit SSR internal fetch resolution (SSR `load()` calls `/api/sites` which must resolve within the Docker network)
- `routes.yml` watched live — route changes apply without container restart

## Test plan
- [ ] `docker compose up` → dashboard at `localhost:8080` returns 200
- [ ] `localhost:8080/api/health` returns 200
- [ ] `localhost:8080/api/sites` returns site list
- [ ] No Traefik socket errors in logs