### PR TITLE
fix(sites): null source_id in unlinkGithubKey to fix deploy HTTP 500

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -137,11 +137,13 @@ export async function unlinkGithubKey(appUuid: string): Promise<void> {
       password: process.env.PGPASSWORD,
     });
     await pg.connect();
-    // Clear private_key_id AND source_type — source_type = 'App\Models\GithubApp' causes
-    // Coolify to route clones through GitHub App flow which double-prefixes the URL.
-    // NULL source_type makes Coolify use git_repository directly (PAT embedded in URL).
+    // Clear private_key_id, source_type, AND source_id — source_type = 'App\Models\GithubApp'
+    // causes Coolify to route clones through GitHub App flow which double-prefixes the URL.
+    // NULL source_type + NULL source_id required: if source_id is non-null with source_type=NULL,
+    // Coolify's morphTo eager-loads via the parent query builder with a null ownerKey,
+    // generating "WHERE "" = source_id" which is a PostgreSQL syntax error (zero-length identifier).
     await pg.query(
-      `UPDATE applications SET private_key_id = NULL, source_type = NULL WHERE uuid=$1`,
+      `UPDATE applications SET private_key_id = NULL, source_type = NULL, source_id = NULL WHERE uuid=$1`,
       [appUuid]
     );
     await pg.end();


### PR DESCRIPTION
## Root Cause

After `unlinkGithubKey`, `source_type = NULL` but `source_id = 0` (left from Coolify's creation). When `ApplicationDeploymentJob` constructs and calls `data_get($application, 'source')`, Laravel's `morphTo()` sees `source_type = NULL` and takes the **eager-loading path** (`morphEagerTo`), which passes `ownerKey = null` to `BelongsTo`.

`BelongsTo::addConstraints()` calls `qualifyColumn(null)` → produces `"applications."` → PostgreSQL rejects as zero-length delimited identifier → HTTP 500 on every deploy.

## Fix

Also set `source_id = NULL` in the `unlinkGithubKey` DB update. With both `source_type = NULL` and `source_id = NULL`, `BelongsTo::getResults()` sees `is_null(foreignKeyValue) = true` and returns early without executing any query.

## Trace

```
ApplicationDeploymentJob.php:217  data_get($application, 'source')
  → morphTo() → morphEagerTo() [source_type is null/empty]
  → MorphTo/BelongsTo::addConstraints()
  → qualifyColumn(null) → "applications."
  → SQL: WHERE "" = 0  ← SQLSTATE[42601] zero-length identifier
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)