### PR TITLE
fix(api): clear source_type and re-apply PAT URL on site creation

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -401,9 +401,16 @@ router.post('/', async (req: Request, res: Response) => {
     let app = await client.createApplication(payload);
 
     // SSH key auth: link the deploy key via DB
-    // PAT auth: token is embedded in the clone URL — no key needed
+    // PAT auth: clear source_type (Coolify defaults to GithubApp) and re-apply PAT URL
     if (deployAuth !== 'pat') {
       await linkGithubKey(app.uuid);
+    } else {
+      // unlinkGithubKey sets source_type = NULL so Coolify uses git_repository directly
+      await unlinkGithubKey(app.uuid);
+      // Re-apply PAT URL after source_type cleared — Coolify may have stripped it
+      await client.updateApplication(app.uuid, { git_repository: resolvedRepoUrl }).catch((e: Error) => {
+        console.warn(`[coolify] PAT url re-patch failed for ${app.uuid}:`, e.message);
+      });
     }
 
     // fqdn is not accepted at creation time — patch it immediately after using 'domains' field


### PR DESCRIPTION
## Summary
- Coolify defaults new apps to `source_type = App\Models\GithubApp`, which causes it to mangle git URLs during deploy — resulting in double-URL failures and credential errors on first deploy for all PAT-authenticated sites
- The PATCH handler already handled this via `unlinkGithubKey()` + re-applying the PAT URL, but the POST (create) handler did not
- Fix: on `deploy_auth=pat` creation, call `unlinkGithubKey()` to set `source_type=NULL`, then re-apply the full `https://TOKEN@github.com/...` URL

## Root cause confirmed on hammer
New site `y9g67rszubpo54dx22yl35lx` had `source_type=App\Models\GithubApp` and bare `git_repository=rdemeritt/probably-fine-publish` after creation, causing: `fatal: could not read Username for 'https://github.com'`

## Test plan
- [ ] Create new site with PAT auth → DB shows `source_type=NULL`, `git_repository=https://TOKEN@github.com/...`
- [ ] First deploy succeeds without credential errors
- [ ] Existing SSH key site creation unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)