### PR TITLE
feat(sites): deploy key viewer with copy + GitHub deep link

### DIFF
--- a/api/src/routes/config.ts
+++ b/api/src/routes/config.ts
@@ -89,12 +89,17 @@ router.put('/', async (req: Request, res: Response) => {
 
 // GET /api/config/deploy-key
 router.get('/deploy-key', (_req: Request, res: Response) => {
-  try {
-    const key = readFileSync('/coolify-api-token/github_deploy.pub', 'utf8').trim();
-    res.json({ public_key: key });
-  } catch {
-    res.status(404).json({ error: 'Deploy key not found' });
+  const candidates = [
+    '/coolify-api-token/github_deploy.pub',
+    '/coolify-keys/github_deploy.pub',
+  ];
+  for (const path of candidates) {
+    try {
+      const key = readFileSync(path, 'utf8').trim();
+      if (key) { res.json({ public_key: key }); return; }
+    } catch { /* try next */ }
   }
+  res.status(404).json({ error: 'Deploy key not found' });
 });
 
 export default router;

--- a/api/src/routes/config.ts
+++ b/api/src/routes/config.ts
@@ -87,4 +87,14 @@ router.put('/', async (req: Request, res: Response) => {
   }
 });
 
+// GET /api/config/deploy-key
+router.get('/deploy-key', (_req: Request, res: Response) => {
+  try {
+    const key = readFileSync('/coolify-api-token/github_deploy.pub', 'utf8').trim();
+    res.json({ public_key: key });
+  } catch {
+    res.status(404).json({ error: 'Deploy key not found' });
+  }
+});
+
 export default router;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -219,6 +219,7 @@ services:
     volumes:
       - hermithost-sites:/app/sites
       - coolify-api-token:/coolify-api-token:ro
+      - coolify-keys:/coolify-keys:ro
       - ./traefik/conf.d:/app/traefik-conf.d
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:

--- a/scripts/coolify-setup.sh
+++ b/scripts/coolify-setup.sh
@@ -105,6 +105,8 @@ fi
 
 GITHUB_PRIV_JSON=$(jq -Rs . < "$GITHUB_KEY_FILE")
 GITHUB_PUB_KEY=$(cat "${GITHUB_KEY_FILE}.pub")
+cp "${GITHUB_KEY_FILE}.pub" /coolify-api-token/github_deploy.pub
+echo "[setup] GitHub public key written to shared volume."
 
 psql -c "DELETE FROM private_keys WHERE name='github-deploy';" > /dev/null 2>&1
 GITHUB_KEY_RESP=$(curl -sf -X POST "$COOLIFY_URL/security/keys" \

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 	import { formatRelativeTime, formatDuration } from '$lib/data';
 	import type { DnsRecord, Deploy, Site } from '$lib/types';
@@ -314,6 +315,52 @@
 			editingRecord = null;
 		}
 	}
+
+	// Deploy key
+	let deployPublicKey = '';
+	let deployKeyCopied = false;
+
+	function parseGithubOwnerRepo(url: string): string | null {
+		if (!url) return null;
+		// SSH: git@github.com:owner/repo.git
+		const sshMatch = url.match(/^git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/);
+		if (sshMatch) return sshMatch[1];
+		// HTTPS: https://github.com/owner/repo[.git]
+		const httpsMatch = url.match(/^https?:\/\/github\.com\/([^/]+\/[^/]+?)(?:\.git)?(?:\/.*)?$/);
+		if (httpsMatch) return httpsMatch[1];
+		return null;
+	}
+
+	async function copyDeployKey(): Promise<void> {
+		if (!deployPublicKey) return;
+		try {
+			await navigator.clipboard.writeText(deployPublicKey);
+			deployKeyCopied = true;
+			setTimeout(() => { deployKeyCopied = false; }, 2000);
+		} catch {
+			// clipboard write failed silently
+		}
+	}
+
+	function openGithubDeployKeys(): void {
+		const ownerRepo = parseGithubOwnerRepo(site.repository);
+		if (!ownerRepo) return;
+		window.open(`https://github.com/${ownerRepo}/settings/keys/new`, '_blank');
+	}
+
+	onMount(async () => {
+		if (data.site.deploy_auth === 'ssh_key') {
+			try {
+				const res = await fetch('/api/config/deploy-key');
+				if (res.ok) {
+					const body: { public_key: string } = await res.json();
+					deployPublicKey = body.public_key;
+				}
+			} catch {
+				// silently fail — key will be empty
+			}
+		}
+	});
 </script>
 
 <svelte:window on:keydown={handleKeydown} />
@@ -770,6 +817,32 @@
 						</div>
 					</div>
 				</div>
+
+				{#if site.deploy_auth === 'ssh_key'}
+				<div class="settings-section">
+					<h2 class="section-title">Deploy Key</h2>
+					<div class="settings-form">
+						<p class="deploy-key-hint text-secondary">Add this public key to your GitHub repository as a deploy key so HermitHost can pull your code.</p>
+						{#if deployPublicKey}
+							<div class="deploy-key-block">
+								<code class="deploy-key-text mono">{deployPublicKey}</code>
+							</div>
+							<div class="form-actions">
+								<button class="btn btn-ghost btn-sm" on:click={copyDeployKey}>
+									{deployKeyCopied ? 'Copied!' : 'Copy'}
+								</button>
+								{#if parseGithubOwnerRepo(site.repository)}
+									<button class="btn btn-primary btn-sm" on:click={openGithubDeployKeys}>
+										Add to GitHub →
+									</button>
+								{/if}
+							</div>
+						{:else}
+							<p class="text-secondary" style="font-size:12px">Loading deploy key…</p>
+						{/if}
+					</div>
+				</div>
+				{/if}
 
 				<div class="settings-section danger-zone">
 					<h2 class="section-title text-danger">Danger Zone</h2>
@@ -1621,5 +1694,27 @@
 		font-size: 0.75rem;
 		margin-top: 0.25rem;
 		margin-bottom: 0;
+	}
+
+	/* Deploy key */
+	.deploy-key-hint {
+		font-size: 12px;
+		margin: 0;
+	}
+
+	.deploy-key-block {
+		background: var(--bg-elevated);
+		border: 1px solid var(--border-bright);
+		border-radius: 5px;
+		padding: 10px 12px;
+		overflow-x: auto;
+	}
+
+	.deploy-key-text {
+		font-size: 11px;
+		color: var(--text-secondary);
+		word-break: break-all;
+		white-space: pre-wrap;
+		display: block;
 	}
 </style>


### PR DESCRIPTION
## Summary

- When a site uses SSH GitHub auth, the Settings tab now shows the ed25519 public key
- One-click copy button copies the key to clipboard with 2s "Copied!" confirmation
- "Add to GitHub →" button opens `https://github.com/{owner}/{repo}/settings/keys/new` in a new tab for semi-automatic key registration
- `coolify-setup.sh` now copies `github_deploy.pub` to the `coolify-api-token` shared volume at startup
- New `GET /api/config/deploy-key` endpoint serves the public key to the frontend

## Test plan

- [ ] Configure a site with `deploy_auth: ssh_key`
- [ ] Open site detail → Settings tab — deploy key section visible
- [ ] Click copy — key lands in clipboard, button shows "Copied!" then resets
- [ ] Click "Add to GitHub →" — opens correct GitHub deploy keys URL in new tab
- [ ] Site with non-SSH auth: deploy key section not rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)