### PR TITLE
fix(docker): set explicit name: coolify on network to prevent hermithost_ prefix mismatch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,6 +255,7 @@ networks:
   hermithost-net:
     driver: bridge
   coolify:
+    name: coolify
     driver: bridge
 
 volumes:


### PR DESCRIPTION
## Summary
- Docker Compose was prefixing the `coolify` network with the project name, creating `hermithost_coolify` instead of `coolify`
- Traefik was attached to `hermithost_coolify` and could not reach containers deployed by Coolify, which uses a standalone network named `coolify`
- Adding `name: coolify` to the network definition forces the exact name Coolify expects, aligning Traefik and deployed containers on the same network after next stack restart

## Change
One line added to the `coolify` network block in `docker-compose.yml`:
\`\`\`yaml
  coolify:
    name: coolify
    driver: bridge
\`\`\`

## Test plan
- [ ] Restart the stack: `docker compose down && docker compose up -d`
- [ ] Confirm `docker network ls` shows `coolify` (not `hermithost_coolify`)
- [ ] Deploy a test app via Coolify and confirm Traefik routes to it successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)