### PR TITLE
fix(ui): parallel probes + consolidate deploy key into auth section

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -103,32 +103,31 @@
 		return { ...site, ...over };
 	}
 
-	onMount(async () => {
+	onMount(() => {
 		const slugs = data.sites.map((s: Site) => s.slug);
-		for (const slug of slugs) {
-			probePending = new Set([...probePending, slug]);
-			try {
-				const res = await fetch(`/api/sites/${slug}`);
-				if (res.ok) {
-					const fresh: Site = await res.json();
-					probeOverrides = {
-						...probeOverrides,
-						[slug]: {
-							http: fresh.http,
-							ssl: fresh.ssl,
-							dns: fresh.dns,
-							overallStatus: fresh.overallStatus
-						}
-					};
-				}
-			} catch {
-				// best-effort probe — leave existing status in place
-			} finally {
-				const next = new Set(probePending);
-				next.delete(slug);
-				probePending = next;
-			}
-		}
+		probePending = new Set(slugs);
+		Promise.allSettled(
+			slugs.map(slug =>
+				Promise.race([
+					fetch(`/api/sites/${slug}`).then(res => res.ok ? res.json() : null),
+					new Promise<null>((_, reject) => setTimeout(() => reject(new Error('timeout')), 5000))
+				])
+				.then((fresh: Site | null) => {
+					if (fresh) {
+						probeOverrides = {
+							...probeOverrides,
+							[slug]: { http: fresh.http, ssl: fresh.ssl, dns: fresh.dns, overallStatus: fresh.overallStatus }
+						};
+					}
+				})
+				.catch(() => { /* best-effort — leave existing status */ })
+				.finally(() => {
+					const next = new Set(probePending);
+					next.delete(slug);
+					probePending = next;
+				})
+			)
+		);
 	});
 
 	function getStatusLabel(site: Site): string {

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -349,16 +349,14 @@
 	}
 
 	onMount(async () => {
-		if (data.site.deploy_auth === 'ssh_key') {
-			try {
-				const res = await fetch('/api/config/deploy-key');
-				if (res.ok) {
-					const body: { public_key: string } = await res.json();
-					deployPublicKey = body.public_key;
-				}
-			} catch {
-				// silently fail — key will be empty
+		try {
+			const res = await fetch('/api/config/deploy-key');
+			if (res.ok) {
+				const body: { public_key: string } = await res.json();
+				deployPublicKey = body.public_key;
 			}
+		} catch {
+			// silently fail — key will be empty
 		}
 	});
 </script>
@@ -795,6 +793,29 @@
 								/>
 							</div>
 						{/if}
+						{#if settingsDeployAuth === 'ssh_key'}
+							<div class="form-field">
+								<label>Deploy Key</label>
+								<p class="deploy-key-hint text-secondary">Add this public key to your GitHub repository as a deploy key so HermitHost can pull your code.</p>
+								{#if deployPublicKey}
+									<div class="deploy-key-block">
+										<code class="deploy-key-text mono">{deployPublicKey}</code>
+									</div>
+									<div class="form-actions" style="margin-top:8px">
+										<button class="btn btn-ghost btn-sm" on:click={copyDeployKey}>
+											{deployKeyCopied ? 'Copied!' : 'Copy Key'}
+										</button>
+										{#if parseGithubOwnerRepo(site.repository)}
+											<button class="btn btn-primary btn-sm" on:click={openGithubDeployKeys}>
+												Add to GitHub →
+											</button>
+										{/if}
+									</div>
+								{:else}
+									<p class="text-secondary" style="font-size:12px">Loading deploy key…</p>
+								{/if}
+							</div>
+						{/if}
 						<div class="form-actions">
 							<button
 								class="btn btn-primary btn-sm"
@@ -817,32 +838,6 @@
 						</div>
 					</div>
 				</div>
-
-				{#if site.deploy_auth === 'ssh_key'}
-				<div class="settings-section">
-					<h2 class="section-title">Deploy Key</h2>
-					<div class="settings-form">
-						<p class="deploy-key-hint text-secondary">Add this public key to your GitHub repository as a deploy key so HermitHost can pull your code.</p>
-						{#if deployPublicKey}
-							<div class="deploy-key-block">
-								<code class="deploy-key-text mono">{deployPublicKey}</code>
-							</div>
-							<div class="form-actions">
-								<button class="btn btn-ghost btn-sm" on:click={copyDeployKey}>
-									{deployKeyCopied ? 'Copied!' : 'Copy'}
-								</button>
-								{#if parseGithubOwnerRepo(site.repository)}
-									<button class="btn btn-primary btn-sm" on:click={openGithubDeployKeys}>
-										Add to GitHub →
-									</button>
-								{/if}
-							</div>
-						{:else}
-							<p class="text-secondary" style="font-size:12px">Loading deploy key…</p>
-						{/if}
-					</div>
-				</div>
-				{/if}
 
 				<div class="settings-section danger-zone">
 					<h2 class="section-title text-danger">Danger Zone</h2>


### PR DESCRIPTION
## Summary

- **Hang fix:** Homepage `onMount` was fetching site probes sequentially in a `for` loop — if any request stalled, the entire UI froze. Replaced with `Promise.allSettled` + 5s per-fetch timeout so all probes run in parallel and a slow/dead site can't block the rest.
- **Deploy key consolidation:** Moved deploy key display out of a separate pane and inline into the Deploy Authentication section. Key + Copy/Add to GitHub buttons appear immediately when "SSH Key" is selected in the dropdown.
- **Always fetch deploy key on mount:** Removed the `deploy_auth === 'ssh_key'` gate on the fetch so the key is ready regardless of current saved state.

## Test plan

- [ ] Homepage with multiple sites — probes run in parallel, UI stays responsive, no hang
- [ ] Site with a stalled/unreachable probe — other sites still resolve within 5s
- [ ] Site detail → Settings → select "SSH Key" — deploy key appears inline with Copy and Add to GitHub buttons
- [ ] Site detail → Settings → select "PAT" — deploy key section hidden, token field shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)