### PR TITLE
fix(dns): resolve container ID leakage in NS/SOA records and add glue record provisioning

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -41,6 +41,9 @@ DNS_PORT=5353
 # Public IP or hostname of this server (shown in DNS setup guides)
 # Prompted by setup.sh if not set.
 NS_HOSTNAME=
+# Public IPv4 of this server — used for DNS glue records (A record for ns1.<zone>).
+# Auto-detected by scripts/setup.sh and coolify-server-setup at boot.
+NS_SERVER_IP=
 
 # ── Traefik ───────────────────────────────────────────────────────
 TRAEFIK_HTTP_PORT=8080

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -6,4 +6,7 @@ fi
 if [ -f "/coolify-api-token/technitium_token" ]; then
   export TECHNITIUM_TOKEN="$(cat /coolify-api-token/technitium_token)"
 fi
+if [ -f "/coolify-api-token/ns_server_ip" ]; then
+  export NS_SERVER_IP="$(cat /coolify-api-token/ns_server_ip)"
+fi
 exec node dist/index.js

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,6 +7,9 @@ import dnsRouter from './routes/dns';
 import backupRouter from './routes/backup';
 import configRouter from './routes/config';
 import { getDeployedSite } from './services/githubDeploy';
+import { readNsHostname, readNsServerIp } from './routes/config';
+import { createTechnitiumClient } from './services/technitium';
+import { ensureNsGlueRecords, cleanBadNsRecords } from './routes/sites';
 
 const app = express();
 const PORT = process.env.PORT ?? 3001;
@@ -59,6 +62,30 @@ app.listen(PORT, () => {
   } else {
     console.warn('[technitium] TECHNITIUM_URL not set — DNS routes will fail at startup');
   }
+
+  // Non-blocking DNS startup fixup — sets dnsServerDomain, creates glue records,
+  // and removes stale container-ID NS records left from unconfigured Technitium.
+  (async () => {
+    const nsHostname = readNsHostname();
+    const serverIp = readNsServerIp();
+    const client = createTechnitiumClient();
+    if (!client || !nsHostname) {
+      console.warn('[dns-init] Skipping: Technitium or NS_HOSTNAME not configured');
+      return;
+    }
+    try {
+      await client.setDnsServerDomain(nsHostname);
+      console.log(`[dns-init] dnsServerDomain → ${nsHostname}`);
+    } catch (err) {
+      console.warn('[dns-init] setDnsServerDomain failed:', (err as Error).message);
+    }
+    if (serverIp) {
+      await ensureNsGlueRecords(client, nsHostname, serverIp);
+    } else {
+      console.warn('[dns-init] NS_SERVER_IP not set — skipping glue record provisioning');
+    }
+    await cleanBadNsRecords(client);
+  })();
 });
 
 export default app;

--- a/api/src/routes/config.ts
+++ b/api/src/routes/config.ts
@@ -19,6 +19,20 @@ export function readNsHostname(): string | null {
   return process.env.NS_HOSTNAME ?? null;
 }
 
