### PR TITLE
feat(dns): auto-provision DNS zones and records on site creation

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -25,6 +25,9 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package.json ./package.json
 RUN npm install --omit=dev
 
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 EXPOSE 3001
 
-CMD ["node", "dist/index.js"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Read tokens from shared volume if present
+if [ -f "/coolify-api-token/token" ]; then
+  export COOLIFY_API_TOKEN="$(cat /coolify-api-token/token)"
+fi
+if [ -f "/coolify-api-token/technitium_token" ]; then
+  export TECHNITIUM_TOKEN="$(cat /coolify-api-token/technitium_token)"
+fi
+exec node dist/index.js

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,8 +8,10 @@
       "name": "hermithost-api",
       "version": "1.0.0",
       "dependencies": {
+        "@types/pg": "^8.20.0",
         "cors": "^2.8.5",
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "pg": "^8.20.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -163,10 +165,20 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/qs": {
@@ -1190,6 +1202,95 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -1201,6 +1302,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1474,6 +1614,15 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1671,7 +1820,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -1719,7 +1867,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"

--- a/api/package.json
+++ b/api/package.json
@@ -9,8 +9,10 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@types/pg": "^8.20.0",
     "cors": "^2.8.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "pg": "^8.20.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import healthRouter from './routes/health';
 import sitesRouter from './routes/sites';
 import hostedRouter from './routes/hosted';
+import dnsRouter from './routes/dns';
 import { getDeployedSite } from './services/githubDeploy';
 
 const app = express();
@@ -16,6 +17,7 @@ app.use(express.json());
 app.use('/api/health', healthRouter);
 app.use('/api/sites', sitesRouter);
 app.use('/api/hosted', hostedRouter);
+app.use('/api/dns', dnsRouter);
 
 // Dynamic static file serving for deployed sites
 // GET /hosted/:slug/* → serves from the site's detected serveDir

--- a/api/src/routes/dns.ts
+++ b/api/src/routes/dns.ts
@@ -1,0 +1,156 @@
+import { Router, Request, Response } from 'express';
+import { DnsRecord } from '../types';
+import { createDnsProvider, DnsOperationError } from '../services/dns';
+import { createTechnitiumClient } from '../services/technitium';
+
+const router = Router();
+
+// ── GET /api/dns/config — nameserver config for UI ────────────────────────────
+router.get('/config', (_req: Request, res: Response) => {
+  res.status(200).json({ nsHostname: process.env.NS_HOSTNAME ?? null });
+});
+
+// ── GET /api/dns/zones — list all zones ───────────────────────────────────────
+// Query param: ?all=true to include internal zones
+router.get('/zones', async (req: Request, res: Response) => {
+  const client = createTechnitiumClient();
+  if (!client) {
+    res.status(503).json({ error: 'DNS service not configured' });
+    return;
+  }
+  try {
+    const zones = await client.listZones();
+    const includeInternal = req.query.all === 'true';
+    const filtered = includeInternal ? zones : zones.filter((z) => !z.internal);
+    res.status(200).json(filtered);
+  } catch (err) {
+    console.error('[dns] GET /zones failed:', (err as Error).message);
+    res.status(502).json({ error: 'Failed to retrieve zones from DNS server' });
+  }
+});
+
+// ── POST /api/dns/zones — create a zone ───────────────────────────────────────
+// Body: { name: string, type?: string }
+router.post('/zones', async (req: Request, res: Response) => {
+  const client = createTechnitiumClient();
+  if (!client) {
+    res.status(503).json({ error: 'DNS service not configured' });
+    return;
+  }
+  const body = req.body as { name?: string; type?: string };
+  if (!body.name) {
+    res.status(400).json({ error: 'Missing required field: name' });
+    return;
+  }
+  try {
+    await client.createZone(body.name, body.type ?? 'Primary');
+    res.status(201).json({ name: body.name, type: body.type ?? 'Primary' });
+  } catch (err) {
+    console.error('[dns] POST /zones failed:', (err as Error).message);
+    res.status(502).json({ error: 'Failed to create zone on DNS server' });
+  }
+});
+
+// ── DELETE /api/dns/zones/:name — delete a zone ───────────────────────────────
+router.delete('/zones/:name', async (req: Request, res: Response) => {
+  const client = createTechnitiumClient();
+  if (!client) {
+    res.status(503).json({ error: 'DNS service not configured' });
+    return;
+  }
+  try {
+    await client.deleteZone(req.params.name);
+    res.status(204).send();
+  } catch (err) {
+    console.error(`[dns] DELETE /zones/${req.params.name} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Failed to delete zone on DNS server' });
+  }
+});
+
+// ── GET /api/dns/zones/:name/records — list records in zone ───────────────────
+router.get('/zones/:name/records', async (req: Request, res: Response) => {
+  try {
+    const dnsProvider = createDnsProvider();
+    const records = await dnsProvider.getRecords(req.params.name);
+    res.status(200).json(records);
+  } catch (err) {
+    if (err instanceof DnsOperationError) {
+      const msg = (err.originalCause as Error)?.message ?? '';
+      if (msg.includes('No such zone')) {
+        res.status(200).json([]);
+        return;
+      }
+      console.warn('[dns] getRecords failed:', err.originalCause);
+      res.status(500).json({ error: 'DNS operation failed' });
+    } else {
+      console.error(`[dns] GET /zones/${req.params.name}/records failed:`, (err as Error).message);
+      res.status(502).json({ error: 'Failed to retrieve DNS records' });
+    }
+  }
+});
+
+// ── POST /api/dns/zones/:name/records — add a record ─────────────────────────
+// Body: { type, name, value, ttl, priority? }
+router.post('/zones/:name/records', async (req: Request, res: Response) => {
+  const body = req.body as Partial<DnsRecord>;
+  if (!body.type || !body.name || !body.value || !body.ttl) {
+    res.status(400).json({ error: 'Missing required fields: type, name, value, ttl' });
+    return;
+  }
+  try {
+    const dnsProvider = createDnsProvider();
+    const record = await dnsProvider.addRecord(req.params.name, {
+      type: body.type,
+      name: body.name,
+      value: body.value,
+      ttl: body.ttl,
+      ...(body.priority !== undefined ? { priority: body.priority } : {}),
+    });
+    res.status(201).json(record);
+  } catch (err) {
+    if (err instanceof DnsOperationError) {
+      console.warn('[dns] addRecord failed:', err.originalCause);
+      res.status(500).json({ error: 'DNS operation failed' });
+    } else {
+      console.error(`[dns] POST /zones/${req.params.name}/records failed:`, (err as Error).message);
+      res.status(502).json({ error: 'Failed to add DNS record' });
+    }
+  }
+});
+
+// ── PUT /api/dns/zones/:name/records/:id — update a record ───────────────────
+router.put('/zones/:name/records/:id', async (req: Request, res: Response) => {
+  const updates = req.body as Partial<Omit<DnsRecord, 'id'>>;
+  try {
+    const dnsProvider = createDnsProvider();
+    const record = await dnsProvider.updateRecord(req.params.name, req.params.id, updates);
+    res.status(200).json(record);
+  } catch (err) {
+    if (err instanceof DnsOperationError) {
+      console.warn('[dns] updateRecord failed:', err.originalCause);
+      res.status(500).json({ error: 'DNS operation failed' });
+    } else {
+      console.error(`[dns] PUT /zones/${req.params.name}/records/${req.params.id} failed:`, (err as Error).message);
+      res.status(502).json({ error: 'Failed to update DNS record' });
+    }
+  }
+});
+
+// ── DELETE /api/dns/zones/:name/records/:id — delete a record ────────────────
+router.delete('/zones/:name/records/:id', async (req: Request, res: Response) => {
+  try {
+    const dnsProvider = createDnsProvider();
+    await dnsProvider.deleteRecord(req.params.name, req.params.id);
+    res.status(204).send();
+  } catch (err) {
+    if (err instanceof DnsOperationError) {
+      console.warn('[dns] deleteRecord failed:', err.originalCause);
+      res.status(500).json({ error: 'DNS operation failed' });
+    } else {
+      console.error(`[dns] DELETE /zones/${req.params.name}/records/${req.params.id} failed:`, (err as Error).message);
+      res.status(502).json({ error: 'Failed to delete DNS record' });
+    }
+  }
+});
+
+export default router;

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from 'express';
+import { readFileSync } from 'fs';
 import { DnsRecord } from '../types';
 import {
   createCoolifyClient,
@@ -8,10 +9,79 @@ import {
 import { mapSite, mapDeploy } from '../services/mapper';
 import { probeSite } from '../services/healthProbe';
 import { createDnsProvider, DnsOperationError } from '../services/dns';
+import { createTechnitiumClient } from '../services/technitium';
 
 const router = Router();
 
-const dnsProvider = createDnsProvider();
+// ── DNS auto-provisioning ─────────────────────────────────────────────────────
+// Creates a zone + A record for the given domain pointing at NS_HOSTNAME.
+// Non-fatal: logs warnings but never throws — site ops should not fail due to DNS.
+async function provisionDns(fqdn: string): Promise<void> {
+  const serverIp = process.env.NS_HOSTNAME;
+  if (!serverIp) {
+    console.warn('[dns-provision] NS_HOSTNAME not set — skipping DNS provisioning');
+    return;
+  }
+  // Strip protocol and trailing slashes to get bare domain
+  const domain = fqdn.replace(/^https?:\/\//, '').replace(/\/.*$/, '').trim();
+  if (!domain) return;
+
+  const client = createTechnitiumClient();
+  if (!client) {
+    console.warn('[dns-provision] Technitium not configured — skipping DNS provisioning');
+    return;
+  }
+
+  try {
+    await client.createZone(domain, 'Primary');
+    console.log(`[dns-provision] Zone created: ${domain}`);
+  } catch (err) {
+    // Zone may already exist — that's fine
+    const msg = (err as Error).message ?? '';
+    if (!msg.includes('already exists') && !msg.toLowerCase().includes('already exists')) {
+      console.warn(`[dns-provision] Zone create warning for ${domain}:`, msg);
+    }
+  }
+
+  try {
+    const params = new URLSearchParams();
+    params.set('type', 'A');
+    params.set('ttl', '3600');
+    params.set('ipAddress', serverIp);
+    await client.addRecord(domain, params);
+    console.log(`[dns-provision] A record created: ${domain} @ → ${serverIp}`);
+  } catch (err) {
+    console.warn(`[dns-provision] A record create warning for ${domain}:`, (err as Error).message);
+  }
+}
+
+// ── GitHub key linking ────────────────────────────────────────────────────────
+// Coolify's create API ignores private_key_uuid — link via DB instead.
+// Non-fatal: deployment will fail gracefully if key not linked.
+async function linkGithubKey(appUuid: string): Promise<void> {
+  try {
+    const { readFileSync } = require('fs') as typeof import('fs');
+    const keyUuid = readFileSync('/coolify-api-token/github_key_uuid', 'utf8').trim();
+    if (!keyUuid) return;
+    const { Client } = require('pg') as typeof import('pg');
+    const pg = new Client({
+      host: process.env.PGHOST ?? 'coolify-db',
+      port: Number(process.env.PGPORT ?? 5432),
+      database: process.env.PGDATABASE ?? 'coolify',
+      user: process.env.PGUSER ?? 'coolify',
+      password: process.env.PGPASSWORD,
+    });
+    await pg.connect();
+    await pg.query(
+      `UPDATE applications SET private_key_id = (SELECT id FROM private_keys WHERE uuid=$1 LIMIT 1) WHERE uuid=$2`,
+      [keyUuid, appUuid]
+    );
+    await pg.end();
+    console.log(`[github-key] Linked github-deploy key to app ${appUuid}`);
+  } catch (err) {
+    console.warn(`[github-key] Could not link key to app ${appUuid}:`, (err as Error).message);
+  }
+}
 
 // ── GET /api/sites — list all sites ──────────────────────────────────────────
 router.get('/', async (_req: Request, res: Response) => {
@@ -55,31 +125,91 @@ router.get('/:slug', async (req: Request, res: Response) => {
 });
 
 // ── POST /api/sites — create a new site ──────────────────────────────────────
-// Requires full Coolify payload: name, git_repository, git_branch, server_uuid, destination_uuid
+// Accepts: name, git_repository, git_branch, build_pack (default: nixpacks), port (default: 3000)
 router.post('/', async (req: Request, res: Response) => {
-  const body = req.body as Partial<CoolifyCreateApplicationPayload>;
-  if (!body.name || !body.git_repository || !body.git_branch || !body.server_uuid || !body.destination_uuid) {
+  const body = req.body as {
+    name?: string;
+    git_repository?: string;
+    git_branch?: string;
+    build_pack?: string;
+    port?: number | string;
+    description?: string;
+    fqdn?: string;
+    domain?: string;  // alias for fqdn accepted from frontend
+  };
+  if (!body.name || !body.git_repository || !body.git_branch) {
     res.status(400).json({
-      error: 'Missing required fields: name, git_repository, git_branch, server_uuid, destination_uuid',
+      error: 'Missing required fields: name, git_repository, git_branch',
     });
     return;
   }
   try {
     const client = createCoolifyClient()!;
+
+    // Auto-discover server_uuid
+    const servers = await client.getServers();
+    if (!servers.length) {
+      res.status(502).json({ error: 'No Coolify servers found' });
+      return;
+    }
+    const server_uuid = servers[0].uuid;
+
+    // Auto-discover destination_uuid from file written by coolify-setup.sh
+    let destination_uuid: string;
+    try {
+      destination_uuid = readFileSync('/coolify-api-token/destination_uuid', 'utf8').trim();
+    } catch {
+      res.status(500).json({ error: 'destination_uuid not available — ensure coolify-setup.sh has run' });
+      return;
+    }
+    if (!destination_uuid) {
+      res.status(500).json({ error: 'destination_uuid file is empty — ensure coolify-setup.sh has run' });
+      return;
+    }
+
+    // Auto-discover or create project
+    let projects = await client.getProjects();
+    let project_uuid: string;
+    if (projects.length > 0) {
+      project_uuid = projects[0].uuid;
+    } else {
+      const created = await client.createProject('hermithost-sites');
+      project_uuid = created.uuid;
+    }
+
     const payload: CoolifyCreateApplicationPayload = {
+      type: 'public',
       name: body.name,
       git_repository: body.git_repository,
       git_branch: body.git_branch,
-      server_uuid: body.server_uuid,
-      destination_uuid: body.destination_uuid,
+      build_pack: body.build_pack ?? 'nixpacks',
+      ports_exposes: String(body.port ?? 3000),
+      server_uuid,
+      destination_uuid,
+      project_uuid,
+      environment_name: 'production',
+      instant_deploy: false,
       ...(body.description !== undefined ? { description: body.description } : {}),
-      ...(body.fqdn !== undefined ? { fqdn: body.fqdn } : {}),
-      ...(body.build_pack !== undefined ? { build_pack: body.build_pack } : {}),
     };
-    const app = await client.createApplication(payload);
+    let app = await client.createApplication(payload);
+    await linkGithubKey(app.uuid);
+
+    // fqdn is not accepted at creation time — patch it immediately after using 'domains' field
+    const resolvedFqdn = body.fqdn ?? body.domain;
+    if (resolvedFqdn) {
+      // Coolify requires full URL format — add https:// if no protocol present
+      const coolifyDomain = /^https?:\/\//i.test(resolvedFqdn) ? resolvedFqdn : `https://${resolvedFqdn}`;
+      await client.updateApplication(app.uuid, { domains: coolifyDomain, force_domain_override: true }).catch((e: Error) => {
+        console.warn(`[coolify] domains patch failed for ${app.uuid}:`, e.message);
+      });
+      // Re-fetch to get full app with updated fqdn
+      const refreshed = await client.getApplication(app.uuid).catch(() => null);
+      if (refreshed) app = refreshed;
+      await provisionDns(resolvedFqdn);
+    }
     res.status(201).json(mapSite(app, []));
   } catch (err) {
-    console.error('[coolify] POST /applications failed:', (err as Error).message);
+    console.error('[coolify] POST /applications/public failed:', (err as Error).message);
     res.status(502).json({ error: 'Failed to create application via Coolify' });
   }
 });
@@ -103,6 +233,8 @@ router.delete('/:slug', async (req: Request, res: Response) => {
 // keeps the frontend decoupled from Coolify internals.
 router.patch('/:slug', async (req: Request, res: Response) => {
   const body = req.body as Partial<CoolifyUpdateApplicationPayload & {
+    fqdn?: string;    // alias — maps to domains
+    domain?: string;  // alias — maps to domains
     repository?: string;
     server?: string;
   }>;
@@ -115,13 +247,20 @@ router.patch('/:slug', async (req: Request, res: Response) => {
     const payload: CoolifyUpdateApplicationPayload = {};
     if (body.name !== undefined) payload.name = body.name;
     if (body.description !== undefined) payload.description = body.description;
-    if (body.fqdn !== undefined) payload.fqdn = body.fqdn;
+    // fqdn/domain → 'domains' (Coolify PATCH field name); requires full URL with protocol
+    const incomingFqdn = (body as any).fqdn ?? (body as any).domain ?? body.domains;
+    if (incomingFqdn !== undefined) {
+      payload.domains = /^https?:\/\//i.test(incomingFqdn) ? incomingFqdn : `https://${incomingFqdn}`;
+    }
     // Accept frontend 'repository' field and translate to git_repository
-    if (body.repository !== undefined) payload.git_repository = body.repository;
+    if ((body as any).repository !== undefined) payload.git_repository = (body as any).repository;
     if (body.git_repository !== undefined) payload.git_repository = body.git_repository;
     if (body.git_branch !== undefined) payload.git_branch = body.git_branch;
     if (body.build_pack !== undefined) payload.build_pack = body.build_pack;
     const app = await client.updateApplication(req.params.slug, payload);
+    if (payload.domains) {
+      await provisionDns(payload.domains);
+    }
     res.status(200).json(mapSite(app, []));
   } catch (err) {
     console.error(`[coolify] PATCH /applications/${req.params.slug} failed:`, (err as Error).message);
@@ -141,10 +280,15 @@ router.get('/:slug/dns', async (req: Request, res: Response) => {
       res.status(422).json({ error: 'Site has no domain configured' });
       return;
     }
-    const records = await dnsProvider.getRecords(domain);
+    const records = await createDnsProvider().getRecords(domain);
     res.status(200).json(records);
   } catch (err) {
     if (err instanceof DnsOperationError) {
+      const msg = (err.originalCause as Error)?.message ?? '';
+      if (msg.includes('No such zone')) {
+        res.status(200).json([]);
+        return;
+      }
       console.warn('[dns] getRecords failed:', err.originalCause);
       res.status(500).json({ error: 'DNS operation failed' });
     } else {
@@ -171,7 +315,7 @@ router.post('/:slug/dns', async (req: Request, res: Response) => {
       res.status(400).json({ error: 'Missing required fields: type, name, value, ttl' });
       return;
     }
-    const record = await dnsProvider.addRecord(domain, {
+    const record = await createDnsProvider().addRecord(domain, {
       type: body.type,
       name: body.name,
       value: body.value,
@@ -203,7 +347,7 @@ router.put('/:slug/dns/:id', async (req: Request, res: Response) => {
       return;
     }
     const updates = req.body as Partial<Omit<DnsRecord, 'id'>>;
-    const record = await dnsProvider.updateRecord(domain, req.params.id, updates);
+    const record = await createDnsProvider().updateRecord(domain, req.params.id, updates);
     res.status(200).json(record);
   } catch (err) {
     if (err instanceof DnsOperationError) {
@@ -228,7 +372,7 @@ router.delete('/:slug/dns/:id', async (req: Request, res: Response) => {
       res.status(422).json({ error: 'Site has no domain configured' });
       return;
     }
-    await dnsProvider.deleteRecord(domain, req.params.id);
+    await createDnsProvider().deleteRecord(domain, req.params.id);
     res.status(204).send();
   } catch (err) {
     if (err instanceof DnsOperationError) {
@@ -260,7 +404,8 @@ router.post('/:slug/deploy', async (req: Request, res: Response) => {
   try {
     const client = createCoolifyClient()!;
     const result = await client.triggerDeploy(req.params.slug);
-    res.status(202).json({ jobId: result.deployment_uuid, status: result.status, message: result.message });
+    const dep = result.deployments?.[0];
+    res.status(202).json({ jobId: dep?.deployment_uuid, message: dep?.message });
   } catch (err) {
     console.error(`[coolify] POST /deploy for ${req.params.slug} failed:`, (err as Error).message);
     res.status(502).json({ error: 'Failed to trigger deploy via Coolify' });

--- a/api/src/services/coolify.ts
+++ b/api/src/services/coolify.ts
@@ -39,26 +39,49 @@ export interface CoolifyDeploymentQueue {
 }
 
 export interface CoolifyTriggerDeployResponse {
-  message: string;
-  deployment_uuid: string;
-  status: string;
+  deployments: Array<{
+    message: string;
+    resource_uuid: string;
+    deployment_uuid: string;
+  }>;
 }
 
 export interface CoolifyCreateApplicationPayload {
+  type: 'public';
   name: string;
   description?: string;
   fqdn?: string;
   git_repository: string;
   git_branch: string;
-  build_pack?: string;
+  build_pack: string;
+  ports_exposes: string;
   server_uuid: string;
   destination_uuid: string;
+  project_uuid: string;
+  environment_name: string;
+  instant_deploy?: boolean;
+  private_key_uuid?: string;
+}
+
+export interface CoolifyServer {
+  uuid: string;
+  name: string;
+  ip: string;
+  is_reachable: boolean;
+  is_usable: boolean;
+}
+
+export interface CoolifyProject {
+  uuid: string;
+  name: string;
+  environments: Array<{ name: string; uuid: string }>;
 }
 
 export interface CoolifyUpdateApplicationPayload {
   name?: string;
   description?: string;
-  fqdn?: string;
+  domains?: string;  // sets fqdn — Coolify PATCH uses 'domains', not 'fqdn'
+  force_domain_override?: boolean;
   git_repository?: string;
   git_branch?: string;
   build_pack?: string;
@@ -98,7 +121,8 @@ export class CoolifyClient {
   async listDeployments(uuid: string, limit = 10): Promise<CoolifyDeploymentQueue[]> {
     const url = `${this.baseUrl}/deployments/applications/${uuid}?limit=${limit}`;
     const res = await fetch(url, { headers: this.headers });
-    return handleResponse<CoolifyDeploymentQueue[]>(res, `GET /deployments/applications/${uuid}`);
+    const data = await handleResponse<{ deployments: CoolifyDeploymentQueue[] } | CoolifyDeploymentQueue[]>(res, `GET /deployments/applications/${uuid}`);
+    return Array.isArray(data) ? data : (data as { deployments: CoolifyDeploymentQueue[] }).deployments ?? [];
   }
 
   async triggerDeploy(uuid: string): Promise<CoolifyTriggerDeployResponse> {
@@ -112,13 +136,40 @@ export class CoolifyClient {
     return handleResponse<CoolifyDeploymentQueue>(res, `GET /deployments/${deploymentUuid}`);
   }
 
+  async getServers(): Promise<CoolifyServer[]> {
+    const res = await fetch(`${this.baseUrl}/servers`, { headers: this.headers });
+    return handleResponse<CoolifyServer[]>(res, 'GET /servers');
+  }
+
+  async getProjects(): Promise<CoolifyProject[]> {
+    const res = await fetch(`${this.baseUrl}/projects`, { headers: this.headers });
+    return handleResponse<CoolifyProject[]>(res, 'GET /projects');
+  }
+
+  async createProject(name: string): Promise<CoolifyProject> {
+    const res = await fetch(`${this.baseUrl}/projects`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ name }),
+    });
+    return handleResponse<CoolifyProject>(res, 'POST /projects');
+  }
+
   async createApplication(payload: CoolifyCreateApplicationPayload): Promise<CoolifyApplication> {
-    const res = await fetch(`${this.baseUrl}/applications`, {
+    const res = await fetch(`${this.baseUrl}/applications/public`, {
       method: 'POST',
       headers: this.headers,
       body: JSON.stringify(payload),
     });
-    return handleResponse<CoolifyApplication>(res, 'POST /applications');
+    return handleResponse<CoolifyApplication>(res, 'POST /applications/public');
+  }
+
+  async deployApplication(uuid: string): Promise<CoolifyTriggerDeployResponse> {
+    const res = await fetch(`${this.baseUrl}/applications/${uuid}/start`, {
+      method: 'POST',
+      headers: this.headers,
+    });
+    return handleResponse<CoolifyTriggerDeployResponse>(res, `POST /applications/${uuid}/start`);
   }
 
   async deleteApplication(uuid: string): Promise<void> {
@@ -144,7 +195,14 @@ export class CoolifyClient {
 
 export function createCoolifyClient(): CoolifyClient | null {
   const baseUrl = process.env.COOLIFY_API_URL;
-  const token = process.env.COOLIFY_API_TOKEN;
+  // Prefer token file — setup script always refreshes it on boot, so it's always valid
+  let token: string | undefined;
+  try {
+    const { readFileSync } = require('fs') as typeof import('fs');
+    token = readFileSync('/coolify-api-token/token', 'utf8').trim() || undefined;
+  } catch { /* file not present */ }
+  // Fall back to env var
+  if (!token) token = process.env.COOLIFY_API_TOKEN;
   if (!baseUrl || !token) return null;
   return new CoolifyClient(baseUrl, token);
 }

--- a/api/src/services/dns/index.ts
+++ b/api/src/services/dns/index.ts
@@ -5,29 +5,17 @@ import { createTechnitiumClient } from '../technitium';
 export type { DnsProvider } from './DnsProvider';
 export { DnsOperationError } from './errors';
 
-let _instance: DnsProvider | null = null;
-
 /**
- * Returns the singleton DnsProvider.
- *
- * Selection:
- *   TECHNITIUM_URL + TECHNITIUM_TOKEN set  → TechnitiumProvider
- *   Otherwise                              → throws at startup (fail fast)
+ * Returns a DnsProvider with a fresh token on every call.
+ * Technitium tokens are session-scoped and expire; reading the token file
+ * each time ensures the provider always uses the current token written by
+ * coolify-setup.sh on boot (or by a token refresh).
  */
 export function createDnsProvider(): DnsProvider {
-  if (_instance) return _instance;
-
   const client = createTechnitiumClient();
   if (client) {
-    console.log('[dns] Technitium provider active');
-    _instance = new TechnitiumProvider(client);
-    return _instance;
+    return new TechnitiumProvider(client);
   }
 
   throw new Error('DNS provider not configured: set TECHNITIUM_URL and TECHNITIUM_TOKEN');
-}
-
-/** Reset singleton — for testing only. */
-export function resetDnsProvider(): void {
-  _instance = null;
 }

--- a/api/src/services/technitium.ts
+++ b/api/src/services/technitium.ts
@@ -14,7 +14,7 @@ export interface TechnitiumRData {
   // A / AAAA
   ipAddress?: string;
   // CNAME
-  cName?: string;
+  cname?: string;
   // MX
   preference?: number;
   exchange?: string;
@@ -35,6 +35,17 @@ export interface TechnitiumRecord {
   type: string;
   ttl: number;
   rData: TechnitiumRData;
+}
+
+export interface TechnitiumZoneListResponse {
+  response: { zones: TechnitiumZone[] };
+  status: string;
+  errorMessage?: string;
+}
+
+export interface TechnitiumZoneResponse {
+  status: string;
+  errorMessage?: string;
 }
 
 export interface TechnitiumGetRecordsResponse {
@@ -74,8 +85,8 @@ async function handleResponse<T extends { status: string; errorMessage?: string 
     throw new Error(`Technitium ${context} failed: HTTP ${res.status} — ${body}`);
   }
   const data = (await res.json()) as T;
-  if (data.status === 'error') {
-    throw new Error(`Technitium ${context} error: ${data.errorMessage ?? 'unknown error'}`);
+  if (data.status !== 'ok') {
+    throw new Error(`Technitium ${context} error: ${data.errorMessage ?? data.status}`);
   }
   return data;
 }
@@ -104,12 +115,12 @@ export class TechnitiumClient {
 
   async getRecords(domain: string): Promise<TechnitiumGetRecordsResult> {
     const body = this.buildParams({ domain, listZone: 'true' });
-    const res = await fetch(`${this.baseUrl}/api/zone/getRecords`, {
+    const res = await fetch(`${this.baseUrl}/api/zones/records/get`, {
       method: 'POST',
       headers: this.postHeaders,
       body,
     });
-    const data = await handleResponse<TechnitiumGetRecordsResponse>(res, 'POST /api/zone/getRecords');
+    const data = await handleResponse<TechnitiumGetRecordsResponse>(res, 'POST /api/zones/records/get');
     return {
       zone: data.response.zone,
       records: data.response.records,
@@ -153,6 +164,37 @@ export class TechnitiumClient {
     return updated;
   }
 
+  async listZones(): Promise<TechnitiumZone[]> {
+    const body = this.buildParams({});
+    const res = await fetch(`${this.baseUrl}/api/zones/list`, {
+      method: 'POST',
+      headers: this.postHeaders,
+      body,
+    });
+    const data = await handleResponse<TechnitiumZoneListResponse>(res, 'POST /api/zones/list');
+    return data.response.zones;
+  }
+
+  async createZone(name: string, type = 'Primary'): Promise<void> {
+    const body = this.buildParams({ zone: name, type });
+    const res = await fetch(`${this.baseUrl}/api/zones/create`, {
+      method: 'POST',
+      headers: this.postHeaders,
+      body,
+    });
+    await handleResponse<TechnitiumZoneResponse>(res, 'POST /api/zones/create');
+  }
+
+  async deleteZone(name: string): Promise<void> {
+    const body = this.buildParams({ zone: name });
+    const res = await fetch(`${this.baseUrl}/api/zones/delete`, {
+      method: 'POST',
+      headers: this.postHeaders,
+      body,
+    });
+    await handleResponse<TechnitiumZoneResponse>(res, 'POST /api/zones/delete');
+  }
+
   async deleteRecord(
     domain: string,
     params: URLSearchParams
@@ -173,7 +215,14 @@ export function createTechnitiumClient(
   token?: string
 ): TechnitiumClient | null {
   const url = baseUrl ?? process.env.TECHNITIUM_URL;
-  const tok = token ?? process.env.TECHNITIUM_TOKEN;
+  let tok = token ?? process.env.TECHNITIUM_TOKEN;
+  // Fall back to token file — setup script refreshes it on every boot
+  if (!tok) {
+    try {
+      const { readFileSync } = require('fs') as typeof import('fs');
+      tok = readFileSync('/coolify-api-token/technitium_token', 'utf8').trim();
+    } catch { /* file not present */ }
+  }
   if (!url || !tok) return null;
   return new TechnitiumClient(url, tok);
 }

--- a/api/src/services/technitiumMapper.ts
+++ b/api/src/services/technitiumMapper.ts
@@ -48,7 +48,7 @@ function extractValue(raw: TechnitiumRecord): string {
     case 'AAAA':
       return r.ipAddress ?? '';
     case 'CNAME':
-      return r.cName ?? '';
+      return r.cname ?? '';
     case 'MX':
       return r.exchange ?? '';
     case 'TXT':

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,164 @@
 services:
+  # ── Coolify — Deployment Engine ────────────────────────────────
+  coolify:
+    image: "ghcr.io/coollabsio/coolify:latest"
+    restart: unless-stopped
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - coolify-storage:/var/www/html/storage/app
+    environment:
+      APP_ENV: "production"
+      APP_ID: "${COOLIFY_APP_ID}"
+      APP_NAME: "Coolify"
+      APP_KEY: "${COOLIFY_APP_KEY}"
+      DB_CONNECTION: "pgsql"
+      DB_HOST: "coolify-db"
+      DB_PORT: "5432"
+      DB_DATABASE: "coolify"
+      DB_USERNAME: "coolify"
+      DB_PASSWORD: "${COOLIFY_DB_PASSWORD}"
+      REDIS_HOST: "coolify-redis"
+      REDIS_PASSWORD: "${COOLIFY_REDIS_PASSWORD}"
+      PUSHER_APP_ID: "${COOLIFY_PUSHER_APP_ID}"
+      PUSHER_APP_KEY: "${COOLIFY_PUSHER_APP_KEY}"
+      PUSHER_APP_SECRET: "${COOLIFY_PUSHER_APP_SECRET}"
+      ROOT_USER_EMAIL: "${COOLIFY_ADMIN_EMAIL}"
+      ROOT_USER_PASSWORD: "${COOLIFY_ADMIN_PASSWORD}"
+      PHP_MEMORY_LIMIT: "256M"
+    ports:
+      - "${COOLIFY_PORT:-8000}:8080"
+    depends_on:
+      coolify-db:
+        condition: service_healthy
+      coolify-redis:
+        condition: service_healthy
+      coolify-realtime:
+        condition: service_healthy
+    networks:
+      - hermithost-net
+    healthcheck:
+      test: curl --fail http://127.0.0.1:8080/api/health || exit 1
+      interval: 10s
+      retries: 15
+      timeout: 3s
+
+  coolify-db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: "coolify"
+      POSTGRES_PASSWORD: "${COOLIFY_DB_PASSWORD}"
+      POSTGRES_DB: "coolify"
+    volumes:
+      - coolify-db:/var/lib/postgresql/data
+      - ./docker/postgres-init:/docker-entrypoint-initdb.d:ro
+    networks:
+      - hermithost-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U coolify -d coolify"]
+      interval: 5s
+      retries: 10
+      timeout: 2s
+
+  coolify-redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --save 20 1 --loglevel warning --requirepass ${COOLIFY_REDIS_PASSWORD}
+    environment:
+      REDIS_PASSWORD: "${COOLIFY_REDIS_PASSWORD}"
+    volumes:
+      - coolify-redis:/data
+    networks:
+      - hermithost-net
+    healthcheck:
+      test: redis-cli -a ${COOLIFY_REDIS_PASSWORD} ping
+      interval: 5s
+      retries: 10
+      timeout: 2s
+
+  coolify-realtime:
+    image: "ghcr.io/coollabsio/coolify-realtime:1.0.13"
+    restart: unless-stopped
+    environment:
+      APP_NAME: "Coolify"
+      SOKETI_DEBUG: "false"
+      SOKETI_DEFAULT_APP_ID: "${COOLIFY_PUSHER_APP_ID}"
+      SOKETI_DEFAULT_APP_KEY: "${COOLIFY_PUSHER_APP_KEY}"
+      SOKETI_DEFAULT_APP_SECRET: "${COOLIFY_PUSHER_APP_SECRET}"
+      SOKETI_HOST: "0.0.0.0"
+    networks:
+      - hermithost-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:6001/ready || exit 1"]
+      interval: 5s
+      retries: 10
+      timeout: 2s
+
+  # ── Coolify Keys Init (one-shot) ──────────────────────────────
+  coolify-keys-init:
+    image: alpine
+    restart: "no"
+    volumes:
+      - coolify-keys:/coolify-keys
+    command: >
+      sh -c "apk add --no-cache openssh-client -q &&
+        if [ ! -f /coolify-keys/hermithost_deploy ]; then
+          ssh-keygen -t ed25519 -f /coolify-keys/hermithost_deploy -N '' -C 'coolify@hermithost' -q &&
+          echo '[keys-init] Key generated.';
+        else echo '[keys-init] Key exists, reusing.'; fi"
+
+  # ── SSH Bridge ────────────────────────────────────────────────
+  ssh-bridge:
+    build:
+      context: ./docker/ssh-bridge
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    depends_on:
+      coolify-keys-init:
+        condition: service_completed_successfully
+    volumes:
+      - coolify-keys:/coolify-keys:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ssh-bridge-host-keys:/etc/ssh/host_keys
+    networks:
+      - hermithost-net
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 22 || exit 1"]
+      interval: 5s
+      retries: 12
+      timeout: 2s
+
+  # ── Coolify Server Setup (one-shot) ───────────────────────────
+  coolify-server-setup:
+    image: alpine
+    restart: "no"
+    depends_on:
+      coolify:
+        condition: service_healthy
+      coolify-db:
+        condition: service_healthy
+      ssh-bridge:
+        condition: service_healthy
+      technitium:
+        condition: service_healthy
+    volumes:
+      - coolify-keys:/coolify-keys
+      - coolify-api-token:/coolify-api-token
+      - ./scripts/coolify-setup.sh:/setup.sh:ro
+    environment:
+      COOLIFY_API_TOKEN: "${COOLIFY_API_TOKEN}"
+      PGHOST: "coolify-db"
+      PGPORT: "5432"
+      PGDATABASE: "coolify"
+      PGUSER: "coolify"
+      PGPASSWORD: "${COOLIFY_DB_PASSWORD}"
+    command: >
+      sh -c "apk add --no-cache openssh-client curl jq postgresql-client -q && sh /setup.sh"
+    networks:
+      - hermithost-net
+
   # ── Reverse Proxy ──────────────────────────────────────────────
   traefik:
     image: traefik:v3.2
@@ -40,27 +200,46 @@ services:
       CORS_ORIGIN: "*"
       SITES_DIR: "/app/sites"
       GITHUB_TOKEN: "${GITHUB_TOKEN}"
-      COOLIFY_API_URL: "${COOLIFY_API_URL:-}"
-      COOLIFY_API_TOKEN: "${COOLIFY_API_TOKEN:-}"
+      COOLIFY_API_URL: "http://coolify:8080/api/v1"
+      COOLIFY_API_TOKEN: "${COOLIFY_API_TOKEN}"
       TECHNITIUM_URL: "${TECHNITIUM_URL:-http://technitium:5380}"
       TECHNITIUM_TOKEN: "${TECHNITIUM_TOKEN:-}"
       DNS_MOCK: "${DNS_MOCK:-}"
+      NS_HOSTNAME: "${NS_HOSTNAME:-}"
+      PGHOST: "coolify-db"
+      PGPORT: "5432"
+      PGDATABASE: "coolify"
+      PGUSER: "coolify"
+      PGPASSWORD: "${COOLIFY_DB_PASSWORD}"
     volumes:
       - hermithost-sites:/app/sites
+      - coolify-api-token:/coolify-api-token:ro
     networks:
       - hermithost-net
     restart: unless-stopped
+    depends_on:
+      coolify:
+        condition: service_healthy
+      coolify-server-setup:
+        condition: service_completed_successfully
 
   # ── Technitium DNS Server ──────────────────────────────────────
   technitium:
     image: technitium/dns-server:latest
     restart: unless-stopped
     ports:
-      - "5380:5380"
+      - "5380:5380"         # Technitium web UI / API
+      - "53:53/udp"         # DNS queries (required)
+      - "53:53/tcp"         # DNS over TCP (required)
     volumes:
       - technitium-config:/etc/dns
     networks:
       - hermithost-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5380/api/user/login?user=admin&pass=admin > /dev/null 2>&1 || exit 1"]
+      interval: 5s
+      retries: 12
+      timeout: 3s
 
 networks:
   hermithost-net:
@@ -70,3 +249,9 @@ volumes:
   hermithost-sites:
   traefik-acme:
   technitium-config:
+  coolify-storage:
+  coolify-db:
+  coolify-redis:
+  coolify-keys:
+  coolify-api-token:
+  ssh-bridge-host-keys:

--- a/docker/postgres-init/01-ensure-root-team.sql
+++ b/docker/postgres-init/01-ensure-root-team.sql
@@ -1,0 +1,26 @@
+-- Fires after every CREATE/ALTER TABLE during Coolify migrations.
+-- Once the `teams` table exists, inserts the root team (id=0) that
+-- Coolify's seeder expects to already exist when it inserts
+-- shared_environment_variables with team_id=0.
+CREATE OR REPLACE FUNCTION ensure_root_team()
+RETURNS event_trigger AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'teams'
+  ) THEN
+    BEGIN
+      INSERT INTO teams (id, name, personal_team, created_at, updated_at)
+      SELECT 0, 'root', false, NOW(), NOW()
+      WHERE NOT EXISTS (SELECT 1 FROM teams WHERE id = 0);
+    EXCEPTION WHEN OTHERS THEN
+      NULL; -- ignore: table may not yet have all columns
+    END;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE EVENT TRIGGER ensure_root_team_trigger
+ON ddl_command_end
+WHEN TAG IN ('CREATE TABLE', 'ALTER TABLE')
+EXECUTE FUNCTION ensure_root_team();

--- a/docker/ssh-bridge/Dockerfile
+++ b/docker/ssh-bridge/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.20
+RUN apk add --no-cache openssh docker-cli bash curl sudo
+RUN adduser -D -s /bin/bash deploy && \
+    passwd -d deploy && \
+    mkdir -p /home/deploy/.ssh && chmod 700 /home/deploy/.ssh && \
+    chown deploy:deploy /home/deploy/.ssh && \
+    echo "deploy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/deploy && \
+    chmod 440 /etc/sudoers.d/deploy
+RUN ssh-keygen -A && mkdir -p /run/sshd
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+EXPOSE 22
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/ssh-bridge/entrypoint.sh
+++ b/docker/ssh-bridge/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+KEY_FILE="/coolify-keys/hermithost_deploy.pub"
+
+echo "[ssh-bridge] Waiting for SSH public key..."
+WAIT=0
+while [ ! -f "$KEY_FILE" ]; do
+  sleep 1; WAIT=$((WAIT+1))
+  if [ $WAIT -gt 60 ]; then echo "ERROR: key never appeared"; exit 1; fi
+done
+
+cat "$KEY_FILE" > /home/deploy/.ssh/authorized_keys
+chmod 600 /home/deploy/.ssh/authorized_keys
+chown deploy:deploy /home/deploy/.ssh/authorized_keys
+echo "[ssh-bridge] Public key installed."
+
+# Align Docker GID to host socket (critical on macOS Docker Desktop)
+SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo "")
+if [ -n "$SOCK_GID" ] && [ "$SOCK_GID" != "0" ]; then
+  if ! getent group docker > /dev/null 2>&1; then
+    addgroup -g "$SOCK_GID" docker
+  else
+    sed -i "s/^docker:x:[0-9]*/docker:x:$SOCK_GID/" /etc/group
+  fi
+  adduser deploy docker
+else
+  # GID=0 (macOS Docker Desktop): socket owned by root:root — add deploy to root group
+  adduser deploy root
+fi
+
+# Ensure the 'coolify' Docker network exists (required for app deployments)
+if ! docker network inspect coolify > /dev/null 2>&1; then
+  docker network create coolify > /dev/null 2>&1 && echo "[ssh-bridge] Created 'coolify' Docker network." || echo "[ssh-bridge] WARNING: could not create 'coolify' network."
+else
+  echo "[ssh-bridge] 'coolify' Docker network already exists."
+fi
+
+echo "[ssh-bridge] Starting sshd..."
+exec /usr/sbin/sshd -D -e

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@sveltejs/kit": "^2.5.5",
         "@sveltejs/vite-plugin-svelte": "^3.1.0",
         "@types/node": "^25.6.0",
+        "playwright": "^1.59.1",
         "svelte": "^4.2.18",
         "svelte-check": "^3.7.1",
         "tslib": "^2.6.2",
@@ -1854,6 +1855,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@sveltejs/kit": "^2.5.5",
     "@sveltejs/vite-plugin-svelte": "^3.1.0",
     "@types/node": "^25.6.0",
+    "playwright": "^1.59.1",
     "svelte": "^4.2.18",
     "svelte-check": "^3.7.1",
     "tslib": "^2.6.2",

--- a/scripts/coolify-setup.sh
+++ b/scripts/coolify-setup.sh
@@ -1,0 +1,183 @@
+#!/bin/sh
+# Runs inside the coolify-server-setup container.
+# Registers the ssh-bridge SSH key with Coolify, updates the server IP,
+# and validates the server — fully automated, idempotent.
+set -e
+set -o pipefail
+
+COOLIFY_URL="http://coolify:8080/api/v1"
+KEY_FILE="/coolify-keys/hermithost_deploy"
+
+auth_header() { echo "Authorization: Bearer $SESSION_TOKEN"; }
+
+# ── 0. Wait for Coolify to seed, then create a session token via DB ──────────
+echo "[setup] Waiting for Coolify to seed..."
+WAIT=0
+while true; do
+  USER_COUNT=$(psql -t -A -c "SELECT COUNT(*) FROM users;" 2>/dev/null || echo "0")
+  [ "$USER_COUNT" -gt 0 ] && break
+  sleep 2; WAIT=$((WAIT+2))
+  if [ $WAIT -gt 120 ]; then echo "[setup] ERROR: Coolify seeding timeout."; exit 1; fi
+done
+echo "[setup] Coolify seeded."
+
+# Ensure root user is linked to root team (seeder doesn't do this)
+psql -c "INSERT INTO team_user (team_id, user_id, role, created_at, updated_at) VALUES (0, 0, 'owner', NOW(), NOW()) ON CONFLICT DO NOTHING;" > /dev/null
+echo "[setup] User linked to root team."
+
+# Enable Coolify API (disabled by default on fresh install)
+psql -c "UPDATE instance_settings SET is_api_enabled=true WHERE id=0;" > /dev/null
+echo "[setup] API enabled."
+
+PLAIN_TOKEN="hermithost-setup-$(date +%s)"
+TOKEN_HASH=$(printf '%s' "$PLAIN_TOKEN" | sha256sum | cut -d' ' -f1)
+USER_ID=$(psql -t -A -c "SELECT id FROM users ORDER BY id LIMIT 1;" | grep -E '^[0-9]+$')
+
+# Clean up any previous hermithost-setup tokens
+psql -c "DELETE FROM personal_access_tokens WHERE name='hermithost-setup';" > /dev/null
+
+TOKEN_ID=$(psql -t -A -c "INSERT INTO personal_access_tokens (tokenable_type, tokenable_id, name, token, abilities, team_id, created_at, updated_at) VALUES ('App\Models\User', $USER_ID, 'hermithost-setup', '$TOKEN_HASH', '[\"*\"]', 0, NOW(), NOW()) RETURNING id;" | grep -E '^[0-9]+$')
+SESSION_TOKEN="${TOKEN_ID}|${PLAIN_TOKEN}"
+echo "[setup] Session token created."
+
+# ── 1. Discover server UUID ───────────────────────────────────────────────────
+echo "[setup] Discovering server UUID..."
+SERVERS_RESP=$(curl -sf "$COOLIFY_URL/servers" -H "$(auth_header)")
+SERVER_UUID=$(echo "$SERVERS_RESP" | jq -r '.[0].uuid')
+if [ -z "$SERVER_UUID" ] || [ "$SERVER_UUID" = "null" ]; then
+  echo "[setup] ERROR: Could not discover server UUID."
+  exit 1
+fi
+echo "[setup] Server UUID: $SERVER_UUID"
+
+# ── 2. Provision tokens (always — session tokens change each boot) ────────────
+# Coolify API token — always re-provision so the file is always valid after DB reset
+API_TOKEN_FILE="/coolify-api-token/token"
+echo "[setup] Provisioning API token..."
+API_PLAIN="hermithost-api-$(date +%s)"
+API_HASH=$(printf '%s' "$API_PLAIN" | sha256sum | cut -d' ' -f1)
+psql -c "DELETE FROM personal_access_tokens WHERE name='hermithost-api';" > /dev/null
+API_TOKEN_ID=$(psql -t -A -c "INSERT INTO personal_access_tokens (tokenable_type, tokenable_id, name, token, abilities, team_id, created_at, updated_at) VALUES ('App\Models\User', $USER_ID, 'hermithost-api', '$API_HASH', '[\"*\"]', 0, NOW(), NOW()) RETURNING id;" | grep -E '^[0-9]+$')
+printf '%s|%s' "$API_TOKEN_ID" "$API_PLAIN" > "$API_TOKEN_FILE"
+echo "[setup] API token written."
+
+# Destination UUID
+DEST_UUID=$(psql -t -A -c "SELECT d.uuid FROM standalone_dockers d JOIN servers s ON s.id = d.server_id WHERE s.uuid='$SERVER_UUID' LIMIT 1;" | grep -E '^[a-z0-9]+$' | head -1)
+if [ -n "$DEST_UUID" ]; then
+  printf '%s' "$DEST_UUID" > /coolify-api-token/destination_uuid
+  echo "[setup] Destination UUID written: $DEST_UUID"
+fi
+
+# Technitium session token (always refresh — session-based)
+echo "[setup] Logging into Technitium..."
+TECH_URL="${TECHNITIUM_URL:-http://technitium:5380}"
+TECH_RESP=$(curl -sf -X POST "$TECH_URL/api/user/login" \
+  -d "user=admin&pass=admin&includeInfo=false" 2>/dev/null || echo "")
+TECH_TOKEN=$(echo "$TECH_RESP" | jq -r '.token // empty' 2>/dev/null)
+if [ -n "$TECH_TOKEN" ]; then
+  printf '%s' "$TECH_TOKEN" > /coolify-api-token/technitium_token
+  echo "[setup] Technitium token written."
+else
+  echo "[setup] WARNING: Could not obtain Technitium token — DNS integration will be limited."
+fi
+
+# ── 3. Provision GitHub deploy key (always — DB is reset on each boot) ───────
+GITHUB_KEY_FILE="/coolify-keys/github_deploy"
+if [ ! -f "$GITHUB_KEY_FILE" ]; then
+  echo "[setup] Generating GitHub deploy key..."
+  ssh-keygen -t ed25519 -f "$GITHUB_KEY_FILE" -N '' -C 'hermithost@github' -q
+  echo "[setup] GitHub deploy key generated."
+fi
+
+GITHUB_PRIV_JSON=$(jq -Rs . < "$GITHUB_KEY_FILE")
+GITHUB_PUB_KEY=$(cat "${GITHUB_KEY_FILE}.pub")
+
+psql -c "DELETE FROM private_keys WHERE name='github-deploy';" > /dev/null 2>&1
+GITHUB_KEY_RESP=$(curl -sf -X POST "$COOLIFY_URL/security/keys" \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"github-deploy\",\"description\":\"HermitHost GitHub deploy key\",\"private_key\":$GITHUB_PRIV_JSON}" || echo "")
+GITHUB_KEY_UUID=$(echo "$GITHUB_KEY_RESP" | jq -r '.uuid // empty')
+
+if [ -n "$GITHUB_KEY_UUID" ]; then
+  psql -c "UPDATE private_keys SET is_git_related=true WHERE uuid='$GITHUB_KEY_UUID';" > /dev/null
+  printf '%s' "$GITHUB_KEY_UUID" > /coolify-api-token/github_key_uuid
+  echo "[setup] GitHub deploy key registered: $GITHUB_KEY_UUID"
+  echo "[setup] ══════════════════════════════════════════════════"
+  echo "[setup] Add this deploy key to your GitHub repos:"
+  echo "$GITHUB_PUB_KEY"
+  echo "[setup] ══════════════════════════════════════════════════"
+else
+  echo "[setup] WARNING: Could not register GitHub deploy key."
+fi
+
+# ── 4. Skip if server already configured and reachable ───────────────────────
+echo "[setup] Checking server status..."
+SERVER_INFO=$(curl -sf "$COOLIFY_URL/servers" \
+  -H "$(auth_header)" | jq -r --arg u "$SERVER_UUID" '.[] | select(.uuid==$u) | {ip: .ip, reachable: .is_reachable}')
+
+SERVER_IP=$(echo "$SERVER_INFO" | jq -r '.ip // empty')
+REACHABLE=$(echo "$SERVER_INFO" | jq -r '.reachable // empty')
+echo "[setup] Server IP=$SERVER_IP reachable=$REACHABLE"
+
+if [ "$SERVER_IP" = "ssh-bridge" ] && [ "$REACHABLE" = "true" ]; then
+  echo "[setup] Server already configured and reachable — skipping server setup."
+  exit 0
+fi
+
+# ── 5. Update server IP to ssh-bridge ────────────────────────────────────────
+echo "[setup] Updating server IP to ssh-bridge..."
+curl -sf -X PATCH "$COOLIFY_URL/servers/$SERVER_UUID" \
+  -H "$(auth_header)" -H "Content-Type: application/json" \
+  -d '{"ip":"ssh-bridge","port":22,"user":"deploy"}' > /dev/null
+echo "[setup] Server IP updated."
+
+# ── 4. Register private key with Coolify ─────────────────────────────────────
+echo "[setup] Registering private key with Coolify..."
+PRIV_JSON=$(jq -Rs . < "$KEY_FILE")
+
+KEY_RESP=$(curl -sf -X POST "$COOLIFY_URL/security/keys" \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"hermithost-deploy\",\"private_key\":$PRIV_JSON}")
+
+KEY_UUID=$(echo "$KEY_RESP" | jq -r '.uuid // empty')
+
+# Key may already exist — look it up
+if [ -z "$KEY_UUID" ]; then
+  echo "[setup] Key may already exist, looking up..."
+  KEY_UUID=$(curl -sf "$COOLIFY_URL/security/keys" \
+    -H "$(auth_header)" \
+    | jq -r '.[] | select(.name=="hermithost-deploy") | .uuid' | head -1)
+fi
+
+if [ -z "$KEY_UUID" ]; then
+  echo "[setup] ERROR: Could not register or find SSH key in Coolify."
+  exit 1
+fi
+echo "[setup] Key UUID: $KEY_UUID"
+
+# ── 5. Link key to server via DB (Coolify API silently ignores private_key_uuid PATCH) ─
+echo "[setup] Linking key to server..."
+KEY_ID=$(psql -t -A -c "SELECT id FROM private_keys WHERE uuid='$KEY_UUID' LIMIT 1;" | grep -E '^[0-9]+$')
+if [ -z "$KEY_ID" ]; then
+  echo "[setup] ERROR: Could not find key ID in DB for UUID $KEY_UUID."
+  exit 1
+fi
+psql -c "UPDATE servers SET private_key_id=$KEY_ID WHERE uuid='$SERVER_UUID';" > /dev/null
+echo "[setup] Key linked (private_key_id=$KEY_ID)."
+
+
+# ── 8. Validate server ────────────────────────────────────────────────────────
+echo "[setup] Validating server (may take a few seconds)..."
+sleep 3
+RESULT=$(curl -sf "$COOLIFY_URL/servers/$SERVER_UUID/validate" \
+  -H "$(auth_header)")
+echo "[setup] Validate response: $RESULT"
+
+# ── 9. Confirm ────────────────────────────────────────────────────────────────
+sleep 8
+STATUS=$(curl -sf "$COOLIFY_URL/servers" \
+  -H "$(auth_header)" | jq -r --arg u "$SERVER_UUID" '.[] | select(.uuid==$u) | {reachable: .is_reachable, usable: .is_usable}')
+echo "[setup] Final server status: $STATUS"
+echo "[setup] Done."

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$SCRIPT_DIR/.."
-PORT=5113
-API_PORT=3013
+PORT="${TRAEFIK_HTTP_PORT:-8080}"
 LOG_DIR="$ROOT/logs"
 export DOCKER_HOST=unix:///Users/rdemeritt/.docker/run/docker.sock
 
@@ -36,25 +35,9 @@ for i in $(seq 1 60); do
   sleep 0.5
 done
 
-# Wait for API port
-echo "   Waiting for port $API_PORT..."
-for i in $(seq 1 60); do
-  if nc -z 127.0.0.1 "$API_PORT" 2>/dev/null; then
-    echo "   API ready"
-    break
-  fi
-  if [[ $i -eq 60 ]]; then
-    echo "   API did not become ready. Check logs:"
-    echo "   docker compose logs api"
-    exit 1
-  fi
-  sleep 0.5
-done
-
 echo ""
 echo "   hermithost fully running"
 echo "   Dashboard  ->  http://localhost:${PORT}"
-echo "   API        ->  http://localhost:${API_PORT}"
 echo ""
 echo "   Logs:   docker compose logs -f"
 echo "   Stop:   bash $SCRIPT_DIR/stop.sh"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,6 +19,10 @@
 				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
 				Sites
 			</a>
+			<a href="/dns" class="nav-item" class:active={$page.url.pathname.startsWith('/dns')}>
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
+				DNS
+			</a>
 		</div>
 
 		<div class="nav-section">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -58,8 +58,8 @@
 				body: JSON.stringify({
 					name: addName.trim(),
 					domain: addDomain.trim(),
-					gitRepo: addGitRepo.trim(),
-					gitBranch: addGitBranch.trim() || 'main'
+					git_repository: addGitRepo.trim(),
+					git_branch: addGitBranch.trim() || 'main'
 				})
 			});
 			if (!res.ok) {

--- a/src/routes/dns/+page.svelte
+++ b/src/routes/dns/+page.svelte
@@ -1,0 +1,1022 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import type { DnsZone } from './+page';
+	import type { DnsRecord } from '$lib/types';
+
+	export let data: PageData;
+
+	let zones: DnsZone[] = data.zones;
+	let nsHostname: string | null = data.nsHostname;
+	let helpExpanded = false;
+	let helpDismissed = false;
+
+	// Auto-expand on first visit (no zones yet) unless already dismissed
+	if (typeof localStorage !== 'undefined') {
+		helpDismissed = localStorage.getItem('hermithost:dns-help-dismissed') === '1';
+	}
+	if (!helpDismissed && zones.length === 0) {
+		helpExpanded = true;
+	}
+
+	function dismissHelp(): void {
+		helpDismissed = true;
+		helpExpanded = false;
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem('hermithost:dns-help-dismissed', '1');
+		}
+	}
+
+	function copyNs(): void {
+		if (nsHostname) navigator.clipboard.writeText(nsHostname);
+	}
+
+	let selectedZone: DnsZone | null = null;
+	let zoneRecords: DnsRecord[] = [];
+	let recordsLoading = false;
+	let recordsError = '';
+
+	// Zone create form
+	let showAddZone = false;
+	let newZoneName = '';
+	let addZoneLoading = false;
+	let addZoneError = '';
+
+	// Zone delete
+	let deletingZone: string | null = null;
+	let deleteZoneError = '';
+	let showDeleteZoneConfirm: string | null = null;
+
+	// DNS record form
+	let showAddDns = false;
+	let editingRecord: DnsRecord | null = null;
+	let newRecord = { type: 'A', name: '', value: '', ttl: 3600, priority: '' };
+	let dnsFormSaving = false;
+	let dnsFormError = '';
+
+	// Record delete
+	let showDeleteRecordConfirm: string | null = null;
+	let deletingRecordId: string | null = null;
+	let deleteRecordError: string | null = null;
+
+	// ── Zone helpers ─────────────────────────────────────────────────────────────
+
+	const userZones = () => zones.filter((z) => !z.internal);
+	const internalZones = () => zones.filter((z) => z.internal);
+
+	async function selectZone(zone: DnsZone): Promise<void> {
+		selectedZone = zone;
+		zoneRecords = [];
+		recordsError = '';
+		recordsLoading = true;
+		resetDnsForm();
+		try {
+			const res = await fetch(`/api/dns/zones/${encodeURIComponent(zone.name)}/records`);
+			if (!res.ok) {
+				const body: { error?: string } = await res.json().catch(() => ({}));
+				recordsError = body.error ?? `Failed to load records (${res.status})`;
+				return;
+			}
+			zoneRecords = await res.json();
+		} catch {
+			recordsError = 'Network error — could not load records';
+		} finally {
+			recordsLoading = false;
+		}
+	}
+
+	async function createZone(): Promise<void> {
+		if (!newZoneName.trim()) return;
+		addZoneLoading = true;
+		addZoneError = '';
+		try {
+			const res = await fetch('/api/dns/zones', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name: newZoneName.trim() })
+			});
+			if (!res.ok) {
+				const body: { error?: string } = await res.json().catch(() => ({}));
+				addZoneError = body.error ?? `Create failed (${res.status})`;
+				return;
+			}
+			const created: DnsZone = await res.json();
+			const fullZone: DnsZone = { disabled: false, internal: false, dnssecStatus: 'Unsigned', ...created };
+			zones = [...zones, fullZone];
+			newZoneName = '';
+			showAddZone = false;
+			await selectZone(fullZone);
+		} catch {
+			addZoneError = 'Network error — could not create zone';
+		} finally {
+			addZoneLoading = false;
+		}
+	}
+
+	async function deleteZone(name: string): Promise<void> {
+		deletingZone = name;
+		deleteZoneError = '';
+		try {
+			const res = await fetch(`/api/dns/zones/${encodeURIComponent(name)}`, { method: 'DELETE' });
+			if (!res.ok) {
+				const body: { error?: string } = await res.json().catch(() => ({}));
+				deleteZoneError = body.error ?? `Delete failed (${res.status})`;
+				deletingZone = null;
+				return;
+			}
+			zones = zones.filter((z) => z.name !== name);
+			if (selectedZone?.name === name) {
+				selectedZone = null;
+				zoneRecords = [];
+			}
+			showDeleteZoneConfirm = null;
+		} catch {
+			deleteZoneError = 'Network error — delete failed';
+			deletingZone = null;
+		}
+	}
+
+	// ── Record helpers ────────────────────────────────────────────────────────────
+
+	function resetDnsForm(): void {
+		newRecord = { type: 'A', name: '', value: '', ttl: 3600, priority: '' };
+		editingRecord = null;
+		dnsFormError = '';
+		showAddDns = false;
+	}
+
+	function startEditRecord(record: DnsRecord): void {
+		editingRecord = record;
+		newRecord = {
+			type: record.type,
+			name: record.name,
+			value: record.value,
+			ttl: record.ttl,
+			priority: record.priority !== undefined ? String(record.priority) : ''
+		};
+		showAddDns = true;
+	}
+
+	async function saveRecord(): Promise<void> {
+		if (!selectedZone) return;
+		dnsFormSaving = true;
+		dnsFormError = '';
+		const isEditing = editingRecord !== null;
+		const url = isEditing
+			? `/api/dns/zones/${encodeURIComponent(selectedZone.name)}/records/${editingRecord!.id}`
+			: `/api/dns/zones/${encodeURIComponent(selectedZone.name)}/records`;
+		const method = isEditing ? 'PUT' : 'POST';
+		const payload: Record<string, string | number | undefined> = {
+			type: newRecord.type,
+			name: newRecord.name,
+			value: newRecord.value,
+			ttl: Number(newRecord.ttl),
+			priority: newRecord.priority !== '' ? Number(newRecord.priority) : undefined
+		};
+		try {
+			const res = await fetch(url, {
+				method,
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(payload)
+			});
+			if (!res.ok) {
+				const body: { error?: string } = await res.json().catch(() => ({}));
+				dnsFormError = body.error ?? `Failed to save record (${res.status})`;
+				dnsFormSaving = false;
+				return;
+			}
+			const saved: DnsRecord = await res.json();
+			if (isEditing) {
+				zoneRecords = zoneRecords.map((r) => (r.id === saved.id ? saved : r));
+			} else {
+				zoneRecords = [...zoneRecords, saved];
+			}
+			resetDnsForm();
+		} catch {
+			dnsFormError = 'Network error — could not save record';
+		} finally {
+			dnsFormSaving = false;
+		}
+	}
+
+	async function deleteRecord(id: string): Promise<void> {
+		if (!selectedZone) return;
+		deletingRecordId = id;
+		deleteRecordError = null;
+		try {
+			const res = await fetch(
+				`/api/dns/zones/${encodeURIComponent(selectedZone.name)}/records/${id}`,
+				{ method: 'DELETE' }
+			);
+			if (!res.ok) {
+				const body: { error?: string } = await res.json().catch(() => ({}));
+				deleteRecordError = body.error ?? `Delete failed (${res.status})`;
+				deletingRecordId = null;
+				return;
+			}
+			zoneRecords = zoneRecords.filter((r) => r.id !== id);
+			showDeleteRecordConfirm = null;
+		} catch {
+			deleteRecordError = 'Network error — delete failed';
+			deletingRecordId = null;
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent): void {
+		if (e.key === 'Escape') {
+			showAddDns = false;
+			editingRecord = null;
+			showDeleteZoneConfirm = null;
+			showDeleteRecordConfirm = null;
+			showAddZone = false;
+		}
+	}
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+<div class="dns-page">
+	<header class="page-header">
+		<h1 class="page-title">DNS Management</h1>
+		<p class="page-sub">Manage zones and records on your Technitium DNS server.</p>
+	</header>
+
+	{#if !helpDismissed}
+		<div class="help-banner" class:expanded={helpExpanded}>
+			<div class="help-banner-header">
+				<button class="help-toggle" on:click={() => helpExpanded = !helpExpanded}>
+					<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+					</svg>
+					How to point your domain at HermitHost
+					<svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<polyline points={helpExpanded ? '18 15 12 9 6 15' : '6 9 12 15 18 9'}/>
+					</svg>
+				</button>
+				<div class="help-ns-chip">
+					NS:
+					{#if nsHostname}
+						<span class="ns-value mono">{nsHostname}</span>
+						<button class="copy-btn" on:click={copyNs} title="Copy nameserver address">
+							<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+						</button>
+					{:else}
+						<span class="ns-placeholder mono" title="Set NS_HOSTNAME in your .env to show your server address">&lt;your-server-ip&gt;</span>
+					{/if}
+				</div>
+				<button class="help-dismiss" on:click={dismissHelp} title="Dismiss">
+					<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+				</button>
+			</div>
+
+			{#if helpExpanded}
+				<ol class="help-steps">
+					<li><strong>Create a zone</strong> — click <code>+</code> in the zone list and enter your domain (e.g. <code>mysite.com</code>).</li>
+					<li><strong>Add your DNS records</strong> — at minimum an A record pointing <code>@</code> to your server's IP.</li>
+					<li><strong>Update nameservers at your registrar</strong> — log in to Namecheap, GoDaddy, Cloudflare Registrar, or wherever your domain is registered. Find the Nameservers section and replace the existing entries with your HermitHost server address{nsHostname ? `: ${nsHostname}` : ' (set NS_HOSTNAME in .env)'}.</li>
+					<li><strong>Wait for propagation</strong> — changes typically take effect within an hour, but can take up to 48 hours. Check progress at <a href="https://dnschecker.org" target="_blank" rel="noopener noreferrer">dnschecker.org</a>.</li>
+				</ol>
+			{/if}
+		</div>
+	{/if}
+
+	<div class="dns-layout">
+		<!-- ── Zone list ─────────────────────────────────────────────────────────── -->
+		<aside class="zone-list">
+			<div class="zone-list-header">
+				<span class="zone-list-title">Zones</span>
+				<button class="btn-icon" title="Add zone" on:click={() => { showAddZone = !showAddZone; addZoneError = ''; }}>
+					<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+				</button>
+			</div>
+
+			{#each userZones() as zone (zone.name)}
+				<button
+					class="zone-item"
+					class:active={selectedZone?.name === zone.name}
+					class:disabled-zone={zone.disabled}
+					on:click={() => selectZone(zone)}
+				>
+					<span class="zone-name mono">{zone.name}</span>
+					<span class="zone-type-badge">{zone.type}</span>
+				</button>
+			{/each}
+
+			{#if internalZones().length > 0}
+				<div class="zone-divider">— Internal —</div>
+				{#each internalZones() as zone (zone.name)}
+					<button
+						class="zone-item zone-internal"
+						class:active={selectedZone?.name === zone.name}
+						on:click={() => selectZone(zone)}
+					>
+						<span class="zone-name mono">{zone.name}</span>
+						<span class="zone-type-badge">{zone.type}</span>
+					</button>
+				{/each}
+			{/if}
+
+			{#if zones.length === 0}
+				<div class="zone-empty">No zones yet.</div>
+			{/if}
+
+			<!-- Add zone form -->
+			{#if showAddZone}
+				<form class="add-zone-form" on:submit|preventDefault={createZone}>
+					<input
+						class="input-sm"
+						type="text"
+						placeholder="example.com"
+						bind:value={newZoneName}
+						disabled={addZoneLoading}
+						autocomplete="off"
+					/>
+					{#if addZoneError}
+						<span class="form-error">{addZoneError}</span>
+					{/if}
+					<div class="add-zone-actions">
+						<button class="btn btn-primary btn-sm" type="submit" disabled={addZoneLoading || !newZoneName.trim()}>
+							{addZoneLoading ? 'Creating…' : 'Create'}
+						</button>
+						<button class="btn btn-ghost btn-sm" type="button" on:click={() => { showAddZone = false; newZoneName = ''; addZoneError = ''; }}>
+							Cancel
+						</button>
+					</div>
+				</form>
+			{/if}
+		</aside>
+
+		<!-- ── Records pane ──────────────────────────────────────────────────────── -->
+		<section class="records-pane">
+			{#if !selectedZone}
+				<div class="records-empty-state">
+					<svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.3"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>
+					<p>Select a zone to manage its records.</p>
+				</div>
+			{:else}
+				<!-- Zone header -->
+				<div class="records-header">
+					<div class="records-header-left">
+						<h2 class="records-zone-name mono">{selectedZone.name}</h2>
+						<span class="zone-type-badge">{selectedZone.type}</span>
+						{#if selectedZone.disabled}
+							<span class="badge-disabled">Disabled</span>
+						{/if}
+					</div>
+					<div class="records-header-actions">
+						<button
+							class="btn btn-ghost btn-sm"
+							on:click={() => { showDeleteZoneConfirm = selectedZone && selectedZone.name; }}
+						>
+							Delete zone
+						</button>
+						<button class="btn btn-primary btn-sm" on:click={() => { showAddDns = true; editingRecord = null; resetDnsForm(); showAddDns = true; }}>
+							+ Add record
+						</button>
+					</div>
+				</div>
+
+				<!-- Delete zone confirm -->
+				{#if showDeleteZoneConfirm === selectedZone.name}
+					<div class="confirm-bar">
+						<span>Delete zone <strong class="mono">{selectedZone.name}</strong> and all its records?</span>
+						<button
+							class="btn btn-danger btn-sm"
+							disabled={deletingZone === selectedZone.name}
+							on:click={() => selectedZone && deleteZone(selectedZone.name)}
+						>
+							{deletingZone === selectedZone.name ? 'Deleting…' : 'Delete'}
+						</button>
+						<button class="btn btn-ghost btn-sm" on:click={() => { showDeleteZoneConfirm = null; }}>Cancel</button>
+						{#if deleteZoneError}<span class="form-error">{deleteZoneError}</span>{/if}
+					</div>
+				{/if}
+
+				<!-- Add / edit record form -->
+				{#if showAddDns}
+					<form class="dns-form" on:submit|preventDefault={saveRecord}>
+						<div class="dns-form-row">
+							<div class="form-field">
+								<label class="form-label" for="dns-type">Type</label>
+								<select id="dns-type" class="select-sm" bind:value={newRecord.type} disabled={dnsFormSaving}>
+									{#each ['A','AAAA','CNAME','MX','TXT','NS','SRV','CAA'] as t}
+										<option value={t}>{t}</option>
+									{/each}
+								</select>
+							</div>
+							<div class="form-field form-field-grow">
+								<label class="form-label" for="dns-name">Name</label>
+								<input id="dns-name" class="input-sm mono" type="text" placeholder="@ or subdomain" bind:value={newRecord.name} disabled={dnsFormSaving} />
+							</div>
+							<div class="form-field form-field-grow">
+								<label class="form-label" for="dns-value">Value</label>
+								<input id="dns-value" class="input-sm mono" type="text" placeholder="1.2.3.4" bind:value={newRecord.value} disabled={dnsFormSaving} />
+							</div>
+							<div class="form-field form-field-narrow">
+								<label class="form-label" for="dns-ttl">TTL</label>
+								<input id="dns-ttl" class="input-sm mono" type="number" min="60" bind:value={newRecord.ttl} disabled={dnsFormSaving} />
+							</div>
+							{#if newRecord.type === 'MX' || newRecord.type === 'SRV'}
+								<div class="form-field form-field-narrow">
+									<label class="form-label" for="dns-priority">Priority</label>
+									<input id="dns-priority" class="input-sm mono" type="number" min="0" bind:value={newRecord.priority} disabled={dnsFormSaving} />
+								</div>
+							{/if}
+						</div>
+						{#if dnsFormError}
+							<span class="form-error">{dnsFormError}</span>
+						{/if}
+						<div class="dns-form-actions">
+							<button class="btn btn-primary btn-sm" type="submit" disabled={dnsFormSaving || !newRecord.name || !newRecord.value}>
+								{dnsFormSaving ? 'Saving…' : editingRecord ? 'Update record' : 'Add record'}
+							</button>
+							<button class="btn btn-ghost btn-sm" type="button" on:click={resetDnsForm}>Cancel</button>
+						</div>
+					</form>
+				{/if}
+
+				<!-- Records table -->
+				{#if recordsLoading}
+					<div class="records-loading">Loading records…</div>
+				{:else if recordsError}
+					<div class="records-error">{recordsError}</div>
+				{:else if zoneRecords.length === 0}
+					<div class="records-empty">No records in this zone. Add one above.</div>
+				{:else}
+					<table class="dns-table">
+						<thead>
+							<tr>
+								<th>Type</th>
+								<th>Name</th>
+								<th>Value</th>
+								<th>TTL</th>
+								<th></th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each zoneRecords as record (record.id)}
+								<tr>
+									<td><span class="record-type-badge record-type-{record.type.toLowerCase()}">{record.type}</span></td>
+									<td class="mono">{record.name}</td>
+									<td class="mono value-cell">{record.value}{record.priority !== undefined ? ` (prio ${record.priority})` : ''}</td>
+									<td class="mono muted">{record.ttl}</td>
+									<td class="record-actions">
+										{#if showDeleteRecordConfirm === record.id}
+											<span class="confirm-inline">
+												<button
+													class="btn btn-danger btn-xs"
+													disabled={deletingRecordId === record.id}
+													on:click={() => deleteRecord(record.id)}
+												>
+													{deletingRecordId === record.id ? '…' : 'Delete'}
+												</button>
+												<button class="btn btn-ghost btn-xs" on:click={() => { showDeleteRecordConfirm = null; }}>Cancel</button>
+											</span>
+										{:else}
+											<button class="btn-row-action" on:click={() => startEditRecord(record)}>Edit</button>
+											<button class="btn-row-action btn-row-danger" on:click={() => { showDeleteRecordConfirm = record.id; deleteRecordError = null; }}>Delete</button>
+										{/if}
+									</td>
+								</tr>
+								{#if deleteRecordError && showDeleteRecordConfirm === record.id}
+									<tr class="error-row"><td colspan="5"><span class="form-error">{deleteRecordError}</span></td></tr>
+								{/if}
+							{/each}
+						</tbody>
+					</table>
+				{/if}
+			{/if}
+		</section>
+	</div>
+</div>
+
+<style>
+	.dns-page {
+		padding: 32px 40px;
+		max-width: 1200px;
+	}
+
+	.page-header {
+		margin-bottom: 28px;
+	}
+
+	.page-title {
+		font-size: 20px;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0 0 4px;
+	}
+
+	.page-sub {
+		font-size: 13px;
+		color: var(--text-muted);
+		margin: 0;
+	}
+
+	/* ── Layout ─────────────────────────────────────────────────────────────────── */
+
+	.dns-layout {
+		display: flex;
+		gap: 0;
+		border: 1px solid var(--border);
+		border-radius: 8px;
+		overflow: hidden;
+		min-height: 480px;
+	}
+
+	/* ── Zone list ──────────────────────────────────────────────────────────────── */
+
+	.zone-list {
+		width: 280px;
+		min-width: 280px;
+		border-right: 1px solid var(--border);
+		background: var(--bg-surface);
+		display: flex;
+		flex-direction: column;
+	}
+
+	.zone-list-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 12px 14px 8px;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.zone-list-title {
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-muted);
+	}
+
+	.btn-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 22px;
+		height: 22px;
+		border-radius: 4px;
+		color: var(--text-secondary);
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		transition: background 0.1s, color 0.1s;
+	}
+
+	.btn-icon:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.zone-item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 9px 14px;
+		cursor: pointer;
+		border: none;
+		background: transparent;
+		text-align: left;
+		color: var(--text-secondary);
+		font-size: 13px;
+		transition: background 0.1s, color 0.1s;
+		width: 100%;
+		gap: 8px;
+	}
+
+	.zone-item:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.zone-item.active {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.zone-item.disabled-zone {
+		opacity: 0.5;
+	}
+
+	.zone-item.zone-internal {
+		opacity: 0.55;
+	}
+
+	.zone-name {
+		flex: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: 12.5px;
+	}
+
+	.zone-type-badge {
+		font-size: 10px;
+		font-family: var(--font-mono);
+		background: var(--bg-elevated);
+		color: var(--text-muted);
+		border: 1px solid var(--border);
+		border-radius: 3px;
+		padding: 1px 5px;
+		flex-shrink: 0;
+	}
+
+	.zone-divider {
+		font-size: 10px;
+		color: var(--text-muted);
+		text-align: center;
+		padding: 8px 0 4px;
+		opacity: 0.6;
+	}
+
+	.zone-empty {
+		padding: 20px 14px;
+		font-size: 12px;
+		color: var(--text-muted);
+		text-align: center;
+	}
+
+	/* Add zone form */
+
+	.add-zone-form {
+		padding: 10px 12px;
+		border-top: 1px solid var(--border);
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		margin-top: auto;
+	}
+
+	.add-zone-actions {
+		display: flex;
+		gap: 6px;
+	}
+
+	/* ── Records pane ───────────────────────────────────────────────────────────── */
+
+	.records-pane {
+		flex: 1;
+		min-width: 0;
+		background: var(--bg-base);
+		display: flex;
+		flex-direction: column;
+	}
+
+	.records-empty-state {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 12px;
+		color: var(--text-muted);
+		font-size: 13px;
+	}
+
+	.records-empty-state p { margin: 0; }
+
+	.records-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 14px 20px;
+		border-bottom: 1px solid var(--border);
+		gap: 12px;
+		flex-wrap: wrap;
+	}
+
+	.records-header-left {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+	}
+
+	.records-zone-name {
+		font-size: 15px;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.badge-disabled {
+		font-size: 10px;
+		background: var(--bg-elevated);
+		color: var(--text-muted);
+		border: 1px solid var(--border);
+		border-radius: 3px;
+		padding: 1px 6px;
+	}
+
+	.records-header-actions {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	/* Confirm bar */
+
+	.confirm-bar {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 10px 20px;
+		background: var(--bg-elevated);
+		border-bottom: 1px solid var(--border);
+		font-size: 13px;
+		color: var(--text-primary);
+		flex-wrap: wrap;
+	}
+
+	/* DNS form */
+
+	.dns-form {
+		padding: 14px 20px;
+		border-bottom: 1px solid var(--border);
+		background: var(--bg-surface);
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.dns-form-row {
+		display: flex;
+		gap: 10px;
+		flex-wrap: wrap;
+		align-items: flex-end;
+	}
+
+	.form-field {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.form-field-grow { flex: 1; min-width: 120px; }
+	.form-field-narrow { width: 80px; }
+
+	.form-label {
+		font-size: 11px;
+		color: var(--text-muted);
+		font-weight: 500;
+	}
+
+	.dns-form-actions {
+		display: flex;
+		gap: 8px;
+	}
+
+	/* States */
+
+	.records-loading, .records-error, .records-empty {
+		padding: 40px 20px;
+		font-size: 13px;
+		color: var(--text-muted);
+		text-align: center;
+	}
+
+	.records-error { color: var(--danger, #e05252); }
+
+	/* Table */
+
+	.dns-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 13px;
+	}
+
+	.dns-table thead th {
+		padding: 10px 16px;
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-muted);
+		text-align: left;
+		border-bottom: 1px solid var(--border);
+		background: var(--bg-surface);
+	}
+
+	.dns-table tbody tr {
+		border-bottom: 1px solid var(--border);
+		transition: background 0.1s;
+	}
+
+	.dns-table tbody tr:last-child { border-bottom: none; }
+	.dns-table tbody tr:hover { background: var(--bg-hover); }
+
+	.dns-table td {
+		padding: 10px 16px;
+		color: var(--text-primary);
+		vertical-align: middle;
+	}
+
+	.value-cell {
+		max-width: 280px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.muted { color: var(--text-muted); }
+
+	.record-type-badge {
+		font-size: 10px;
+		font-family: var(--font-mono);
+		font-weight: 600;
+		border-radius: 3px;
+		padding: 2px 6px;
+		background: var(--bg-elevated);
+		color: var(--text-secondary);
+		border: 1px solid var(--border);
+	}
+
+	.record-type-a    { color: #4ade80; border-color: #4ade8044; background: #4ade8012; }
+	.record-type-aaaa { color: #60a5fa; border-color: #60a5fa44; background: #60a5fa12; }
+	.record-type-cname { color: #a78bfa; border-color: #a78bfa44; background: #a78bfa12; }
+	.record-type-mx   { color: #fb923c; border-color: #fb923c44; background: #fb923c12; }
+	.record-type-txt  { color: #facc15; border-color: #facc1544; background: #facc1512; }
+	.record-type-ns   { color: #94a3b8; border-color: #94a3b844; background: #94a3b812; }
+
+	.record-actions {
+		text-align: right;
+		white-space: nowrap;
+	}
+
+	.confirm-inline {
+		display: inline-flex;
+		gap: 6px;
+		align-items: center;
+	}
+
+	.error-row td { padding: 4px 16px 10px; }
+
+	/* Shared small inputs */
+
+	.input-sm {
+		height: 30px;
+		padding: 0 8px;
+		font-size: 12px;
+		background: var(--bg-base);
+		border: 1px solid var(--border);
+		border-radius: 5px;
+		color: var(--text-primary);
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	.input-sm:focus { outline: none; border-color: var(--accent-teal); }
+	.input-sm:disabled { opacity: 0.5; cursor: not-allowed; }
+
+	.select-sm {
+		height: 30px;
+		padding: 0 6px;
+		font-size: 12px;
+		background: var(--bg-base);
+		border: 1px solid var(--border);
+		border-radius: 5px;
+		color: var(--text-primary);
+		width: 100%;
+		cursor: pointer;
+	}
+
+	.select-sm:focus { outline: none; border-color: var(--accent-teal); }
+	.select-sm:disabled { opacity: 0.5; cursor: not-allowed; }
+
+	/* Buttons */
+
+	.btn { display: inline-flex; align-items: center; gap: 6px; border: none; border-radius: 5px; cursor: pointer; font-size: 13px; font-weight: 500; transition: background 0.1s, color 0.1s; }
+	.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+	.btn-sm { height: 30px; padding: 0 12px; font-size: 12px; }
+	.btn-xs { height: 24px; padding: 0 8px; font-size: 11px; }
+
+	.btn-primary { background: var(--accent-teal); color: #fff; }
+	.btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
+
+	.btn-ghost { background: transparent; color: var(--text-secondary); border: 1px solid var(--border); }
+	.btn-ghost:hover:not(:disabled) { background: var(--bg-hover); color: var(--text-primary); }
+
+	.btn-danger { background: var(--danger, #e05252); color: #fff; }
+	.btn-danger:hover:not(:disabled) { filter: brightness(1.1); }
+
+	.btn-row-action {
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 12px;
+		color: var(--text-muted);
+		padding: 2px 6px;
+		border-radius: 3px;
+		transition: color 0.1s, background 0.1s;
+	}
+	.btn-row-action:hover { color: var(--text-primary); background: var(--bg-hover); }
+	.btn-row-danger:hover { color: var(--danger, #e05252); }
+
+	.form-error {
+		font-size: 12px;
+		color: var(--danger, #e05252);
+	}
+
+	.mono { font-family: var(--font-mono); }
+
+	/* ── Help banner ────────────────────────────────────────────────────────────── */
+	.help-banner {
+		border: 1px solid var(--border);
+		border-radius: 8px;
+		background: var(--bg-surface);
+		margin-bottom: 16px;
+		overflow: hidden;
+	}
+
+	.help-banner-header {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 10px 14px;
+	}
+
+	.help-toggle {
+		display: flex;
+		align-items: center;
+		gap: 7px;
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 13px;
+		color: var(--text-secondary);
+		flex: 1;
+		text-align: left;
+	}
+
+	.help-toggle:hover { color: var(--text-primary); }
+	.help-toggle svg:first-child { color: var(--accent-teal); flex-shrink: 0; }
+	.chevron { margin-left: auto; flex-shrink: 0; }
+
+	.help-ns-chip {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-size: 11px;
+		color: var(--text-muted);
+		background: var(--bg-elevated);
+		border: 1px solid var(--border);
+		border-radius: 4px;
+		padding: 3px 8px;
+		white-space: nowrap;
+	}
+
+	.ns-value { color: var(--accent-teal); }
+	.ns-placeholder { color: #f59e0b; }
+
+	.copy-btn {
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--text-muted);
+		display: flex;
+		align-items: center;
+		padding: 0;
+	}
+	.copy-btn:hover { color: var(--text-primary); }
+
+	.help-dismiss {
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--text-muted);
+		display: flex;
+		align-items: center;
+		padding: 2px;
+		border-radius: 3px;
+		flex-shrink: 0;
+	}
+	.help-dismiss:hover { color: var(--text-primary); background: var(--bg-hover); }
+
+	.help-steps {
+		padding: 12px 20px 14px 36px;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		border-top: 1px solid var(--border);
+	}
+
+	.help-steps li {
+		font-size: 13px;
+		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+
+	.help-steps strong { color: var(--text-primary); }
+	.help-steps code {
+		font-family: var(--font-mono);
+		font-size: 12px;
+		background: var(--bg-elevated);
+		border: 1px solid var(--border);
+		border-radius: 3px;
+		padding: 1px 4px;
+	}
+	.help-steps a { color: var(--accent-teal); text-decoration: none; }
+	.help-steps a:hover { text-decoration: underline; }
+</style>

--- a/src/routes/dns/+page.ts
+++ b/src/routes/dns/+page.ts
@@ -1,0 +1,24 @@
+import type { PageLoad } from './$types';
+
+export interface DnsZone {
+  name: string;
+  type: string;
+  disabled: boolean;
+  internal: boolean;
+  dnssecStatus: string;
+}
+
+export interface DnsPageData {
+  zones: DnsZone[];
+  nsHostname: string | null;
+}
+
+export const load: PageLoad = async ({ fetch }): Promise<DnsPageData> => {
+  const [zonesRes, configRes] = await Promise.all([
+    fetch('/api/dns/zones'),
+    fetch('/api/dns/config'),
+  ]);
+  const zones: DnsZone[] = zonesRes.ok ? await zonesRes.json() : [];
+  const config = configRes.ok ? await configRes.json() : {};
+  return { zones, nsHostname: config.nsHostname ?? null };
+};

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -35,10 +35,10 @@
 	}
 
 	// Settings form state
-	let settingsDomain = site.domain;
-	let settingsRepo = site.repository;
-	let settingsServer = site.server;
-	let settingsDesc = site.description;
+	let settingsDomain = data.site.domain;
+	let settingsRepo = data.site.repository;
+	let settingsServer = data.site.server;
+	let settingsDesc = data.site.description;
 
 	$: {
 		// Keep settings fields in sync when site changes (e.g. after refresh)
@@ -118,11 +118,119 @@
 		}
 	}
 	let logModal: Deploy | null = null;
+	let showDeleteSiteConfirm = false;
+	let deleteSiteState: 'idle' | 'deleting' | 'error' = 'idle';
+	let deleteSiteError = '';
+
+	async function deleteSite(): Promise<void> {
+		deleteSiteState = 'deleting';
+		deleteSiteError = '';
+		try {
+			const res = await fetch(`/api/sites/${site.slug}`, { method: 'DELETE' });
+			if (!res.ok) {
+				const body: { error?: string } = await res.json().catch(() => ({}));
+				deleteSiteError = body.error ?? `Delete failed (${res.status})`;
+				deleteSiteState = 'error';
+				return;
+			}
+			window.location.href = '/';
+		} catch {
+			deleteSiteError = 'Network error — could not delete site';
+			deleteSiteState = 'error';
+		}
+	}
+
 	let showDeleteDnsConfirm: string | null = null; // stores the record ID pending confirmation, null when no dialog open
 	let showAddDns = false;
 
 	// New DNS record form state
 	let newRecord = { type: 'A', name: '', value: '', ttl: 3600, priority: '' };
+
+	// DNS add/edit state
+	let editingRecord: DnsRecord | null = null;
+	let dnsFormSaving = false;
+	let dnsFormError = '';
+	let deletingRecordId: string | null = null;
+	let deleteError: string | null = null;
+
+	function resetDnsForm() {
+		newRecord = { type: 'A', name: '', value: '', ttl: 3600, priority: '' };
+		editingRecord = null;
+		dnsFormError = '';
+		showAddDns = false;
+	}
+
+	async function addRecord(): Promise<void> {
+		dnsFormSaving = true;
+		dnsFormError = '';
+		const isEditing = editingRecord !== null;
+		const url = isEditing
+			? `/api/sites/${site.slug}/dns/${editingRecord!.id}`
+			: `/api/sites/${site.slug}/dns`;
+		const method = isEditing ? 'PUT' : 'POST';
+		const payload: Record<string, string | number | undefined> = {
+			type: newRecord.type,
+			name: newRecord.name,
+			value: newRecord.value,
+			ttl: Number(newRecord.ttl),
+			priority: newRecord.priority !== '' ? Number(newRecord.priority) : undefined
+		};
+		try {
+			const res = await fetch(url, {
+				method,
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(payload)
+			});
+			if (!res.ok) {
+				const body: { error?: string } = await res.json().catch(() => ({}));
+				dnsFormError = body.error ?? `Failed to save record (${res.status})`;
+				dnsFormSaving = false;
+				return;
+			}
+			const saved: DnsRecord = await res.json();
+			if (isEditing) {
+				dns = dns.map((r) => (r.id === saved.id ? saved : r));
+			} else {
+				dns = [...dns, saved];
+			}
+			resetDnsForm();
+		} catch {
+			dnsFormError = 'Network error — could not save record';
+		} finally {
+			dnsFormSaving = false;
+		}
+	}
+
+	function startEditRecord(record: DnsRecord): void {
+		editingRecord = record;
+		newRecord = {
+			type: record.type,
+			name: record.name,
+			value: record.value,
+			ttl: record.ttl,
+			priority: record.priority !== undefined ? String(record.priority) : ''
+		};
+		showAddDns = true;
+	}
+
+	async function deleteRecord(id: string): Promise<void> {
+		deletingRecordId = id;
+		deleteError = null;
+		try {
+			const res = await fetch(`/api/sites/${site.slug}/dns/${id}`, { method: 'DELETE' });
+			if (!res.ok) {
+				const body: { error?: string } = await res.json().catch(() => ({}));
+				deleteError = body.error ?? `Delete failed (${res.status})`;
+				deletingRecordId = null;
+				return;
+			}
+			dns = dns.filter((r) => r.id !== id);
+			showDeleteDnsConfirm = null;
+		} catch {
+			deleteError = 'Network error — delete failed';
+			deletingRecordId = null;
+		}
+	}
 
 	function openLog(deploy: Deploy) {
 		logModal = deploy;
@@ -156,7 +264,9 @@
 		if (e.key === 'Escape') {
 			logModal = null;
 			showDeleteDnsConfirm = null;
+			showDeleteSiteConfirm = false;
 			showAddDns = false;
+			editingRecord = null;
 		}
 	}
 </script>
@@ -370,14 +480,18 @@
 					<h2 class="section-title">DNS Records</h2>
 					<p class="section-sub mono">{site.domain}</p>
 				</div>
-				<button class="btn btn-primary btn-sm" on:click={() => showAddDns = !showAddDns}>
+				<button
+					class="btn btn-primary btn-sm"
+					disabled={showAddDns && editingRecord !== null}
+					on:click={() => { if (showAddDns) { resetDnsForm(); } else { showAddDns = true; } }}
+				>
 					{showAddDns ? 'Cancel' : '+ Add Record'}
 				</button>
 			</div>
 
 			{#if showAddDns}
 				<div class="add-record-form">
-					<div class="form-title">New DNS Record</div>
+					<div class="form-title">{editingRecord ? 'Edit Record' : 'New DNS Record'}</div>
 					<div class="form-row">
 						<div class="form-field">
 							<label for="dns-type">Type</label>
@@ -390,6 +504,7 @@
 						<div class="form-field">
 							<label for="dns-name">Name</label>
 							<input id="dns-name" bind:value={newRecord.name} placeholder="@ or subdomain" class="input mono" />
+							<p class="dns-preview mono text-secondary">{newRecord.name === '@' || newRecord.name === '' ? site.domain : `${newRecord.name}.${site.domain}`}</p>
 						</div>
 						<div class="form-field form-field-wide">
 							<label for="dns-value">Value</label>
@@ -407,53 +522,69 @@
 						{/if}
 					</div>
 					<div class="form-actions">
-						<button class="btn btn-primary btn-sm">Save Record</button>
-						<button class="btn btn-ghost btn-sm" on:click={() => showAddDns = false}>Cancel</button>
+						<button class="btn btn-primary btn-sm" disabled={dnsFormSaving} on:click={addRecord}>
+							{dnsFormSaving ? 'Saving…' : editingRecord ? 'Update Record' : 'Save Record'}
+						</button>
+						<button class="btn btn-ghost btn-sm" on:click={resetDnsForm}>Cancel</button>
+						{#if dnsFormError}
+							<span class="text-danger">{dnsFormError}</span>
+						{/if}
 					</div>
 				</div>
 			{/if}
 
-			<div class="table-wrapper">
-				<table class="dns-table">
-					<thead>
-						<tr>
-							<th>Type</th>
-							<th>Name</th>
-							<th>Value</th>
-							<th>TTL</th>
-							<th>Priority</th>
-							<th></th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each dns as record}
+			{#if dns.length === 0 && !showAddDns}
+				<div class="dns-empty">
+					<p class="text-secondary">No DNS records yet.</p>
+					<button class="btn btn-ghost btn-sm" on:click={() => showAddDns = true}>+ Add first record</button>
+				</div>
+			{:else if dns.length > 0}
+				<div class="table-wrapper">
+					<table class="dns-table">
+						<thead>
 							<tr>
-								<td>
-									<span class="dns-type-badge dns-type-{record.type.toLowerCase()}">{record.type}</span>
-								</td>
-								<td class="mono">{record.name}</td>
-								<td class="mono dns-value">{record.value}</td>
-								<td class="mono text-secondary">{record.ttl}</td>
-								<td class="mono text-secondary">{record.priority ?? '—'}</td>
-								<td class="cell-actions">
-									{#if showDeleteDnsConfirm === record.id}
-										<div class="delete-confirm">
-											<span class="text-danger">Delete {record.type} {record.name}?</span>
-											<button class="btn btn-danger btn-xs">Confirm delete</button>
-											<button class="btn btn-ghost btn-xs" on:click={() => showDeleteDnsConfirm = null}>Cancel</button>
-										</div>
-									{:else}
-										<div class="row-actions">
-											<button class="btn btn-ghost btn-xs">Edit</button>
-											<button class="btn btn-ghost btn-xs text-danger" on:click={() => showDeleteDnsConfirm = record.id}>Delete</button>
-										</div>
-									{/if}
-								</td>
+								<th>Type</th>
+								<th>Name</th>
+								<th>Value</th>
+								<th>TTL</th>
+								<th>Priority</th>
+								<th></th>
 							</tr>
-						{/each}
-					</tbody>
-				</table>
-			</div>
+						</thead>
+						<tbody>
+							{#each dns as record}
+								<tr style={deletingRecordId === record.id ? 'opacity: 0.4' : ''}>
+									<td>
+										<span class="dns-type-badge dns-type-{record.type.toLowerCase()}">{record.type}</span>
+									</td>
+									<td class="mono">{record.name}</td>
+									<td class="mono dns-value">{record.value}</td>
+									<td class="mono text-secondary">{record.ttl}</td>
+									<td class="mono text-secondary">{record.priority ?? '—'}</td>
+									<td class="cell-actions">
+										{#if deletingRecordId === record.id}
+											<span class="text-secondary">Deleting…</span>
+										{:else if deleteError && showDeleteDnsConfirm === record.id}
+											<span class="text-danger">{deleteError} <button class="btn btn-ghost btn-xs" on:click={() => deleteRecord(record.id)}>Retry?</button></span>
+										{:else if showDeleteDnsConfirm === record.id}
+											<div class="delete-confirm">
+												<span class="text-danger">Delete {record.type} {record.name}?</span>
+												<button class="btn btn-danger btn-xs" on:click={() => deleteRecord(record.id)}>Confirm delete</button>
+												<button class="btn btn-ghost btn-xs" on:click={() => { showDeleteDnsConfirm = null; deleteError = null; }}>Cancel</button>
+											</div>
+										{:else}
+											<div class="row-actions">
+												<button class="btn btn-ghost btn-xs" on:click={() => startEditRecord(record)}>Edit</button>
+												<button class="btn btn-ghost btn-xs text-danger" on:click={() => { showDeleteDnsConfirm = record.id; deleteError = null; }}>Delete</button>
+											</div>
+										{/if}
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
 		</div>
 	{/if}
 
@@ -465,7 +596,12 @@
 					<h2 class="section-title">Deployments</h2>
 					<p class="section-sub">{deploys.length} deploy{deploys.length !== 1 ? 's' : ''}</p>
 				</div>
-				<button class="btn btn-primary btn-sm">Deploy HEAD</button>
+				<button
+					class="btn btn-primary btn-sm"
+					class:btn-loading={deployState === 'loading'}
+					disabled={deployState === 'loading'}
+					on:click={triggerDeploy}
+				>{deployState === 'loading' ? 'Deploying…' : 'Deploy HEAD'}</button>
 			</div>
 
 			<div class="deploys-list">
@@ -549,7 +685,20 @@
 							<div class="danger-label">Remove site from HermitHost</div>
 							<div class="danger-desc text-secondary">Removes the site from this dashboard. Does not delete files from the server or DNS records.</div>
 						</div>
-						<button class="btn btn-danger-outline">Remove site…</button>
+						{#if !showDeleteSiteConfirm}
+							<button class="btn btn-danger-outline" on:click={() => { showDeleteSiteConfirm = true; deleteSiteError = ''; }}>Remove site…</button>
+						{:else}
+							<div class="delete-site-confirm">
+								<span class="danger-desc">Remove <strong class="mono">{site.domain}</strong>?</span>
+								<button
+									class="btn btn-danger btn-sm"
+									disabled={deleteSiteState === 'deleting'}
+									on:click={deleteSite}
+								>{deleteSiteState === 'deleting' ? 'Removing…' : 'Yes, remove'}</button>
+								<button class="btn btn-ghost btn-sm" on:click={() => { showDeleteSiteConfirm = false; deleteSiteError = ''; }}>Cancel</button>
+								{#if deleteSiteError}<span class="save-feedback save-feedback-error">{deleteSiteError}</span>{/if}
+							</div>
+						{/if}
 					</div>
 				</div>
 			</div>
@@ -1195,6 +1344,13 @@
 		gap: 16px;
 	}
 
+	.delete-site-confirm {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-wrap: wrap;
+	}
+
 	.danger-label {
 		font-size: 13px;
 		font-weight: 500;
@@ -1357,5 +1513,20 @@
 
 	.save-feedback-error {
 		color: var(--danger);
+	}
+
+	/* DNS empty state */
+	.dns-empty {
+		text-align: center;
+		padding: 2rem;
+		border: 1px dashed var(--border);
+		border-radius: 6px;
+	}
+
+	/* DNS domain preview */
+	.dns-preview {
+		font-size: 0.75rem;
+		margin-top: 0.25rem;
+		margin-bottom: 0;
 	}
 </style>

--- a/src/routes/sites/[slug]/+page.ts
+++ b/src/routes/sites/[slug]/+page.ts
@@ -17,15 +17,8 @@ export const load: PageLoad = async ({ fetch, params }) => {
 		fetch(`/api/sites/${params.slug}/deployments`)
 	]);
 
-	if (!dnsRes.ok) {
-		throw new Error(`Failed to load DNS records: ${dnsRes.status}`);
-	}
-	if (!deploysRes.ok) {
-		throw new Error(`Failed to load deployments: ${deploysRes.status}`);
-	}
-
-	const dns: DnsRecord[] = await dnsRes.json();
-	const deploys: Deploy[] = await deploysRes.json();
+	const dns: DnsRecord[] = dnsRes.ok ? await dnsRes.json() : [];
+	const deploys: Deploy[] = deploysRes.ok ? await deploysRes.json() : [];
 
 	return { site, dns, deploys };
 };


### PR DESCRIPTION
- Add DNS auto-provisioning in sites route: creates zone + A record via Technitium when a site is created (non-fatal, logs warnings on skip)
- Link GitHub SSH key to Coolify app via postgres after creation
- Add /dns API route and frontend DNS management page
- Add ssh-bridge Docker service for Coolify Git deployments
- Add postgres-init SQL to ensure root team exists in Coolify DB
- Expand docker-compose with postgres, ssh-bridge, and coolify-setup
- Add coolify-setup.sh and api entrypoint.sh for container init