### PR TITLE
fix(traefik): route user sites correctly + auto-provision on deploy

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -1,5 +1,7 @@
 import { Router, Request, Response } from 'express';
-import { readFileSync } from 'fs';
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
+import * as http from 'http';
+import * as path from 'path';
 import { DnsRecord } from '../types';
 import {
   createCoolifyClient,
@@ -80,6 +82,73 @@ async function linkGithubKey(appUuid: string): Promise<void> {
     console.log(`[github-key] Linked github-deploy key to app ${appUuid}`);
   } catch (err) {
     console.warn(`[github-key] Could not link key to app ${appUuid}:`, (err as Error).message);
+  }
+}
+
+// ── Traefik route provisioning ────────────────────────────────────────────────
+// Queries Docker API for the running Coolify container for a given slug,
+// then writes (or removes) a Traefik conf.d route file so the site domain
+// is proxied to the correct container. Non-fatal.
+const TRAEFIK_CONF_DIR = process.env.TRAEFIK_CONF_DIR ?? '/app/traefik-conf.d';
+
+function dockerGet(path: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(
+      { socketPath: '/var/run/docker.sock', path, headers: { Host: 'localhost' } },
+      (res) => {
+        let body = '';
+        res.on('data', (d: Buffer) => { body += d; });
+        res.on('end', () => {
+          try { resolve(JSON.parse(body)); }
+          catch { reject(new Error(`Docker API parse error: ${body.slice(0, 200)}`)); }
+        });
+      }
+    );
+    req.on('error', reject);
+    req.setTimeout(3000, () => { req.destroy(); reject(new Error('Docker API timeout')); });
+  });
+}
+
+async function provisionTraefikRoute(slug: string, domain: string, port: number | string = 3000): Promise<void> {
+  const confDir = TRAEFIK_CONF_DIR;
+  const filePath = path.join(confDir, `site-${slug}.yml`);
+  try {
+    // Find running container with coolify.name=slug label
+    const filter = encodeURIComponent(JSON.stringify({ label: [`coolify.name=${slug}`] }));
+    const containers = await dockerGet(`/containers/json?filters=${filter}`) as Array<{ Names: string[] }>;
+    if (!containers.length) {
+      console.warn(`[traefik-route] No running container for slug ${slug} — route not written`);
+      return;
+    }
+    const containerName = containers[0].Names[0].replace(/^\//, '');
+    const yml = `http:
+  routers:
+    site-${slug}:
+      rule: "Host(\`${domain}\`)"
+      entryPoints:
+        - http
+        - https
+      service: site-${slug}
+
+  services:
+    site-${slug}:
+      loadBalancer:
+        servers:
+          - url: "http://${containerName}:${port}"
+`;
+    writeFileSync(filePath, yml, 'utf8');
+    console.log(`[traefik-route] Route written for ${domain} → ${containerName}:${port}`);
+  } catch (err) {
+    console.warn(`[traefik-route] Failed to provision route for ${slug}:`, (err as Error).message);
+  }
+}
+
+function removeTraefikRoute(slug: string): void {
+  try {
+    unlinkSync(path.join(TRAEFIK_CONF_DIR, `site-${slug}.yml`));
+    console.log(`[traefik-route] Route removed for slug ${slug}`);
+  } catch {
+    // File may not exist — that's fine
   }
 }
 
@@ -206,6 +275,7 @@ router.post('/', async (req: Request, res: Response) => {
       const refreshed = await client.getApplication(app.uuid).catch(() => null);
       if (refreshed) app = refreshed;
       await provisionDns(resolvedFqdn);
+      // Route file written after first deploy (container doesn't exist yet at creation time)
     }
     res.status(201).json(mapSite(app, []));
   } catch (err) {
@@ -219,6 +289,7 @@ router.delete('/:slug', async (req: Request, res: Response) => {
   try {
     const client = createCoolifyClient()!;
     await client.deleteApplication(req.params.slug);
+    removeTraefikRoute(req.params.slug);
     res.status(204).send();
   } catch (err) {
     console.error(`[coolify] DELETE /applications/${req.params.slug} failed:`, (err as Error).message);
@@ -260,6 +331,9 @@ router.patch('/:slug', async (req: Request, res: Response) => {
     const app = await client.updateApplication(req.params.slug, payload);
     if (payload.domains) {
       await provisionDns(payload.domains);
+      const domain = payload.domains.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+      const port = (app as any).ports_exposes ?? 3000;
+      await provisionTraefikRoute(req.params.slug, domain, port);
     }
     res.status(200).json(mapSite(app, []));
   } catch (err) {
@@ -403,9 +477,35 @@ router.get('/:slug/deployments', async (req: Request, res: Response) => {
 router.post('/:slug/deploy', async (req: Request, res: Response) => {
   try {
     const client = createCoolifyClient()!;
+    const app = await client.getApplication(req.params.slug);
     const result = await client.triggerDeploy(req.params.slug);
     const dep = result.deployments?.[0];
     res.status(202).json({ jobId: dep?.deployment_uuid, message: dep?.message });
+
+    // Async: update Traefik route once the container is running.
+    // Poll up to 3 minutes for the new container to appear.
+    if (app.fqdn) {
+      const domain = app.fqdn.split(',')[0].trim().replace(/^https?:\/\//, '');
+      const port = (app as any).ports_exposes ?? 3000;
+      const slug = req.params.slug;
+      (async () => {
+        const maxAttempts = 18; // 18 × 10s = 3 min
+        for (let i = 0; i < maxAttempts; i++) {
+          await new Promise(r => setTimeout(r, 10_000));
+          try {
+            const filter = encodeURIComponent(JSON.stringify({ label: [`coolify.name=${slug}`] }));
+            const containers = await dockerGet(`/containers/json?filters=${filter}`) as Array<{ Names: string[]; State: string }>;
+            const running = containers.find(c => c.State === 'running');
+            if (running) {
+              await provisionTraefikRoute(slug, domain, port);
+              break;
+            }
+          } catch {
+            // keep polling
+          }
+        }
+      })();
+    }
   } catch (err) {
     console.error(`[coolify] POST /deploy for ${req.params.slug} failed:`, (err as Error).message);
     res.status(502).json({ error: 'Failed to trigger deploy via Coolify' });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,13 +165,13 @@ services:
     restart: unless-stopped
     command:
       - "--api.insecure=true"
-      - "--providers.file.filename=/etc/traefik/routes.yml"
+      - "--providers.file.directory=/etc/traefik/conf.d"
       - "--providers.file.watch=true"
-      - "--entrypoints.web.address=:80"
-      - "--entrypoints.websecure.address=:443"
-      - "--entrypoints.websecure.http.tls.certresolver=letsencrypt"
+      - "--entrypoints.http.address=:80"
+      - "--entrypoints.https.address=:443"
+      - "--entrypoints.https.http.tls.certresolver=letsencrypt"
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
-      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http"
       - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
       - "--certificatesresolvers.letsencrypt.acme.storage=/acme/acme.json"
     ports:
@@ -179,10 +179,11 @@ services:
       - "${TRAEFIK_HTTPS_PORT:-8443}:443"
       - "8081:8080"
     volumes:
-      - ./traefik/routes.yml:/etc/traefik/routes.yml:ro
+      - ./traefik/conf.d:/etc/traefik/conf.d
       - traefik-acme:/acme
     networks:
       - hermithost-net
+      - coolify
 
   # ── SvelteKit Dashboard ────────────────────────────────────────
   frontend:
@@ -249,6 +250,8 @@ services:
 networks:
   hermithost-net:
     driver: bridge
+  coolify:
+    external: true
 
 volumes:
   hermithost-sites:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,6 +169,11 @@ services:
       - "--providers.file.watch=true"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.websecure.http.tls.certresolver=letsencrypt"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/acme/acme.json"
     ports:
       - "${TRAEFIK_HTTP_PORT:-8080}:80"
       - "${TRAEFIK_HTTPS_PORT:-8443}:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,8 +220,11 @@ services:
     volumes:
       - hermithost-sites:/app/sites
       - coolify-api-token:/coolify-api-token:ro
+      - ./traefik/conf.d:/app/traefik-conf.d
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - hermithost-net
+      - coolify
     restart: unless-stopped
     depends_on:
       coolify:

--- a/traefik/conf.d/routes.yml
+++ b/traefik/conf.d/routes.yml
@@ -1,19 +1,22 @@
 http:
   routers:
+    # ── HermitHost Admin UI ───────────────────────────────────────
+    # Fallback: serves admin when no site-specific Host rule matches.
+    # Site routers (higher priority via longer rule) take precedence.
     api:
       rule: "PathPrefix(`/api`)"
       priority: 10
       entryPoints:
-        - web
-        - websecure
+        - http
+        - https
       service: api
 
     frontend:
       rule: "PathPrefix(`/`)"
       priority: 1
       entryPoints:
-        - web
-        - websecure
+        - http
+        - https
       service: frontend
 
   services:

--- a/traefik/conf.d/site-smm1r5ot3dcm5xvz0kgr6eeu.yml
+++ b/traefik/conf.d/site-smm1r5ot3dcm5xvz0kgr6eeu.yml
@@ -1,0 +1,14 @@
+http:
+  routers:
+    site-smm1r5ot3dcm5xvz0kgr6eeu:
+      rule: "Host(`probablyfine.shallowfordroad.com`)"
+      entryPoints:
+        - http
+        - https
+      service: site-smm1r5ot3dcm5xvz0kgr6eeu
+
+  services:
+    site-smm1r5ot3dcm5xvz0kgr6eeu:
+      loadBalancer:
+        servers:
+          - url: "http://smm1r5ot3dcm5xvz0kgr6eeu-041630115142:3000"


### PR DESCRIPTION
## Summary

- Fix HTTPS 404: add Let's Encrypt ACME to Traefik websecure entrypoint
- Fix user sites showing HermitHost admin UI: switch to conf.d directory provider with per-site route files; rename entrypoints to match Coolify label convention (`http`/`https`)
- Root cause of routing failure: `tls: certResolver:` in site router made it TLS-only, HTTP fell through to admin UI fallback
- Auto-provision Traefik route files from API on deploy, domain change, and deletion — queries Docker by `coolify.name` label to get current container name

## Test plan

- [ ] `probablyfine.shallowfordroad.com` serves the Coolify-deployed site, not HermitHost admin
- [ ] HTTP and HTTPS both return 200
- [ ] `/api/sites` returns 200
- [ ] Deploying a new site auto-writes `traefik/conf.d/site-{slug}.yml` within 3 minutes
- [ ] Deleting a site removes the route file
- [ ] Changing a site's domain updates the route file

🤖 Generated with [Claude Code](https://claude.com/claude-code)