### PR TITLE
fix(ssh-bridge): add git, jq, docker-compose for Coolify ValidateServer

### DIFF
--- a/docker/ssh-bridge/Dockerfile
+++ b/docker/ssh-bridge/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.20
-RUN apk add --no-cache openssh docker-cli bash curl sudo
+RUN apk add --no-cache openssh docker-cli docker-cli-compose bash curl sudo git jq
 RUN adduser -D -s /bin/bash deploy && \
     passwd -d deploy && \
     mkdir -p /home/deploy/.ssh && chmod 700 /home/deploy/.ssh && \


### PR DESCRIPTION
## Problem

Coolify's `ValidateServer` job SSHs into the server and checks for `git` and `jq`. The ssh-bridge only had `openssh docker-cli bash curl sudo` — missing both prerequisites. ValidateServer would fail immediately, marking the server unreachable and blocking all deploys.

## Fix

- Added `git` — required by ValidateServer prerequisites check
- Added `jq` — required by ValidateServer prerequisites check  
- Added `docker-cli-compose` — enables `docker compose` subcommand over SSH bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)