### PR TITLE
feat(dns): Cloudflare DNS provider + networking fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HermitHost
 
-A self-hosted web platform dashboard for managing deployed sites, DNS records, and deployments. HermitHost wraps Coolify (deployments), Technitium (DNS), and Traefik (reverse proxy + SSL) into a single unified dashboard with zero-config setup.
+A self-hosted web platform dashboard for managing deployed sites, DNS records, and deployments. HermitHost wraps Coolify (deployments), Technitium or Cloudflare (DNS), and Traefik (reverse proxy + SSL) into a single unified dashboard with zero-config setup.
 
 **Status Dashboard** • **DNS Management** • **Deploy History** • **Health Monitoring** • **Backup & Restore** • **Auto SSL**
 
@@ -11,7 +11,7 @@ A self-hosted web platform dashboard for managing deployed sites, DNS records, a
 HermitHost is a lightweight platform dashboard that gives you visibility and control over all your deployed web applications in one place. Instead of logging into Coolify, Technitium, and Traefik separately, HermitHost surfaces everything in a single UI.
 
 - **Monitor everything:** HTTP status, SSL certificate health, DNS resolution — live probes, 60s cache
-- **Manage DNS:** View, create, update, and delete DNS records via Technitium
+- **Manage DNS:** Use Technitium (internal/LAN) or Cloudflare (public authoritative DNS) — switchable from Settings
 - **Track deployments:** See deployment history and stream logs per site
 - **Backup & restore:** Export/import your full hermithost configuration
 - **Auto SSL:** Traefik + Let's Encrypt — HTTPS with no manual certificate management
@@ -23,22 +23,27 @@ HermitHost is a lightweight platform dashboard that gives you visibility and con
 
 ```
 Browser
-  ↓
-Traefik (reverse proxy) :8080 / :8443
-  ├─ /api/* → Express API :3001
-  └─ /*     → SvelteKit Frontend :3000
+  ├─ LAN: http://<server-ip>:9080 (internal, no DNS required)
+  │
+  └─ Named domain: https://hermithost.<your-domain>
        ↓
-  ┌────────────────────────────────┐
-  │  Express API                   │
-  │  ├─ Coolify (deployments)      │
-  │  ├─ Technitium (DNS)           │
-  │  ├─ Health probes (HTTP/SSL/DNS)│
-  │  ├─ Config API                 │
-  │  └─ Backup / restore           │
-  └────────────────────────────────┘
-       ↓                    ↓
-  Coolify :8000        Technitium :5380
-  (PostgreSQL + Redis)
+  Traefik (reverse proxy) :8080 / :8443
+    ├─ /api/* → Express API :3001
+    └─ /*     → SvelteKit Frontend :3000
+         ↓
+    ┌──────────────────────────────────┐
+    │  Express API                      │
+    │  ├─ DnsProvider (abstraction)     │
+    │  │   ├─ TechnitiumProvider        │
+    │  │   └─ CloudflareProvider        │
+    │  ├─ Coolify (deployments)         │
+    │  ├─ Health probes (HTTP/SSL/DNS) │
+    │  ├─ Config API                    │
+    │  └─ Backup / restore              │
+    └──────────────────────────────────┘
+         ↓                    ↓
+    Coolify :8000        DNS Server
+    (PostgreSQL + Redis)  (Technitium :5380 OR Cloudflare API)
 ```
 
 ### Services
@@ -46,10 +51,10 @@ Traefik (reverse proxy) :8080 / :8443
 | Service | Tech | Purpose |
 |---------|------|---------|
 | **Frontend** | SvelteKit + TypeScript | Dashboard UI |
-| **API** | Express.js + TypeScript | Aggregation layer — Coolify, Technitium, probes |
+| **API** | Express.js + TypeScript | Aggregation layer — Coolify, DNS providers, probes |
 | **Traefik** | Traefik v3 | Reverse proxy, Let's Encrypt SSL |
 | **Coolify** | Coolify (Docker) | Deployment and app lifecycle management |
-| **Technitium** | Technitium DNS | DNS server with REST management API |
+| **DNS Provider** | Technitium DNS or Cloudflare API | DNS server with REST management (switchable) |
 | **PostgreSQL** | Postgres 15 | Coolify database |
 | **Redis** | Redis | Coolify queue and cache |
 
@@ -59,6 +64,7 @@ Traefik (reverse proxy) :8080 / :8443
 
 - **Docker** (v20.10+) and **Docker Compose** (v2.0+)
 - **Node.js** (v18+) — only for native development, not required for Docker
+- **Cloudflare account** (optional, only if using Cloudflare for public DNS)
 
 ---
 
@@ -85,14 +91,22 @@ bash scripts/setup.sh
 bash scripts/start.sh
 ```
 
+This script automatically creates the `coolify` Docker network if it doesn't exist (required for inter-container communication).
+
 ### 3. Open the dashboard
 
+**LAN (no DNS required):**
 ```
-http://localhost:8080
+http://<server-ip>:9080
+```
+
+**Named domain (requires DNS + TLS):**
+```
+https://hermithost.<your-domain>
 ```
 
 Coolify UI (escape hatch only): `http://localhost:8000`
-Technitium DNS UI: `http://localhost:5380`
+Technitium DNS UI (if using Technitium): `http://localhost:5380`
 
 ---
 
@@ -112,6 +126,8 @@ bash scripts/setup.sh
 | `COOLIFY_PUSHER_*` | Auto-generated |
 | `ACME_EMAIL` | **Prompted** — required for SSL cert issuance |
 | `NS_HOSTNAME` | **Prompted** — your server's public IP or hostname |
+| `DNS_PROVIDER` | Default: `technitium` — optionally switch to `cloudflare` after setup |
+| `CLOUDFLARE_TOKEN` | Optional — set via Settings if using Cloudflare provider |
 
 Safe to re-run — only fills empty values, never overwrites existing ones.
 
@@ -132,6 +148,8 @@ Full reference for `.env`:
 | `TRAEFIK_HTTPS_PORT` | Traefik HTTPS port | `8443` |
 | `TECHNITIUM_URL` | Technitium API base URL | `http://technitium:5380` |
 | `DNS_PORT` | Host port for DNS queries. Use `53` on dedicated servers; default avoids macOS/Linux conflict | `5353` |
+| `DNS_PROVIDER` | Active DNS provider | `technitium` |
+| `CLOUDFLARE_TOKEN` | Cloudflare API token (also settable via Settings UI) | *(empty)* |
 | `COOLIFY_API_TOKEN` | Auto-provisioned at startup | *(auto)* |
 | `TECHNITIUM_TOKEN` | Auto-provisioned at startup | *(auto)* |
 