+const NS_SERVER_IP_FILE = '/coolify-api-token/ns_server_ip';
+
+// NS_SERVER_IP read precedence:
+// 1. File /coolify-api-token/ns_server_ip (written by coolify-server-setup)
+// 2. process.env.NS_SERVER_IP
+// 3. null
+export function readNsServerIp(): string | null {
+  try {
+    const val = readFileSync(NS_SERVER_IP_FILE, 'utf8').trim();
+    if (val) return val;
+  } catch { /* file not present */ }
+  return process.env.NS_SERVER_IP ?? null;
+}
+
 type IntegrationStatus = 'connected' | 'error' | 'not_configured';
 
 async function getCoolifyStatus(): Promise<IntegrationStatus> {
@@ -80,6 +94,13 @@ router.put('/', async (req: Request, res: Response) => {
     // Ensure directory exists (best-effort — directory is normally created by init container)
     try { mkdirSync('/coolify-api-token', { recursive: true }); } catch { /* ok */ }
     writeFileSync(NS_HOSTNAME_FILE, value, 'utf8');
+    // Sync new hostname to Technitium immediately — non-fatal
+    const client = createTechnitiumClient();
+    if (client) {
+      client.setDnsServerDomain(value).catch((e: Error) =>
+        console.warn('[config] setDnsServerDomain after PUT failed:', e.message)
+      );
+    }
     res.status(200).json({ ns_hostname: value });
   } catch (err) {
     console.error('[config] PUT write ns_hostname failed:', (err as Error).message);

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -12,7 +12,8 @@ import { mapSite, mapDeploy } from '../services/mapper';
 import { probeSite } from '../services/healthProbe';
 import { createDnsProvider, DnsOperationError } from '../services/dns';
 import { createTechnitiumClient } from '../services/technitium';
-import { readNsHostname } from './config';
+import { readNsHostname, readNsServerIp } from './config';
+import { TechnitiumClient } from '../services/technitium';
 
 const router = Router();
 
@@ -54,12 +55,12 @@ function mapSiteWithStoredAuth(
 }
 
 // ── DNS auto-provisioning ─────────────────────────────────────────────────────
-// Creates a zone + A record for the given domain pointing at NS_HOSTNAME.
+// Creates a zone + A record for the given domain pointing at NS_SERVER_IP.
 // Non-fatal: logs warnings but never throws — site ops should not fail due to DNS.
 export async function provisionDns(fqdn: string): Promise<void> {
-  const serverIp = readNsHostname();
+  const serverIp = readNsServerIp();
   if (!serverIp) {
-    console.warn('[dns-provision] NS_HOSTNAME not set — skipping DNS provisioning');
+    console.warn('[dns-provision] NS_SERVER_IP not set — skipping DNS provisioning');
     return;
   }
   // Strip protocol and trailing slashes to get bare domain
@@ -92,6 +93,64 @@ export async function provisionDns(fqdn: string): Promise<void> {
     console.log(`[dns-provision] A record created: ${domain} @ → ${serverIp}`);
   } catch (err) {
     console.warn(`[dns-provision] A record create warning for ${domain}:`, (err as Error).message);
+  }
+}
+
+// ── DNS glue record provisioning ─────────────────────────────────────────────
+// Creates A record: nsHostname → serverIp in the parent zone.
+// e.g. ns1.example.com → 1.2.3.4 in the example.com zone.
+export async function ensureNsGlueRecords(
+  client: TechnitiumClient,
+  nsHostname: string,
+  serverIp: string
+): Promise<void> {
+  try {
+    const parts = nsHostname.split('.');
+    if (parts.length < 2) return;
+    const zone = parts.slice(1).join('.');
+    try {
+      await client.createZone(zone, 'Primary');
+    } catch (err) {
+      const msg = (err as Error).message ?? '';
+      if (!msg.toLowerCase().includes('already exists')) {
+        console.warn(`[dns-init] Zone create warning for ${zone}:`, msg);
+      }
+    }
+    const params = new URLSearchParams();
+    params.set('type', 'A');
+    params.set('ipAddress', serverIp);
+    params.set('ttl', '3600');
+    await client.addRecord(nsHostname, params);
+    console.log(`[dns-init] Glue A record: ${nsHostname} → ${serverIp}`);
+  } catch (err) {
+    console.warn('[dns-init] ensureNsGlueRecords failed:', (err as Error).message);
+  }
+}
+
+// ── Bad NS record cleanup ─────────────────────────────────────────────────────
+// Removes NS records whose value is a bare label (no dots) — Docker container IDs
+// leaked into zones when Technitium dnsServerDomain was not configured.
+export async function cleanBadNsRecords(client: TechnitiumClient): Promise<void> {
+  try {
+    const zones = await client.listZones();
+    for (const zone of zones) {
+      if (zone.internal || zone.type !== 'Primary') continue;
+      const { records } = await client.getRecords(zone.name);
+      for (const rec of records) {
+        if (rec.type !== 'NS') continue;
+        const ns: string = (rec.rData as { nameServer?: string }).nameServer ?? '';
+        const bare = ns.replace(/\.$/, '');
+        if (!bare.includes('.')) {
+          const params = new URLSearchParams();
+          params.set('type', 'NS');
+          params.set('nameServer', ns);
+          await client.deleteRecord(zone.name, params);
+          console.log(`[dns-init] Removed bad NS record: ${zone.name} NS ${ns}`);
+        }
+      }
+    }
+  } catch (err) {
+    console.warn('[dns-init] cleanBadNsRecords failed:', (err as Error).message);
   }
 }
 

--- a/api/src/services/technitium.ts
+++ b/api/src/services/technitium.ts
@@ -210,6 +210,14 @@ export class TechnitiumClient {
       await handleResponse<TechnitiumDeleteResponse>(res, 'POST /api/zones/records/delete');
     });
   }
+
+  async setDnsServerDomain(domain: string): Promise<void> {
+    return this.withTokenRetry(async () => {
+      const body = this.buildParams({ dnsServerDomain: domain });
+      const res = await fetch(`${this.baseUrl}/api/settings/set`, { method: 'POST', headers: this.postHeaders, body });
+      await handleResponse<TechnitiumDeleteResponse>(res, 'POST /api/settings/set');
+    });
+  }
 }
 
 export function createTechnitiumClient(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,6 +211,7 @@ services:
       TECHNITIUM_TOKEN: "${TECHNITIUM_TOKEN:-}"
       DNS_MOCK: "${DNS_MOCK:-}"
       NS_HOSTNAME: "${NS_HOSTNAME:-}"
+      NS_SERVER_IP: "${NS_SERVER_IP:-}"
       PGHOST: "coolify-db"
       PGPORT: "5432"
       PGDATABASE: "coolify"

--- a/scripts/coolify-setup.sh
+++ b/scripts/coolify-setup.sh
@@ -95,6 +95,17 @@ else
   echo "[setup] WARNING: Could not obtain Technitium token — DNS integration will be limited."
 fi
 
+# ── NS_SERVER_IP — public IP for DNS glue records ────────────────────────────
+echo "[setup] Detecting public IP for DNS glue records..."
+PUBLIC_IP=$(curl -sf --max-time 5 https://ifconfig.me 2>/dev/null || \
+            curl -sf --max-time 5 https://api.ipify.org 2>/dev/null || echo "")
+if [ -n "$PUBLIC_IP" ]; then
+  printf '%s' "$PUBLIC_IP" > /coolify-api-token/ns_server_ip
+  echo "[setup] NS_SERVER_IP written: $PUBLIC_IP"
+else
+  echo "[setup] WARNING: Could not auto-detect public IP — DNS glue records will be skipped at API startup"
+fi
+
 # ── 3. Provision GitHub deploy key (always — DB is reset on each boot) ───────
 GITHUB_KEY_FILE="/coolify-keys/github_deploy"
 if [ ! -f "$GITHUB_KEY_FILE" ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,6 +60,16 @@ echo ""
 echo "[setup] Checking required configuration..."
 prompt_if_empty "ACME_EMAIL"   "Email for Let's Encrypt SSL certificates (e.g. you@example.com)"
 prompt_if_empty "NS_HOSTNAME"  "Public IP or hostname of this server (e.g. 192.168.2.56 or ns1.example.com)"
+# Auto-detect public IP for NS_SERVER_IP; fall back to prompt if unavailable
+if grep -qE "^NS_SERVER_IP=\s*$" "$ENV_FILE" 2>/dev/null; then
+  AUTO_IP=$(curl -sf --max-time 5 https://ifconfig.me 2>/dev/null || echo "")
+  if [ -n "$AUTO_IP" ]; then
+    sed -i '' "s|^NS_SERVER_IP=.*|NS_SERVER_IP=${AUTO_IP}|" "$ENV_FILE"
+    echo "[setup] Auto-detected NS_SERVER_IP: ${AUTO_IP}"
+  else
+    prompt_if_empty "NS_SERVER_IP" "Public IPv4 of this server for DNS glue records (e.g. 203.0.113.1)"
+  fi
+fi
 
 # ── Coolify admin defaults ────────────────────────────────────────────────────
 # Email defaults to ACME_EMAIL (a real, validated address — required for Coolify's RFC+DNS email check).


### PR DESCRIPTION
## Summary

- Technitium was using Docker container hostnames as SOA MNAME and zone NS records because `dnsServerDomain` was never configured — fixed by calling `setDnsServerDomain(NS_HOSTNAME)` at API startup and on config update
- `provisionDns` was passing `NS_HOSTNAME` (a FQDN) as the A record `ipAddress` value — fixed by introducing `NS_SERVER_IP` (auto-detected at boot) as the dedicated IP for A records
- Stale container-ID NS entries are swept from all zones on startup via `cleanBadNsRecords()`

## Test plan

- [ ] Deploy stack with `NS_HOSTNAME=ns1.<zone>` and verify `NS_SERVER_IP` is auto-detected in `coolify-server-setup` logs
- [ ] Confirm API logs show `[dns-init] dnsServerDomain → ns1.<zone>` at startup
- [ ] `dig <zone> SOA +short` — MNAME should be `ns1.<zone>`, not a container ID
- [ ] `dig ns1.<zone> A +short` — should return server public IP
- [ ] `dig <zone> NS +short` — no bare container-ID entries
- [ ] `dig <subdomain>.<zone> A +short` — should resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)