### PR TITLE
feat: full DNS record type support, restore overwrite, and deploy fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20-alpine AS builder
 
+RUN apk add --no-cache git
+
 WORKDIR /app
 
 COPY package.json ./

--- a/api/src/services/backup.ts
+++ b/api/src/services/backup.ts
@@ -369,17 +369,23 @@ export async function importBackup(data: BackupFile): Promise<ImportResult> {
             await technitium.updateRecord(zone.name, params);
             result.dns.created.push(`${zone.name} ${record.type} ${record.name}`);
           } else {
-            let skipped = false;
+            let alreadyExists = false;
             await technitium.addRecord(zone.name, params).catch((err: Error) => {
               const msg = err.message.toLowerCase();
               if (msg.includes('already exists') || msg.includes('duplicate')) {
-                skipped = true;
+                alreadyExists = true;
               } else {
                 throw err;
               }
             });
-            if (skipped) {
-              result.dns.skipped.push(`${zone.name} ${record.type} ${record.name}: already exists`);
+            if (alreadyExists) {
+              try {
+                await technitium.deleteRecord(zone.name, params);
+                await technitium.addRecord(zone.name, params);
+                result.dns.created.push(`${zone.name} ${record.type} ${record.name} [replaced]`);
+              } catch (replaceErr) {
+                result.dns.failed.push(`${zone.name} ${record.type} ${record.name}: replace failed — ${(replaceErr as Error).message}`);
+              }
             } else {
               result.dns.created.push(`${zone.name} ${record.type} ${record.name}`);
             }

--- a/api/src/services/technitium.ts
+++ b/api/src/services/technitium.ts
@@ -29,6 +29,20 @@ export interface TechnitiumRData {
   weight?: number;
   port?: number;
   target?: string;
+  // SOA
+  primaryNameServer?: string;
+  responsiblePerson?: string;
+  serial?: number;
+  refresh?: number;
+  retry?: number;
+  expire?: number;
+  minimum?: number;
+  // CAA
+  tag?: string;
+  flags?: number;
+  value?: string;
+  // PTR
+  ptrdname?: string;
 }
 
 export interface TechnitiumRecord {

--- a/api/src/services/technitiumMapper.ts
+++ b/api/src/services/technitiumMapper.ts
@@ -57,6 +57,12 @@ function extractValue(raw: TechnitiumRecord): string {
       return r.nameServer ?? '';
     case 'SRV':
       return r.target ?? '';
+    case 'SOA':
+      return r.primaryNameServer ?? '';
+    case 'CAA':
+      return r.value ?? `${r.flags ?? 0} ${r.tag ?? ''} ""`;
+    case 'PTR':
+      return r.ptrdname ?? '';
     default:
       return '';
   }
@@ -65,7 +71,7 @@ function extractValue(raw: TechnitiumRecord): string {
 // ── Supported record type guard ───────────────────────────────────────────────
 
 const SUPPORTED_TYPES: ReadonlySet<string> = new Set([
-  'A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'SRV',
+  'A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'SRV', 'SOA', 'CAA', 'PTR',
 ]);
 
 function isSupportedType(type: string): type is DnsRecordType {
@@ -73,13 +79,9 @@ function isSupportedType(type: string): type is DnsRecordType {
 }
 
 // ── Filter predicate ──────────────────────────────────────────────────────────
-// Filter out: disabled records, SOA records, internal NS records (apex NS = zone's own NS)
 
 export function shouldIncludeRecord(raw: TechnitiumRecord, zoneName: string): boolean {
   if (raw.disabled) return false;
-  if (raw.type === 'SOA') return false;
-  // Internal apex NS records (zone's own authority NS records)
-  if (raw.type === 'NS' && raw.name === zoneName) return false;
   if (!isSupportedType(raw.type)) return false;
   return true;
 }
@@ -146,6 +148,14 @@ export function buildAddParams(domain: string, record: DnsRecord): URLSearchPara
       params.set('priority', String(record.priority ?? 0));
       params.set('weight', '0');
       params.set('port', '0');
+      break;
+    case 'CAA':
+      params.set('flags', String(record.priority ?? 0));
+      params.set('tag', 'issue');  // default tag; value contains the actual issuer
+      params.set('value', record.value);
+      break;
+    case 'PTR':
+      params.set('ptrdname', record.value);
       break;
   }
 
@@ -227,6 +237,14 @@ export function buildDeleteParams(domain: string, record: DnsRecord): URLSearchP
     case 'SRV':
       params.set('target', record.value);
       params.set('priority', String(record.priority ?? 0));
+      break;
+    case 'CAA':
+      params.set('flags', String(record.priority ?? 0));
+      params.set('tag', 'issue');
+      params.set('value', record.value);
+      break;
+    case 'PTR':
+      params.set('ptrdname', record.value);
       break;
   }
 

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -3,7 +3,7 @@
 
 export type SiteStatus = 'healthy' | 'warning' | 'error' | 'pending';
 export type DeployStatus = 'success' | 'failed' | 'running' | 'pending';
-export type DnsRecordType = 'A' | 'AAAA' | 'CNAME' | 'MX' | 'TXT' | 'NS' | 'SRV' | 'CAA';
+export type DnsRecordType = 'A' | 'AAAA' | 'CNAME' | 'MX' | 'TXT' | 'NS' | 'SRV' | 'CAA' | 'SOA' | 'PTR';
 
 export interface HttpStatus {
   reachable: boolean;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,8 +255,7 @@ networks:
   hermithost-net:
     driver: bridge
   coolify:
-    name: coolify
-    driver: bridge
+    external: true
 
 volumes:
   hermithost-sites:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,7 +255,6 @@ networks:
   hermithost-net:
     driver: bridge
   coolify:
-    external: true
 
 volumes:
   hermithost-sites:

--- a/scripts/coolify-setup.sh
+++ b/scripts/coolify-setup.sh
@@ -156,7 +156,7 @@ fi
 echo "[setup] Updating server IP to ssh-bridge..."
 curl -sf -X PATCH "$COOLIFY_URL/servers/$SERVER_UUID" \
   -H "$(auth_header)" -H "Content-Type: application/json" \
-  -d '{"ip":"ssh-bridge","port":22,"user":"deploy"}' > /dev/null
+  -d '{"ip":"ssh-bridge","port":22,"user":"deploy"}' > /dev/null || true
 echo "[setup] Server IP updated."
 
 # ── 4. Register private key with Coolify ─────────────────────────────────────
@@ -166,7 +166,7 @@ PRIV_JSON=$(jq -Rs . < "$KEY_FILE")
 KEY_RESP=$(curl -sf -X POST "$COOLIFY_URL/security/keys" \
   -H "$(auth_header)" \
   -H "Content-Type: application/json" \
-  -d "{\"name\":\"hermithost-deploy\",\"private_key\":$PRIV_JSON}")
+  -d "{\"name\":\"hermithost-deploy\",\"private_key\":$PRIV_JSON}" || echo "")
 
 KEY_UUID=$(echo "$KEY_RESP" | jq -r '.uuid // empty')
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,6 @@
 export type SiteStatus = 'healthy' | 'warning' | 'error' | 'pending';
 export type DeployStatus = 'success' | 'failed' | 'running' | 'pending';
-export type DnsRecordType = 'A' | 'AAAA' | 'CNAME' | 'MX' | 'TXT' | 'NS' | 'SRV' | 'CAA';
+export type DnsRecordType = 'A' | 'AAAA' | 'CNAME' | 'MX' | 'TXT' | 'NS' | 'SRV' | 'SOA' | 'CAA' | 'PTR';
 
 export interface HttpStatus {
 	reachable: boolean;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import '../app.css';
 	import { page } from '$app/stores';
+	declare const __GIT_COMMIT__: string;
 </script>
 
 <div class="app-shell">
@@ -10,7 +11,7 @@
 				<span class="logo-icon">⬡</span>
 				<span class="logo-text">HermitHost</span>
 			</div>
-			<div class="logo-sub">v0.1.0</div>
+			<div class="logo-sub">v0.1.0 <span class="logo-commit">· {__GIT_COMMIT__}</span></div>
 		</div>
 
 		<div class="nav-section">
@@ -113,6 +114,11 @@
 		font-size: 10px;
 		color: var(--text-muted);
 		margin-left: 26px;
+	}
+	.logo-commit {
+		opacity: 0.5;
+		font-size: 0.85em;
+		letter-spacing: 0.03em;
 	}
 
 	.nav-section {

--- a/src/routes/dns/+page.svelte
+++ b/src/routes/dns/+page.svelte
@@ -123,7 +123,7 @@
 				deletingZone = null;
 				return;
 			}
-			zones = zones.filter((z) => z.name !== name);
+			zones = [...zones.filter((z) => z.name !== name)];
 			if (selectedZone?.name === name) {
 				selectedZone = null;
 				zoneRecords = [];
@@ -399,7 +399,7 @@
 							<div class="form-field">
 								<label class="form-label" for="dns-type">Type</label>
 								<select id="dns-type" class="select-sm" bind:value={newRecord.type} disabled={dnsFormSaving}>
-									{#each ['A','AAAA','CNAME','MX','TXT','NS','SRV','CAA'] as t}
+									{#each ['A','AAAA','CNAME','MX','TXT','NS','SRV','SOA','CAA','PTR'] as t}
 										<option value={t}>{t}</option>
 									{/each}
 								</select>
@@ -838,6 +838,10 @@
 	.record-type-mx   { color: #fb923c; border-color: #fb923c44; background: #fb923c12; }
 	.record-type-txt  { color: #facc15; border-color: #facc1544; background: #facc1512; }
 	.record-type-ns   { color: #94a3b8; border-color: #94a3b844; background: #94a3b812; }
+	.record-type-srv  { color: #f472b6; border-color: #f472b644; background: #f472b612; }
+	.record-type-soa  { color: #c084fc; border-color: #c084fc44; background: #c084fc12; }
+	.record-type-caa  { color: #fb923c; border-color: #fb923c44; background: #fb923c12; }
+	.record-type-ptr  { color: #2dd4bf; border-color: #2dd4bf44; background: #2dd4bf12; }
 
 	.record-actions {
 		text-align: right;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,17 @@
+import { execSync } from 'child_process';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
+const gitCommit = (() => {
+	try { return execSync('git rev-parse --short HEAD').toString().trim(); }
+	catch { return 'dev'; }
+})();
+
 export default defineConfig({
 	plugins: [sveltekit()],
+	define: {
+		__GIT_COMMIT__: JSON.stringify(gitCommit)
+	},
 	server: {
 		port: 5113,
 		proxy: {


### PR DESCRIPTION
## Summary

- **DNS full record type support** — SOA, CAA, PTR now visible in UI and included in backups; apex NS filter removed; all types available in add-record dropdown with styled badges
- **Backup restore overwrite** — import now uses delete-then-re-add instead of skipping on "already exists", ensuring NS and auto-generated records are properly replaced
- **Git SHA in sidebar** — sidebar shows running commit SHA baked in at build time (`v0.1.0 · abc1234`)
- **Docker fixes** — install `git` in builder stage for SHA injection; remove `coolify` network name override to avoid label conflicts on redeploy; fix `coolify-server-setup` exit 22 on redeploy by adding `|| true` / `|| echo ""` to idempotent curl calls
- **Svelte zone deletion reactivity fix** — spread operator on filter result to force UI update

## Test plan

- [x] DNS backup → delete → restore cycle tested via Playwright QA
- [x] All record types (SOA, CAA, PTR, NS) visible in DNS UI
- [x] Import shows `[replaced]` for auto-generated NS records instead of skipped
- [x] Sidebar shows correct commit SHA after Docker build
- [x] `docker compose up -d --build` succeeds on redeploy without exit 22
- [x] Zone deletion updates UI immediately without page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)