### PR TITLE
fix(api): clear source_type when switching to PAT auth

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -137,7 +137,13 @@ export async function unlinkGithubKey(appUuid: string): Promise<void> {
       password: process.env.PGPASSWORD,
     });
     await pg.connect();
-    await pg.query(`UPDATE applications SET private_key_id = NULL WHERE uuid=$1`, [appUuid]);
+    // Clear private_key_id AND source_type — source_type = 'App\Models\GithubApp' causes
+    // Coolify to route clones through GitHub App flow which double-prefixes the URL.
+    // NULL source_type makes Coolify use git_repository directly (PAT embedded in URL).
+    await pg.query(
+      `UPDATE applications SET private_key_id = NULL, source_type = NULL WHERE uuid=$1`,
+      [appUuid]
+    );
     await pg.end();
     console.log(`[github-key] Unlinked github-deploy key from app ${appUuid}`);
   } catch (err) {


### PR DESCRIPTION
## Summary

- `source_type = 'App\Models\GithubApp'` in Coolify caused deploy clones to be routed through GitHub App integration, which double-prefixed the URL: `https://github.com/https://TOKEN@github.com/...` → `Not Found`
- Fix: clear `source_type` alongside `private_key_id` in `unlinkGithubKey()` when switching to PAT so Coolify uses `git_repository` as a plain HTTPS URL with embedded credentials

## Test plan

- [ ] Switch site from SSH key to PAT → deploy clones via `https://TOKEN@github.com/owner/repo` without double-prefix
- [ ] Trigger deploy → succeeds (no `Not Found` error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)