### PR TITLE
fix(api): deploy auth reliability — SSH URL format, PAT persistence, sidecar storage

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -473,7 +473,11 @@ router.patch('/:slug', async (req: Request, res: Response) => {
       const port = (app as any).ports_exposes ?? 3000;
       await provisionTraefikRoute(req.params.slug, domain, port);
     }
-    res.status(200).json(mapSite(app, []));
+    const result = mapSite(app, []);
+    // Override deploy_auth in the response when explicitly switching — the refetch happens before
+    // linkGithubKey/unlinkGithubKey so private_key_uuid hasn't updated in Coolify yet.
+    if (switchingAuth) result.deploy_auth = body.deploy_auth!;
+    res.status(200).json(result);
   } catch (err) {
     console.error(`[coolify] PATCH /applications/${req.params.slug} failed:`, (err as Error).message);
     res.status(502).json({ error: 'Failed to update application via Coolify' });

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -232,6 +232,21 @@ function sshUrlToHttps(url: string): string {
   return url;
 }
 
+// ── HTTPS / short-form → SSH URL conversion ───────────────────────────────────
+// Converts any repo reference to git@github.com:owner/repo.git format.
+// Required when using SSH key auth — Coolify needs the SSH transport URL.
+function httpsToSshUrl(url: string): string {
+  if (/^git@/.test(url)) return url.endsWith('.git') ? url : `${url}.git`;
+  try {
+    const u = new URL(url.startsWith('http') ? url : `https://github.com/${url}`);
+    const path = u.pathname.replace(/^\//, '').replace(/\.git$/, '');
+    return `git@${u.host}:${path}.git`;
+  } catch {
+    // short-form: owner/repo or owner/repo.git
+    return `git@github.com:${url.replace(/\.git$/, '')}.git`;
+  }
+}
+
 // ── Embed PAT into a GitHub HTTPS clone URL ───────────────────────────────────
 // Converts https://github.com/org/repo to https://TOKEN@github.com/org/repo.
 // Handles SSH-format URLs (git@github.com:...) by converting to HTTPS first.
@@ -312,10 +327,10 @@ router.post('/', async (req: Request, res: Response) => {
       project_uuid = created.uuid;
     }
 
-    // Resolve clone URL — embed PAT for pat auth, use raw URL for ssh_key
+    // Resolve clone URL — embed PAT for pat auth, SSH format for ssh_key
     const resolvedRepoUrl = deployAuth === 'pat'
       ? embedPatInRepoUrl(body.git_repository, body.deploy_token!.trim())
-      : body.git_repository;
+      : httpsToSshUrl(body.git_repository);
 
     const payload: CoolifyCreateApplicationPayload = {
       type: deployAuth === 'pat' ? 'public' : 'private',
@@ -449,7 +464,7 @@ router.patch('/:slug', async (req: Request, res: Response) => {
 
       payload.git_repository = (effectiveAuth === 'pat' && effectiveToken)
         ? embedPatInRepoUrl(cleanBase, effectiveToken)
-        : cleanBase;
+        : httpsToSshUrl(cleanBase);
     }
 
     let app = await client.updateApplication(req.params.slug, payload);

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -16,6 +16,43 @@ import { readNsHostname } from './config';
 
 const router = Router();
 
+// ── Deploy auth sidecar ───────────────────────────────────────────────────────
+// Coolify may strip embedded PAT credentials from stored git_repository URLs,
+// making URL-based auth detection unreliable after page refresh.
+// We persist deploy_auth to a small sidecar file so it survives across requests.
+const SITES_DIR = process.env.SITES_DIR ?? '/app/sites';
+
+function readStoredDeployAuth(uuid: string): 'ssh_key' | 'pat' | null {
+  try {
+    const { mkdirSync } = require('fs') as typeof import('fs');
+    mkdirSync(SITES_DIR, { recursive: true });
+    const val = readFileSync(path.join(SITES_DIR, `${uuid}.auth`), 'utf8').trim();
+    if (val === 'pat' || val === 'ssh_key') return val;
+  } catch { /* not stored yet */ }
+  return null;
+}
+
+function writeStoredDeployAuth(uuid: string, auth: 'ssh_key' | 'pat'): void {
+  try {
+    const { mkdirSync } = require('fs') as typeof import('fs');
+    mkdirSync(SITES_DIR, { recursive: true });
+    writeFileSync(path.join(SITES_DIR, `${uuid}.auth`), auth, 'utf8');
+  } catch (err) {
+    console.warn(`[deploy-auth] Could not write auth sidecar for ${uuid}:`, (err as Error).message);
+  }
+}
+
+function mapSiteWithStoredAuth(
+  app: Parameters<typeof mapSite>[0],
+  deployments: Parameters<typeof mapSite>[1],
+  probe?: Parameters<typeof mapSite>[2]
+): ReturnType<typeof mapSite> {
+  const site = mapSite(app, deployments, probe ?? null);
+  const stored = readStoredDeployAuth(app.uuid);
+  if (stored) site.deploy_auth = stored;
+  return site;
+}
+
 // ── DNS auto-provisioning ─────────────────────────────────────────────────────
 // Creates a zone + A record for the given domain pointing at NS_HOSTNAME.
 // Non-fatal: logs warnings but never throws — site ops should not fail due to DNS.
@@ -190,7 +227,7 @@ router.get('/', async (_req: Request, res: Response) => {
     const sites = await Promise.all(
       applications.map(async (app) => {
         const deployments = await client.listDeployments(app.uuid).catch(() => []);
-        return mapSite(app, deployments);
+        return mapSiteWithStoredAuth(app, deployments);
       })
     );
     res.status(200).json(sites);
@@ -216,7 +253,7 @@ router.get('/:slug', async (req: Request, res: Response) => {
         : Promise.resolve(null),
     ]);
 
-    res.status(200).json(mapSite(app, deployments, probe));
+    res.status(200).json(mapSiteWithStoredAuth(app, deployments, probe));
   } catch (err) {
     console.error(`[coolify] GET /applications/${req.params.slug} failed:`, (err as Error).message);
     res.status(502).json({ error: 'Failed to retrieve site from Coolify' });
@@ -368,7 +405,8 @@ router.post('/', async (req: Request, res: Response) => {
       await provisionDns(resolvedFqdn);
       // Route file written after first deploy (container doesn't exist yet at creation time)
     }
-    res.status(201).json(mapSite(app, []));
+    writeStoredDeployAuth(app.uuid, deployAuth);
+    res.status(201).json(mapSiteWithStoredAuth(app, []));
   } catch (err) {
     console.error('[coolify] POST /applications/public failed:', (err as Error).message);
     res.status(502).json({ error: 'Failed to create application via Coolify' });
@@ -488,10 +526,8 @@ router.patch('/:slug', async (req: Request, res: Response) => {
       const port = (app as any).ports_exposes ?? 3000;
       await provisionTraefikRoute(req.params.slug, domain, port);
     }
-    const result = mapSite(app, []);
-    // Override deploy_auth in the response when explicitly switching — the refetch happens before
-    // linkGithubKey/unlinkGithubKey so private_key_uuid hasn't updated in Coolify yet.
-    if (switchingAuth) result.deploy_auth = body.deploy_auth!;
+    if (switchingAuth) writeStoredDeployAuth(req.params.slug, body.deploy_auth!);
+    const result = mapSiteWithStoredAuth(app, []);
     res.status(200).json(result);
   } catch (err) {
     console.error(`[coolify] PATCH /applications/${req.params.slug} failed:`, (err as Error).message);

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -289,15 +289,24 @@ function httpsToSshUrl(url: string): string {
 // Handles SSH-format URLs (git@github.com:...) by converting to HTTPS first.
 // Handles URLs that already have auth embedded (idempotent).
 export function embedPatInRepoUrl(repoUrl: string, token: string): string {
-  // SSH URLs can't carry a PAT — convert to HTTPS first
-  const httpsUrl = /^git@/.test(repoUrl) ? sshUrlToHttps(repoUrl) : repoUrl;
+  // Normalize to a full HTTPS URL first:
+  // 1. SSH → HTTPS
+  // 2. short-form owner/repo[.git] → https://github.com/owner/repo.git
+  // 3. already HTTPS → leave as-is
+  let httpsUrl: string;
+  if (/^git@/.test(repoUrl)) {
+    httpsUrl = sshUrlToHttps(repoUrl);
+  } else if (/^https?:\/\//.test(repoUrl)) {
+    httpsUrl = repoUrl;
+  } else {
+    httpsUrl = `https://github.com/${repoUrl.replace(/\.git$/, '')}.git`;
+  }
   try {
     const url = new URL(httpsUrl);
     url.username = token;
     url.password = '';
     return url.toString();
   } catch {
-    // Fallback: string replacement for bare github.com/org/repo
     return httpsUrl.replace(/^https?:\/\//, `https://${token}@`);
   }
 }

--- a/api/src/services/coolify.ts
+++ b/api/src/services/coolify.ts
@@ -12,6 +12,7 @@ export interface CoolifyApplication {
   build_pack: string;
   created_at: string;
   updated_at: string;
+  private_key_uuid?: string;
 }
 
 export interface CoolifyLogEntry {

--- a/api/src/services/mapper.ts
+++ b/api/src/services/mapper.ts
@@ -139,7 +139,15 @@ export function mapDeploy(
 
 // ── Deploy auth detection ─────────────────────────────────────────────────────
 
-function detectDeployAuth(gitUrl: string): { deployAuth: 'ssh_key' | 'pat'; cleanUrl: string } {
+function detectDeployAuth(
+  gitUrl: string,
+  privateKeyUuid?: string
+): { deployAuth: 'ssh_key' | 'pat'; cleanUrl: string } {
+  // private_key_uuid is the authoritative SSH signal — Coolify strips embedded credentials
+  // from git_repository URLs before returning them, making URL-based detection unreliable.
+  if (privateKeyUuid) {
+    return { deployAuth: 'ssh_key', cleanUrl: gitUrl };
+  }
   try {
     const url = new URL(gitUrl);
     if (url.username) {
@@ -168,7 +176,7 @@ export function mapSite(
   const http: HttpStatus = probe ? probe.http : stubHttpStatus(app.status);
   const ssl: SslStatus = probe ? probe.ssl : stubSslStatus();
   const dns: DnsStatus = probe ? probe.dns : stubDnsStatus();
-  const { deployAuth, cleanUrl } = detectDeployAuth(app.git_repository);
+  const { deployAuth, cleanUrl } = detectDeployAuth(app.git_repository, app.private_key_uuid);
 
   return {
     slug: app.uuid,


### PR DESCRIPTION
## Summary

Three related fixes for deploy authentication reliability:

1. **SSH key auth requires SSH URL format** — Coolify needs `git@github.com:owner/repo.git` to use SSH transport. Was storing HTTPS/short-form URLs, causing `could not read Username` failures. Added `httpsToSshUrl()` applied to all SSH key auth saves.

2. **PAT auth survives page refresh** — Coolify strips embedded PAT credentials from stored `git_repository` URLs before returning them via API. `detectDeployAuth` fell back to `ssh_key`. Fix: persist `deploy_auth` to `/app/sites/{uuid}.auth` sidecar on every create/switch; all `mapSite` calls apply stored value as authoritative override.

3. **Short-form repo URL PAT embedding** — `embedPatInRepoUrl` with `owner/repo` input threw on `new URL()`, fallback regex didn't match, token never embedded. Fix: normalize short-form to `https://github.com/owner/repo.git` before embedding.

4. **`private_key_uuid` as SSH detection signal** — More reliable than URL credential parsing since Coolify controls key linkage state.

## Test plan

- [ ] Create site with SSH key auth → `git_repository` stored as `git@github.com:owner/repo.git` → deploy clones via SSH
- [ ] Switch to PAT, enter token → `git_repository` stored as `https://TOKEN@github.com/owner/repo.git`
- [ ] Refresh page → deploy_auth stays `pat`
- [ ] Switch back to SSH → stays `ssh_key` on refresh
- [ ] Short-form repo (`owner/repo`) with PAT → token embedded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)