@@ -152,7 +170,26 @@ Real-time per-site probes run in parallel, cached 60 seconds:
 Trigger deploys, view deployment history, stream live deployment logs — all via the Coolify integration.
 
 ### DNS Management
-Create, update, and delete DNS records for your sites via the Technitium integration. Records update immediately.
+Create, update, and delete DNS records via Technitium (internal/LAN) or Cloudflare (public authoritative DNS). Switch providers anytime from Settings → DNS Provider.
+
+### DNS Provider Setup
+
+#### Technitium (Default)
+- No setup required — Technitium is deployed automatically
+- Access UI at `http://localhost:5380` (internal only)
+- Best for: home labs, internal networks, ISPs that don't block port 53
+
+#### Cloudflare (Public DNS)
+- Use when your ISP blocks inbound port 53 (common with AT&T and others)
+- **One-time setup:**
+  1. Create a Cloudflare API token at https://dash.cloudflare.com/profile/api-tokens
+  2. Token must have permissions: **Zone:Edit** + **Zone:Create** (account-level)
+  3. *(Note: "Edit zone DNS" template is insufficient — create a custom token)*
+  4. Open HermitHost Settings → DNS Provider
+  5. Select "Cloudflare"
+  6. Paste your API token
+  7. Save — system will verify connectivity
+- Best for: public-facing sites, when ISP blocks port 53, production deployments
 
 ### Backup & Restore
 Export a full snapshot of your hermithost configuration (sites, DNS records, settings) to a JSON file. Import to restore or migrate to a new server.
@@ -163,7 +200,13 @@ Settings → Backup → Import
 ```
 
 ### Settings
-Manage hermithost configuration (NS hostname, Traefik ports, admin credentials) from the UI without editing `.env` directly.
+Manage hermithost configuration:
+- NS hostname, Traefik ports, admin credentials
+- **DNS Provider** — switch between Technitium and Cloudflare
+- **Cloudflare Token** — set/update your API token
+- Backup & restore
+
+All from the UI without editing `.env` directly.
 
 ### Auto SSL
 Traefik + Let's Encrypt automatically issues and renews SSL certificates for all sites. Requires a valid `ACME_EMAIL` and publicly reachable `NS_HOSTNAME`.
@@ -175,7 +218,7 @@ Traefik + Let's Encrypt automatically issues and renews SSL certificates for all
 | Script | Purpose |
 |--------|---------|
 | `bash scripts/setup.sh` | First-time config — generates secrets, prompts for email + hostname |
-| `bash scripts/start.sh` | Start the full stack |
+| `bash scripts/start.sh` | Start the full stack (auto-creates Docker `coolify` network) |
 | `bash scripts/stop.sh` | Stop all containers |
 | `bash scripts/restart.sh` | Restart the stack |
 | `bash scripts/status.sh` | Show container status |
@@ -214,8 +257,8 @@ All endpoints are under `/api`.
 ### Config & Backup
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/config` | Get current hermithost config |
-| `PATCH` | `/api/config` | Update config values |
+| `GET` | `/api/config` | Get current hermithost config (includes `dns_provider`, `cloudflare_status`, `cloudflare_token_set`) |
+| `PATCH` | `/api/config` | Update config values (accepts `dns_provider`, `cloudflare_token`) |
 | `GET` | `/api/backup/export` | Export full config backup |
 | `POST` | `/api/backup/import` | Import backup file |
 | `POST` | `/api/backup/validate` | Validate backup before importing |
@@ -241,10 +284,14 @@ hermithost/
 │   │   │   └── health.ts         # Health check
 │   │   ├── services/
 │   │   │   ├── coolify.ts        # Coolify API client
-│   │   │   ├── technitium.ts     # Technitium DNS client
 │   │   │   ├── healthProbe.ts    # HTTP/SSL/DNS probes
 │   │   │   ├── backup.ts         # Backup/restore logic
-│   │   │   └── mapper.ts         # Coolify → hermithost type mapper
+│   │   │   ├── mapper.ts         # Coolify → hermithost type mapper
+│   │   │   └── dns/
+│   │   │       ├── DnsProvider.ts        # Interface (abstract)
+│   │   │       ├── TechnitiumProvider.ts # Technitium implementation
+│   │   │       ├── CloudflareProvider.ts # Cloudflare API v4 implementation
+│   │   │       └── index.ts              # Factory (reads DNS_PROVIDER setting)
 │   │   └── types.ts              # Shared API types
 │   ├── package.json
 │   └── Dockerfile
@@ -254,7 +301,7 @@ hermithost/
 │   │   ├── sites/[slug]/
 │   │   │   └── +page.svelte      # Site detail
 │   │   └── settings/
-│   │       └── +page.svelte      # Settings + backup UI
+│   │       └── +page.svelte      # Settings + backup + DNS provider UI
 │   └── lib/
 │       └── types.ts              # Frontend types
 ├── traefik/                      # Traefik config
@@ -314,6 +361,15 @@ docker compose down          # Stop and remove
 
 Run `bash scripts/setup.sh` — it will prompt for anything missing and generate all secrets.
 
+### Stack won't start — Docker network missing
+
+`scripts/start.sh` automatically creates the `coolify` network. If manually running `docker compose up`, ensure the network exists:
+
+```bash
+docker network create coolify
+docker compose up
+```
+
 ### Coolify login fails
 
 - **Email:** the value of `ACME_EMAIL` you entered during `setup.sh`
@@ -331,6 +387,21 @@ Run `bash scripts/setup.sh` — it will prompt for anything missing and generate
 - Verify the site domain is publicly resolvable
 - Confirm outbound HTTPS from the container isn't blocked
 - Test: `curl -I https://yourdomain.com`
+
+### ISP blocks port 53 (DNS queries fail)
+
+Use Cloudflare provider instead:
+1. Create a Cloudflare API token (see **DNS Provider Setup** section)
+2. Open Settings → DNS Provider
+3. Select "Cloudflare" and paste your token
+4. Save and verify connection
+
+### Cloudflare provider not connecting
+
+- Verify token has **Zone:Edit** + **Zone:Create** permissions (not just "Edit zone DNS" template)
+- Check that your Cloudflare account owns the domain you're configuring
+- Review API token in Cloudflare dashboard — confirm it hasn't expired
+- Check API logs: `docker compose logs api | grep -i cloudflare`
 
 ### Port conflict
 

--- a/api/src/routes/config.ts
+++ b/api/src/routes/config.ts
@@ -6,6 +6,8 @@ import { createTechnitiumClient } from '../services/technitium';
 const router = Router();
 
 const NS_HOSTNAME_FILE = '/coolify-api-token/ns_hostname';
