### PR TITLE
fix(api): always provision Traefik route on PATCH

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -537,9 +537,14 @@ router.patch('/:slug', async (req: Request, res: Response) => {
 
     if (payload.domains) {
       await provisionDns(payload.domains);
-      const domain = payload.domains.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+    }
+    // Always attempt Traefik route provision on every PATCH — self-heals sites
+    // whose route file was never written (e.g. all prior deploys failed).
+    // Non-fatal: provisionTraefikRoute logs a warning if no container is running.
+    const currentDomain = app.fqdn ? app.fqdn.split(',')[0].trim().replace(/^https?:\/\//, '').replace(/\/.*$/, '') : '';
+    if (currentDomain) {
       const port = (app as any).ports_exposes ?? 3000;
-      await provisionTraefikRoute(req.params.slug, domain, port);
+      await provisionTraefikRoute(req.params.slug, currentDomain, port);
     }
     if (switchingAuth) writeStoredDeployAuth(req.params.slug, body.deploy_auth!);
     const result = mapSiteWithStoredAuth(app, []);


### PR DESCRIPTION
## Summary
- `provisionTraefikRoute` was only called when `payload.domains` changed — so sites with no domain change (including first-time saves) never got a route file
- Sites that had failed deploys before the route was provisioned fell through to Traefik's fallback router (PathPrefix('/') priority 1) → hermithost UI was served instead
- Fix: always write the Traefik route on every PATCH using the current domain from Coolify

## Root cause
`zine.shallowfordroad.com` had no Traefik route file because all prior deploys failed. Without a route, the fallback router catches all unmatched hosts and serves the hermithost dashboard.

## Test plan
- [ ] PATCH any site on hammer (no domain change) → route file appears in `conf.d/`
- [ ] `zine.shallowfordroad.com` routes to deployed site, not hermithost UI
- [ ] Sites without a domain set: no error, no spurious route file

🤖 Generated with [Claude Code](https://claude.com/claude-code)