+const DNS_PROVIDER_FILE = '/coolify-api-token/dns_provider';
+const CLOUDFLARE_TOKEN_FILE = '/coolify-api-token/cloudflare_token';
 
 // NS_HOSTNAME read precedence:
 // 1. File /coolify-api-token/ns_hostname
@@ -33,7 +35,17 @@ export function readNsServerIp(): string | null {
   return process.env.NS_SERVER_IP ?? null;
 }
 
+function readSetting(key: string): string | null {
+  try {
+    const val = readFileSync(`/coolify-api-token/${key}`, 'utf8').trim();
+    return val || null;
+  } catch {
+    return null;
+  }
+}
+
 type IntegrationStatus = 'connected' | 'error' | 'not_configured';
+type CloudflareStatus = 'connected' | 'disconnected' | 'unconfigured';
 
 async function getCoolifyStatus(): Promise<IntegrationStatus> {
   const client = createCoolifyClient();
@@ -43,6 +55,19 @@ async function getCoolifyStatus(): Promise<IntegrationStatus> {
     return 'connected';
   } catch {
     return 'error';
+  }
+}
+
+async function getCloudflareStatus(token: string | null): Promise<CloudflareStatus> {
+  if (!token || !token.trim()) return 'unconfigured';
+  try {
+    const res = await fetch('https://api.cloudflare.com/client/v4/user/tokens/verify', {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+    const data = await res.json() as { success: boolean };
+    return data.success ? 'connected' : 'disconnected';
+  } catch {
+    return 'disconnected';
   }
 }
 
@@ -60,10 +85,14 @@ async function getTechnitiumStatus(): Promise<IntegrationStatus> {
 // GET /api/config
 router.get('/', async (_req: Request, res: Response) => {
   try {
-    const [coolify_status, technitium_status] = await Promise.all([
+    const cfToken = readSetting('cloudflare_token') ?? process.env.CLOUDFLARE_TOKEN ?? null;
+    const [coolify_status, technitium_status, cloudflare_status] = await Promise.all([
       getCoolifyStatus(),
       getTechnitiumStatus(),
+      getCloudflareStatus(cfToken),
     ]);
+
+    const dns_provider = readSetting('dns_provider') ?? process.env.DNS_PROVIDER ?? 'technitium';
 
     res.status(200).json({
       ns_hostname: readNsHostname(),
@@ -72,6 +101,9 @@ router.get('/', async (_req: Request, res: Response) => {
       coolify_status,
       technitium_url: process.env.TECHNITIUM_URL ?? null,
       technitium_status,
+      dns_provider,
+      cloudflare_status,
+      cloudflare_token_set: !!cfToken,
     });
   } catch (err) {
     console.error('[config] GET failed:', (err as Error).message);
@@ -81,30 +113,65 @@ router.get('/', async (_req: Request, res: Response) => {
 
 // PUT /api/config
 router.put('/', async (req: Request, res: Response) => {
-  const body = req.body as { ns_hostname?: unknown };
+  const body = req.body as {
+    ns_hostname?: unknown;
+    dns_provider?: unknown;
+    cloudflare_token?: unknown;
+  };
 
-  if (typeof body.ns_hostname !== 'string' || !body.ns_hostname.trim()) {
-    res.status(400).json({ error: 'ns_hostname must be a non-empty string' });
+  // Validate at least one known key is present
+  const hasNsHostname = typeof body.ns_hostname === 'string' && body.ns_hostname.trim();
+  const hasDnsProvider = typeof body.dns_provider === 'string' && body.dns_provider.trim();
+  const hasCfToken = typeof body.cloudflare_token === 'string';
+
+  if (!hasNsHostname && !hasDnsProvider && !hasCfToken) {
+    res.status(400).json({ error: 'At least one field required: ns_hostname, dns_provider, cloudflare_token' });
     return;
   }
 
-  const value = body.ns_hostname.trim();
+  // Validate dns_provider enum if provided
+  if (hasDnsProvider && !['technitium', 'cloudflare'].includes((body.dns_provider as string).trim())) {
+    res.status(400).json({ error: 'dns_provider must be "technitium" or "cloudflare"' });
+    return;
+  }
 
   try {
     // Ensure directory exists (best-effort — directory is normally created by init container)
     try { mkdirSync('/coolify-api-token', { recursive: true }); } catch { /* ok */ }
-    writeFileSync(NS_HOSTNAME_FILE, value, 'utf8');
-    // Sync new hostname to Technitium immediately — non-fatal
-    const client = createTechnitiumClient();
-    if (client) {
-      client.setDnsServerDomain(value).catch((e: Error) =>
-        console.warn('[config] setDnsServerDomain after PUT failed:', e.message)
-      );
+
+    const result: Record<string, string> = {};
+
+    if (hasNsHostname) {
+      const value = (body.ns_hostname as string).trim();
+      writeFileSync(NS_HOSTNAME_FILE, value, 'utf8');
+      // Sync new hostname to Technitium immediately — non-fatal
+      const client = createTechnitiumClient();
+      if (client) {
+        client.setDnsServerDomain(value).catch((e: Error) =>
+          console.warn('[config] setDnsServerDomain after PUT failed:', e.message)
+        );
+      }
+      result.ns_hostname = value;
     }
-    res.status(200).json({ ns_hostname: value });
+
+    if (hasDnsProvider) {
+      const value = (body.dns_provider as string).trim();
+      writeFileSync(DNS_PROVIDER_FILE, value, 'utf8');
+      result.dns_provider = value;
+    }
+
+    if (hasCfToken) {
+      const value = (body.cloudflare_token as string).trim();
+      writeFileSync(CLOUDFLARE_TOKEN_FILE, value, 'utf8');
+      result.cloudflare_token_set = value ? 'true' : 'false';
+      const cloudflare_status = await getCloudflareStatus(value || null);
+      result.cloudflare_status = cloudflare_status;
+    }
+
+    res.status(200).json(result);
   } catch (err) {
-    console.error('[config] PUT write ns_hostname failed:', (err as Error).message);
-    res.status(500).json({ error: 'Failed to write ns_hostname' });
+    console.error('[config] PUT failed:', (err as Error).message);
+    res.status(500).json({ error: 'Failed to write config' });
   }
 });
 

--- a/api/src/routes/dns.ts
+++ b/api/src/routes/dns.ts
@@ -1,7 +1,6 @@
 import { Router, Request, Response } from 'express';
 import { DnsRecord } from '../types';
 import { createDnsProvider, DnsOperationError } from '../services/dns';
-import { createTechnitiumClient } from '../services/technitium';
 
 const router = Router();
 
@@ -11,18 +10,11 @@ router.get('/config', (_req: Request, res: Response) => {
 });
 
 // ── GET /api/dns/zones — list all zones ───────────────────────────────────────
-// Query param: ?all=true to include internal zones
-router.get('/zones', async (req: Request, res: Response) => {
-  const client = createTechnitiumClient();
-  if (!client) {
-    res.status(503).json({ error: 'DNS service not configured' });
-    return;
-  }
+router.get('/zones', async (_req: Request, res: Response) => {
   try {
-    const zones = await client.listZones();
-    const includeInternal = req.query.all === 'true';
-    const filtered = includeInternal ? zones : zones.filter((z) => !z.internal);
-    res.status(200).json(filtered);
+    const provider = createDnsProvider();
+    const zones = await provider.listZones();
+    res.status(200).json(zones);
   } catch (err) {
     console.error('[dns] GET /zones failed:', (err as Error).message);
     res.status(502).json({ error: 'Failed to retrieve zones from DNS server' });
@@ -30,21 +22,17 @@ router.get('/zones', async (req: Request, res: Response) => {
 });
 
 // ── POST /api/dns/zones — create a zone ───────────────────────────────────────
-// Body: { name: string, type?: string }
+// Body: { name: string }
 router.post('/zones', async (req: Request, res: Response) => {
-  const client = createTechnitiumClient();
-  if (!client) {
-    res.status(503).json({ error: 'DNS service not configured' });
-    return;
-  }
-  const body = req.body as { name?: string; type?: string };
+  const body = req.body as { name?: string };
   if (!body.name) {
     res.status(400).json({ error: 'Missing required field: name' });
     return;
   }
   try {
-    await client.createZone(body.name, body.type ?? 'Primary');
-    res.status(201).json({ name: body.name, type: body.type ?? 'Primary' });
+    const provider = createDnsProvider();
+    await provider.createZone(body.name);
+    res.status(201).json({ name: body.name });
   } catch (err) {
     console.error('[dns] POST /zones failed:', (err as Error).message);
     res.status(502).json({ error: 'Failed to create zone on DNS server' });
@@ -53,13 +41,9 @@ router.post('/zones', async (req: Request, res: Response) => {
 
 // ── DELETE /api/dns/zones/:name — delete a zone ───────────────────────────────
 router.delete('/zones/:name', async (req: Request, res: Response) => {
-  const client = createTechnitiumClient();
-  if (!client) {
-    res.status(503).json({ error: 'DNS service not configured' });
-    return;
-  }
   try {
-    await client.deleteZone(req.params.name);
+    const provider = createDnsProvider();
+    await provider.deleteZone(req.params.name);
     res.status(204).send();
   } catch (err) {
     console.error(`[dns] DELETE /zones/${req.params.name} failed:`, (err as Error).message);

--- a/api/src/services/dns/CloudflareProvider.ts
+++ b/api/src/services/dns/CloudflareProvider.ts
@@ -1,0 +1,193 @@
+// Cloudflare DNS provider — uses Node 18+ native fetch.
+// Auth: Authorization: Bearer <token>
+// Base: https://api.cloudflare.com/client/v4
+
+import type { DnsProvider, DnsZone } from './DnsProvider';
+import type { DnsRecord, DnsRecordType } from '../../types';
+import { DnsOperationError } from './errors';
+
+const CF_BASE = 'https://api.cloudflare.com/client/v4';
+
+interface CfError {
+  code: number;
+  message: string;
+}
+
+interface CfResponse<T> {
+  success: boolean;
+  errors: CfError[];
+  result: T;
+}
+
+interface CfZone {
+  id: string;
+  name: string;
+  status: string;
+  paused: boolean;
+}
+
+interface CfRecord {
+  id: string;
+  type: string;
+  name: string;
+  content: string;
+  ttl: number;
+  priority?: number;
+  proxied?: boolean;
+}
+
+export class CloudflareProvider implements DnsProvider {
+  private readonly headers: Record<string, string>;
+  /** Zone name → zone ID cache (lives for the lifetime of this instance). */
+  private readonly zoneCache = new Map<string, string>();
+
+  constructor(private readonly token: string) {
+    this.headers = {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  // ── Internal helpers ───────────────────────────────────────────
+
+  private async cfFetch<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(`${CF_BASE}${path}`, {
+      ...init,
+      headers: { ...this.headers, ...(init?.headers ?? {}) },
+    });
+    const data = await res.json() as CfResponse<T>;
+    if (!data.success) {
+      const msg = data.errors[0]?.message ?? `Cloudflare API error (HTTP ${res.status})`;
+      throw new Error(msg);
+    }
+    return data.result;
+  }
+
+  private async getZoneId(name: string): Promise<string> {
+    if (this.zoneCache.has(name)) return this.zoneCache.get(name)!;
+    const zones = await this.cfFetch<CfZone[]>(`/zones?name=${encodeURIComponent(name)}&per_page=1`);
+    if (!zones.length) throw new Error(`Cloudflare zone not found: ${name}`);
+    const id = zones[0].id;
+    this.zoneCache.set(name, id);
+    return id;
+  }
+
+  private static readonly VALID_RECORD_TYPES = new Set<string>([
+    'A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'SRV', 'CAA', 'SOA', 'PTR',
+  ]);
+
+  private mapRecord(r: CfRecord): DnsRecord | null {
+    if (!CloudflareProvider.VALID_RECORD_TYPES.has(r.type)) {
+      console.warn(`Skipping unsupported Cloudflare record type: ${r.type}`);
+      return null;
+    }
+    return {
+      id: r.id,
+      type: r.type as DnsRecordType,
+      name: r.name,
+      value: r.content,
+      ttl: r.ttl,
+      ...(r.priority !== undefined ? { priority: r.priority } : {}),
+    };
+  }
+
+  // ── Zone methods ───────────────────────────────────────────────
+
+  async listZones(): Promise<DnsZone[]> {
+    try {
+      const zones = await this.cfFetch<CfZone[]>('/zones?per_page=50');
+      return zones.map((z) => ({ name: z.name, disabled: z.paused }));
+    } catch (err) {
+      throw new DnsOperationError('Failed to list Cloudflare zones', err);
+    }
+  }
+
+  async createZone(name: string): Promise<void> {
+    try {
+      const zone = await this.cfFetch<CfZone>('/zones', {
+        method: 'POST',
+        body: JSON.stringify({ name, type: 'full', jump_start: false }),
+      });
+      this.zoneCache.set(name, zone.id);
+    } catch (err) {
+      throw new DnsOperationError('Failed to create Cloudflare zone', err);
+    }
+  }
+
+  async deleteZone(name: string): Promise<void> {
+    try {
+      const id = await this.getZoneId(name);
+      await this.cfFetch<{ id: string }>(`/zones/${id}`, { method: 'DELETE' });
+      this.zoneCache.delete(name);
+    } catch (err) {
+      throw new DnsOperationError('Failed to delete Cloudflare zone', err);
+    }
+  }
+
+  // ── Record methods ─────────────────────────────────────────────
+
+  async getRecords(domain: string): Promise<DnsRecord[]> {
+    try {
+      const id = await this.getZoneId(domain);
+      const records = await this.cfFetch<CfRecord[]>(`/zones/${id}/dns_records?per_page=100`);
+      return records.map((r) => this.mapRecord(r)).filter((r): r is DnsRecord => r !== null);
+    } catch (err) {
+      throw new DnsOperationError('Failed to retrieve Cloudflare DNS records', err);
+    }
+  }
+
+  async addRecord(domain: string, record: Omit<DnsRecord, 'id'>): Promise<DnsRecord> {
+    try {
+      const id = await this.getZoneId(domain);
+      const body: Record<string, unknown> = {
+        type: record.type,
+        name: record.name === '@' ? domain : `${record.name}.${domain}`,
+        content: record.value,
+        ttl: record.ttl,
+        proxied: false,
+      };
+      if (record.priority !== undefined) body.priority = record.priority;
+      const created = await this.cfFetch<CfRecord>(`/zones/${id}/dns_records`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
+      return this.mapRecord(created);
+    } catch (err) {
+      throw new DnsOperationError('Failed to add Cloudflare DNS record', err);
+    }
+  }
+
+  async updateRecord(
+    domain: string,
+    id: string,
+    updates: Partial<Omit<DnsRecord, 'id'>>
+  ): Promise<DnsRecord> {
+    try {
+      const zoneId = await this.getZoneId(domain);
+      const patch: Record<string, unknown> = {};
+      if (updates.type !== undefined) patch.type = updates.type;
+      if (updates.name !== undefined) patch.name = updates.name;
+      if (updates.value !== undefined) patch.content = updates.value;
+      if (updates.ttl !== undefined) patch.ttl = updates.ttl;
+      if (updates.priority !== undefined) patch.priority = updates.priority;
+      const updated = await this.cfFetch<CfRecord>(`/zones/${zoneId}/dns_records/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+      });
+      return this.mapRecord(updated);
+    } catch (err) {
+      throw new DnsOperationError('Failed to update Cloudflare DNS record', err);
+    }
+  }
+
+  async deleteRecord(domain: string, id: string): Promise<void> {
+    try {
+      const zoneId = await this.getZoneId(domain);
+      await this.cfFetch<{ id: string }>(`/zones/${zoneId}/dns_records/${id}`, {
+        method: 'DELETE',
+      });
+    } catch (err) {
+      throw new DnsOperationError('Failed to delete Cloudflare DNS record', err);
+    }
+  }
+}

--- a/api/src/services/dns/CloudflareProvider.ts
+++ b/api/src/services/dns/CloudflareProvider.ts
@@ -151,7 +151,9 @@ export class CloudflareProvider implements DnsProvider {
         method: 'POST',
         body: JSON.stringify(body),
       });
-      return this.mapRecord(created);
+      const result = this.mapRecord(created);
+      if (!result) throw new DnsOperationError('Cloudflare returned unsupported record type', null);
+      return result;
     } catch (err) {
       throw new DnsOperationError('Failed to add Cloudflare DNS record', err);
     }
@@ -174,7 +176,9 @@ export class CloudflareProvider implements DnsProvider {
         method: 'PATCH',
         body: JSON.stringify(patch),
       });
-      return this.mapRecord(updated);
+      const result = this.mapRecord(updated);
+      if (!result) throw new DnsOperationError('Cloudflare returned unsupported record type', null);
+      return result;
     } catch (err) {
       throw new DnsOperationError('Failed to update Cloudflare DNS record', err);
     }

--- a/api/src/services/dns/CloudflareProvider.ts
+++ b/api/src/services/dns/CloudflareProvider.ts
@@ -78,7 +78,7 @@ export class CloudflareProvider implements DnsProvider {
         return { zoneId, recordName };
       }
       const zones = await this.cfFetch<CfZone[]>(
-        `/zones?name=${encodeURIComponent(candidate)}&status=active`
+        `/zones?name=${encodeURIComponent(candidate)}`
       );
       if (zones.length > 0) {
         const zoneId = zones[0].id;

--- a/api/src/services/dns/CloudflareProvider.ts
+++ b/api/src/services/dns/CloudflareProvider.ts
@@ -63,13 +63,31 @@ export class CloudflareProvider implements DnsProvider {
     return data.result;
   }
 
-  private async getZoneId(name: string): Promise<string> {
-    if (this.zoneCache.has(name)) return this.zoneCache.get(name)!;
-    const zones = await this.cfFetch<CfZone[]>(`/zones?name=${encodeURIComponent(name)}&per_page=1`);
-    if (!zones.length) throw new Error(`Cloudflare zone not found: ${name}`);
-    const id = zones[0].id;
-    this.zoneCache.set(name, id);
-    return id;
+  private async getZoneId(domain: string): Promise<string> {
+    const { zoneId } = await this.getZoneAndName(domain);
+    return zoneId;
+  }
+
+  private async getZoneAndName(domain: string): Promise<{ zoneId: string; recordName: string }> {
+    const parts = domain.split('.');
+    for (let i = 0; i < parts.length - 1; i++) {
+      const candidate = parts.slice(i).join('.');
+      if (this.zoneCache.has(candidate)) {
+        const zoneId = this.zoneCache.get(candidate)!;
+        const recordName = i === 0 ? '@' : parts.slice(0, i).join('.');
+        return { zoneId, recordName };
+      }
+      const zones = await this.cfFetch<CfZone[]>(
+        `/zones?name=${encodeURIComponent(candidate)}&status=active`
+      );
+      if (zones.length > 0) {
+        const zoneId = zones[0].id;
+        this.zoneCache.set(candidate, zoneId);
+        const recordName = i === 0 ? '@' : parts.slice(0, i).join('.');
+        return { zoneId, recordName };
+      }
+    }
+    throw new DnsOperationError(`Cloudflare zone not found for domain: ${domain}`, null);
   }
 
   private static readonly VALID_RECORD_TYPES = new Set<string>([

--- a/api/src/services/dns/DnsProvider.ts
+++ b/api/src/services/dns/DnsProvider.ts
@@ -1,6 +1,13 @@
 import type { DnsRecord } from '../../types';
 
+export interface DnsZone {
+  name: string;
+  disabled?: boolean;
+}
+
 export interface DnsProvider {
+  // ── Records ────────────────────────────────────────────────────
+
   /** Fetch all records for a domain. */
   getRecords(domain: string): Promise<DnsRecord[]>;
 
@@ -12,4 +19,15 @@ export interface DnsProvider {
 
   /** Delete a record by id. */
   deleteRecord(domain: string, id: string): Promise<void>;
+
+  // ── Zones ──────────────────────────────────────────────────────
+
+  /** List all zones managed by this provider. */
+  listZones(): Promise<DnsZone[]>;
+
+  /** Create a new zone. */
+  createZone(name: string): Promise<void>;
+
+  /** Delete a zone by name. */
+  deleteZone(name: string): Promise<void>;
 }

--- a/api/src/services/dns/TechnitiumProvider.ts
+++ b/api/src/services/dns/TechnitiumProvider.ts
@@ -1,4 +1,4 @@
-import type { DnsProvider } from './DnsProvider';
+import type { DnsProvider, DnsZone } from './DnsProvider';
 import type { DnsRecord } from '../../types';
 import { TechnitiumClient } from '../technitium';
 import {
@@ -76,6 +76,31 @@ export class TechnitiumProvider implements DnsProvider {
       await this.client.deleteRecord(identity.domain, params);
     } catch (err) {
       throw new DnsOperationError('Failed to delete DNS record', err);
+    }
+  }
+
+  async listZones(): Promise<DnsZone[]> {
+    try {
+      const zones = await this.client.listZones();
+      return zones.map((z) => ({ name: z.name, disabled: z.disabled }));
+    } catch (err) {
+      throw new DnsOperationError('Failed to list DNS zones', err);
+    }
+  }
+
+  async createZone(name: string): Promise<void> {
+    try {
+      await this.client.createZone(name);
+    } catch (err) {
+      throw new DnsOperationError('Failed to create DNS zone', err);
+    }
+  }
+
+  async deleteZone(name: string): Promise<void> {
+    try {
+      await this.client.deleteZone(name);
+    } catch (err) {
+      throw new DnsOperationError('Failed to delete DNS zone', err);
     }
   }
 }

--- a/api/src/services/dns/index.ts
+++ b/api/src/services/dns/index.ts
@@ -1,17 +1,46 @@
+import { readFileSync } from 'fs';
 import type { DnsProvider } from './DnsProvider';
 import { TechnitiumProvider } from './TechnitiumProvider';
+import { CloudflareProvider } from './CloudflareProvider';
 import { createTechnitiumClient } from '../technitium';
 
 export type { DnsProvider } from './DnsProvider';
+export type { DnsZone } from './DnsProvider';
 export { DnsOperationError } from './errors';
 
 /**
- * Returns a DnsProvider with a fresh token on every call.
- * Technitium tokens are session-scoped and expire; reading the token file
- * each time ensures the provider always uses the current token written by
- * coolify-setup.sh on boot (or by a token refresh).
+ * Read a persisted setting from /coolify-api-token/<key>.
+ * Returns null if the file is absent or empty.
+ */
+function readSetting(key: string): string | null {
+  try {
+    const val = readFileSync(`/coolify-api-token/${key}`, 'utf8').trim();
+    return val || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns a DnsProvider based on the active dns_provider setting.
+ * Precedence: persisted file → env var → 'technitium' default.
+ *
+ * For Technitium: token is read fresh each call (tokens are session-scoped
+ * and written by coolify-setup.sh on boot).
  */
 export function createDnsProvider(): DnsProvider {
+  const provider = readSetting('dns_provider') ?? process.env.DNS_PROVIDER ?? 'technitium';
+
+  if (provider === 'cloudflare') {
+    const token = readSetting('cloudflare_token') ?? process.env.CLOUDFLARE_TOKEN ?? '';
+    if (!token) {
+      // Intentional: operator must configure token before switching provider.
+      // No silent fallback — misconfiguration should fail loudly.
+      throw new Error('Cloudflare DNS provider selected but CLOUDFLARE_TOKEN is not set');
+    }
+    return new CloudflareProvider(token);
+  }
+
   const client = createTechnitiumClient();
   if (client) {
     return new TechnitiumProvider(client);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,7 +221,7 @@ services:
       PGPASSWORD: "${COOLIFY_DB_PASSWORD}"
     volumes:
       - hermithost-sites:/app/sites
-      - coolify-api-token:/coolify-api-token:ro
+      - coolify-api-token:/coolify-api-token
       - coolify-keys:/coolify-keys:ro
       - ./traefik/conf.d:/app/traefik-conf.d
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,6 +210,8 @@ services:
       TECHNITIUM_URL: "${TECHNITIUM_URL:-http://technitium:5380}"
       TECHNITIUM_TOKEN: "${TECHNITIUM_TOKEN:-}"
       DNS_MOCK: "${DNS_MOCK:-}"
+      DNS_PROVIDER: "${DNS_PROVIDER:-technitium}"
+      CLOUDFLARE_TOKEN: "${CLOUDFLARE_TOKEN:-}"
       NS_HOSTNAME: "${NS_HOSTNAME:-}"
       NS_SERVER_IP: "${NS_SERVER_IP:-}"
       PGHOST: "coolify-db"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,6 +169,7 @@ services:
       - "--providers.file.watch=true"
       - "--entrypoints.http.address=:80"
       - "--entrypoints.https.address=:443"
+      - "--entrypoints.admin.address=:9080"
       - "--entrypoints.https.http.tls.certresolver=letsencrypt"
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http"
@@ -178,6 +179,7 @@ services:
       - "${TRAEFIK_HTTP_PORT:-8080}:80"
       - "${TRAEFIK_HTTPS_PORT:-8443}:443"
       - "8081:8080"
+      - "9080:9080"
     volumes:
       - ./traefik/conf.d:/etc/traefik/conf.d
       - traefik-acme:/acme

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -261,6 +261,8 @@ networks:
   hermithost-net:
     driver: bridge
   coolify:
+    external: true
+    name: coolify
 
 volumes:
   hermithost-sites:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -10,6 +10,17 @@ export DOCKER_HOST=unix:///Users/rdemeritt/.docker/run/docker.sock
 
 mkdir -p "$LOG_DIR"
 
+# Ensure the coolify network exists before compose up.
+# Coolify normally creates this network, but on a fresh machine it may not
+# exist yet. Traefik joins it to reach Coolify-deployed site containers.
+if ! docker network inspect coolify &>/dev/null; then
+  echo "   'coolify' network not found — creating it..."
+  docker network create coolify
+  echo "   'coolify' network created. Start Coolify to attach it to its containers."
+else
+  echo "   'coolify' network present."
+fi
+
 # Determine whether to force a rebuild
 BUILD_FLAG=""
 if [[ "${1:-}" == "--build" || "${1:-}" == "-b" ]]; then

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -28,6 +28,17 @@
 	let configSaveError = '';
 	let configSaveSuccess = false;
 
+	// ── DNS Provider ───────────────────────────────────────────────────────────
+	let dnsProvider: 'technitium' | 'cloudflare' = 'technitium';
+	let cloudflareStatus: 'connected' | 'disconnected' | 'unconfigured' = 'unconfigured';
+	let cloudflareTokenInput = '';
+	let savingDnsProvider = false;
+	let dnsProviderError = '';
+	let savingCloudflareToken = false;
+	let cloudflareTokenError = '';
+	let cloudflareTokenSuccess = false;
+	let dnsProviderWarning = '';
+
 	// ── Selector ───────────────────────────────────────────────────────────────
 	let availableSites: SiteSummary[] = [];
 	let availableZones: ZoneSummary[] = [];
@@ -119,6 +130,9 @@
 					coolify_status?: 'connected' | 'error' | 'not_configured';
 					technitium_url?: string;
 					technitium_status?: 'connected' | 'error' | 'not_configured';
+					dns_provider?: 'technitium' | 'cloudflare';
+					cloudflare_status?: 'connected' | 'disconnected' | 'unconfigured';
+					cloudflare_token_set?: boolean;
 				};
 				nsHostname = cfg.ns_hostname ?? '';
 				acmeEmail = cfg.acme_email ?? '';
@@ -126,6 +140,8 @@
 				coolifyStatus = cfg.coolify_status ?? 'not_configured';
 				technitiumUrl = cfg.technitium_url ?? '';
 				technitiumStatus = cfg.technitium_status ?? 'not_configured';
+				dnsProvider = cfg.dns_provider ?? 'technitium';
+				cloudflareStatus = cfg.cloudflare_status ?? 'unconfigured';
 			}
 		} catch {
 			// non-fatal; page still renders
@@ -153,6 +169,61 @@
 			configSaveError = (err as Error).message;
 		} finally {
 			savingConfig = false;
+		}
+	}
+
+	// ── DNS Provider handlers ──────────────────────────────────────────────────
+	async function onDnsProviderChange(event: Event) {
+		const select = event.currentTarget as HTMLSelectElement;
+		const newProvider = select.value as 'technitium' | 'cloudflare';
+		if (newProvider === dnsProvider) return;
+
+		dnsProviderWarning = `DNS provisioning will use ${newProvider === 'cloudflare' ? 'Cloudflare' : 'Technitium'} going forward. Existing zones are not migrated automatically.`;
+		savingDnsProvider = true;
+		dnsProviderError = '';
+		try {
+			const res = await fetch('/api/config', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ dns_provider: newProvider }),
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({})) as { error?: string };
+				throw new Error(body.error ?? `HTTP ${res.status}`);
+			}
+			dnsProvider = newProvider;
+		} catch (err) {
+			dnsProviderError = (err as Error).message;
+			select.value = dnsProvider; // revert select visually
+		} finally {
+			savingDnsProvider = false;
+		}
+	}
+
+	async function saveCloudflareToken() {
+		if (!cloudflareTokenInput.trim()) return;
+		savingCloudflareToken = true;
+		cloudflareTokenError = '';
+		cloudflareTokenSuccess = false;
+		try {
+			const res = await fetch('/api/config', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ cloudflare_token: cloudflareTokenInput.trim() }),
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({})) as { error?: string };
+				throw new Error(body.error ?? `HTTP ${res.status}`);
+			}
+			const updated = await res.json().catch(() => ({})) as { cloudflare_status?: 'connected' | 'disconnected' | 'unconfigured' };
+			if (updated.cloudflare_status) cloudflareStatus = updated.cloudflare_status;
+			cloudflareTokenInput = '';
+			cloudflareTokenSuccess = true;
+			setTimeout(() => { cloudflareTokenSuccess = false; }, 3000);
+		} catch (err) {
+			cloudflareTokenError = (err as Error).message;
+		} finally {
+			savingCloudflareToken = false;
 		}
 	}
 
@@ -397,10 +468,101 @@
 						<span class="integration-url">{technitiumUrl}</span>
 					{/if}
 				</div>
-				<span class="status-label" class:label-connected={technitiumStatus === 'connected'} class:label-error={technitiumStatus === 'error'} class:label-unconfigured={technitiumStatus === 'not_configured'}>
-					{#if technitiumStatus === 'connected'}Connected{:else if technitiumStatus === 'error'}Error{:else}Not configured{/if}
-				</span>
+				<div class="integration-right">
+					{#if dnsProvider === 'technitium'}
+						<span class="provider-badge badge-active">Active</span>
+					{/if}
+					<span class="status-label" class:label-connected={technitiumStatus === 'connected'} class:label-error={technitiumStatus === 'error'} class:label-unconfigured={technitiumStatus === 'not_configured'}>
+						{#if technitiumStatus === 'connected'}Connected{:else if technitiumStatus === 'error'}Error{:else}Not configured{/if}
+					</span>
+				</div>
 			</div>
+
+			<!-- DNS Provider selector -->
+			<div class="dns-provider-block" style="margin-top: 16px;">
+				<div class="field-group">
+					<label class="field-label" for="dns-provider">DNS Provider</label>
+					<p class="field-hint">Select which provider handles DNS zone provisioning.</p>
+					<div class="input-row">
+						<select
+							id="dns-provider"
+							class="text-input select-input"
+							on:change={onDnsProviderChange}
+							disabled={savingDnsProvider}
+							value={dnsProvider}
+						>
+							<option value="technitium">Technitium</option>
+							<option value="cloudflare">Cloudflare</option>
+						</select>
+						{#if savingDnsProvider}
+							<span class="spinner"></span>
+						{/if}
+					</div>
+					{#if dnsProviderWarning}
+						<p class="provider-warning">{dnsProviderWarning}</p>
+					{/if}
+					{#if dnsProviderError}
+						<p class="error-msg">{dnsProviderError}</p>
+					{/if}
+				</div>
+			</div>
+
+			<!-- Cloudflare token — only when cloudflare is active -->
+			{#if dnsProvider === 'cloudflare'}
+				<div class="integration-row cf-token-row" style="margin-top: 10px; flex-direction: column; align-items: flex-start; gap: 10px;">
+					<div class="integration-info" style="width: 100%; justify-content: space-between;">
+						<div class="integration-info">
+							<span
+								class="status-dot"
+								class:dot-connected={cloudflareStatus === 'connected'}
+								class:dot-error={cloudflareStatus === 'disconnected'}
+								class:dot-unconfigured={cloudflareStatus === 'unconfigured'}
+							></span>
+							<span class="integration-name">Cloudflare</span>
+							<span class="provider-badge badge-active">Active</span>
+						</div>
+						<span
+							class="status-label"
+							class:label-connected={cloudflareStatus === 'connected'}
+							class:label-error={cloudflareStatus === 'disconnected'}
+							class:label-unconfigured={cloudflareStatus === 'unconfigured'}
+						>
+							{#if cloudflareStatus === 'connected'}Connected{:else if cloudflareStatus === 'disconnected'}Disconnected{:else}Unconfigured{/if}
+						</span>
+					</div>
+					<div class="field-group" style="width: 100%;">
+						<label class="field-label" for="cf-token">Cloudflare API Token</label>
+						<p class="field-hint">Requires Zone:DNS:Edit permission on the target zones.</p>
+						<div class="input-row">
+							<input
+								id="cf-token"
+								class="text-input"
+								type="password"
+								placeholder="••••••••••••••••"
+								bind:value={cloudflareTokenInput}
+								autocomplete="off"
+							/>
+							<button
+								class="btn btn-primary"
+								on:click={saveCloudflareToken}
+								disabled={savingCloudflareToken || !cloudflareTokenInput.trim()}
+							>
+								{#if savingCloudflareToken}
+									<span class="spinner"></span> Saving…
+								{:else}
+									Save
+								{/if}
+							</button>
+						</div>
+						{#if cloudflareTokenSuccess}
+							<p class="inline-success">Token saved successfully.</p>
+						{/if}
+						{#if cloudflareTokenError}
+							<p class="error-msg">{cloudflareTokenError}</p>
+						{/if}
+					</div>
+				</div>
+			{/if}
 		</div>
 	</section>
 
@@ -1145,4 +1307,54 @@
 	.result-list.created { color: var(--success, #4caf82); }
 	.result-list.skipped { color: var(--text-muted); }
 	.result-list.failed { color: var(--danger, #cf5c5c); }
+
+	/* ── DNS Provider ── */
+	.select-input {
+		appearance: none;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%234a5568' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+		background-repeat: no-repeat;
+		background-position: right 10px center;
+		padding-right: 28px;
+		cursor: pointer;
+	}
+
+	.dns-provider-block {
+		padding: 0;
+	}
+
+	.integration-right {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.provider-badge {
+		font-size: 10px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: 2px 6px;
+		border-radius: 3px;
+	}
+
+	.badge-active {
+		background: color-mix(in srgb, var(--accent-teal) 15%, transparent);
+		color: var(--accent-teal);
+		border: 1px solid color-mix(in srgb, var(--accent-teal) 35%, transparent);
+	}
+
+	.provider-warning {
+		font-size: 11px;
+		color: var(--warning, #d4a843);
+		margin-top: 6px;
+		line-height: 1.4;
+		padding: 6px 10px;
+		background: color-mix(in srgb, var(--warning, #d4a843) 10%, transparent);
+		border: 1px solid color-mix(in srgb, var(--warning, #d4a843) 30%, transparent);
+		border-radius: 4px;
+	}
+
+	.cf-token-row {
+		padding: 12px;
+	}
 </style>

--- a/traefik/conf.d/routes.yml
+++ b/traefik/conf.d/routes.yml
@@ -18,6 +18,19 @@ http:
       tls: {}
       service: frontend
 
+    # ── LAN admin access — port 9080, no Host required, no TLS ────────────────
+    api-admin-lan:
+      rule: "PathPrefix(`/api`)"
+      entryPoints:
+        - admin
+      service: api
+
+    frontend-admin-lan:
+      rule: "PathPrefix(`/`)"
+      entryPoints:
+        - admin
+      service: frontend
+
   services:
     api:
       loadBalancer:

--- a/traefik/conf.d/routes.yml
+++ b/traefik/conf.d/routes.yml
@@ -18,25 +18,6 @@ http:
       tls: {}
       service: frontend
 
-    # ── Fallback: no-host catch-all ────────────────────────────────────────────
-    # Serves admin when no site-specific Host rule matches (e.g., direct IP access).
-    # No TLS cert — no hostname for ACME to target.
-    api:
-      rule: "PathPrefix(`/api`)"
-      priority: 10
-      entryPoints:
-        - http
-        - https
-      service: api
-
-    frontend:
-      rule: "PathPrefix(`/`)"
-      priority: 1
-      entryPoints:
-        - http
-        - https
-      service: frontend
-
   services:
     api:
       loadBalancer:


### PR DESCRIPTION
## Summary

- Add Cloudflare as a switchable DNS provider behind the `DnsProvider` abstraction (fixes SSL issuance when ISP blocks port 53)
- Admin UI now served on dedicated LAN port 9080 — no longer exposed at any public domain
- Fix Traefik network isolation (sites returning 502 due to incorrect `coolify` network declaration)
- Bootstrap `coolify` Docker network in `start.sh` on fresh machines

## Changes

### Feature: Cloudflare DNS Provider
- `DnsProvider` interface extended with zone methods + `DnsZone` type
- `CloudflareProvider` — full 7-method Cloudflare v4 impl with parent-zone walk-up and zone-ID cache
- `TechnitiumProvider` — zone methods delegated to existing `TechnitiumClient`
- Factory reads `dns_provider` setting; routes to CF or Technitium
- `config.ts` — GET/PUT for `dns_provider`, `cloudflare_token`, `cloudflare_status`
- Settings UI — provider dropdown, token input, connection status badges, switch warning
- `docker-compose.yml` — `DNS_PROVIDER` + `CLOUDFLARE_TOKEN` env vars added

### Bug Fixes
- TS compile: null-check `mapRecord()` result in `addRecord`/`updateRecord`
- Volume `coolify-api-token` was mounted `:ro` — blocked config writes
- Zone lookup now walks up domain labels (`sub.domain.com` → `domain.com`)
- Zone query no longer filters `&status=active` — pending zones (e.g. `570n3r.com`) now visible
- Removed catch-all Traefik routes that exposed admin UI at any domain
- `coolify` network declared `external: true` — fixes 502 for Coolify-deployed sites
- `start.sh` bootstraps `coolify` network if missing on fresh machines

### Docs
- README updated: architecture diagram, DNS provider setup, port 9080, troubleshooting

## Test Plan

- [x] `probablyfine.shallowfordroad.com` loads over HTTPS (Playwright verified)
- [x] Admin UI accessible at `http://hammer:9080`
- [x] `shallowfordroad.com` no longer serves admin UI
- [x] `570n3r.com` (pending zone) viewable in DNS UI
- [x] Cloudflare token verified via `/user/tokens/verify`
- [x] All 5 QA-identified issues resolved and re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)