### PR TITLE
feat(dns): provider-agnostic backup/restore with v1 migration

### DIFF
--- a/api/src/services/backup.ts
+++ b/api/src/services/backup.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import { createCoolifyClient } from './coolify';
 import { createTechnitiumClient } from './technitium';
+import { createDnsProvider } from './dns';
 import { embedPatInRepoUrl, linkGithubKey } from '../routes/sites';
 import { readNsHostname } from '../routes/config';
 
@@ -18,7 +19,17 @@ export interface BackupSite {
   deploy_token?: string;
 }
 
+// v2 schema: provider-neutral normalized record
 export interface BackupDnsRecord {
+  name: string;
+  type: string;
+  ttl: number;
+  value: string;
+  priority?: number;
+}
+
+// v1 schema (legacy): Technitium-specific rData bag
+interface BackupDnsRecordV1 {
   name: string;
   type: string;
   ttl: number;
@@ -32,7 +43,7 @@ export interface BackupDnsZone {
 }
 
 export interface BackupFile {
-  version: 1;
+  version: 1 | 2;
   exported_at: string;
   sites: BackupSite[];
   dns_zones: BackupDnsZone[];
@@ -97,9 +108,61 @@ export interface ExportFilter {
   zones?: string[];   // same semantics
 }
 
+// ── v1 migration helpers ──────────────────────────────────────────────────────
+// Convert a Technitium-format v1 record (rData bag) to normalized v2 format.
+
+function normalizeV1Name(recordName: string, zoneName: string): string {
+  if (recordName === zoneName) return '@';
+  const suffix = `.${zoneName}`;
+  if (recordName.endsWith(suffix)) {
+    return recordName.slice(0, -suffix.length);
+  }
+  return recordName;
+}
+
+function extractV1Value(rData: Record<string, unknown>, type: string): string {
+  switch (type) {
+    case 'A':
+    case 'AAAA':   return String(rData.ipAddress ?? '');
+    case 'CNAME':  return String(rData.cname ?? '');
+    case 'MX':     return String(rData.exchange ?? '');
+    case 'TXT':    return String(rData.text ?? '');
+    case 'NS':     return String(rData.nameServer ?? '');
+    case 'SRV':    return String(rData.target ?? '');
+    case 'SOA':    return String(rData.primaryNameServer ?? '');
+    case 'CAA':    return rData.value !== undefined
+                     ? String(rData.value)
+                     : `${rData.flags ?? 0} ${rData.tag ?? ''} ""`;
+    case 'PTR':    return String(rData.ptrdname ?? '');
+    default:       return '';
+  }
+}
+
+function extractV1Priority(rData: Record<string, unknown>, type: string): number | undefined {
+  if (type === 'MX')  return rData.preference as number | undefined;
+  if (type === 'SRV') return rData.priority   as number | undefined;
+  return undefined;
+}
+
+function migrateV1Zone(zone: { name: string; type: string; records: BackupDnsRecordV1[] }): BackupDnsZone {
+  return {
+    name: zone.name,
+    type: zone.type,
+    records: zone.records.map(r => {
+      const name     = normalizeV1Name(r.name, zone.name);
+      const value    = extractV1Value(r.rData, r.type);
+      const priority = extractV1Priority(r.rData, r.type);
+      const out: BackupDnsRecord = { name, type: r.type, ttl: r.ttl, value };
+      if (priority !== undefined) out.priority = priority;
+      return out;
+    }),
+  };
+}
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
 export async function exportBackup(filter?: ExportFilter): Promise<BackupFile> {
   const coolify = createCoolifyClient();
-  const technitium = createTechnitiumClient();
 
   let sites: BackupSite[] = [];
   if (coolify) {
@@ -139,34 +202,38 @@ export async function exportBackup(filter?: ExportFilter): Promise<BackupFile> {
   }
 
   const dns_zones: BackupDnsZone[] = [];
-  // Skip Technitium calls entirely when zones filter is an empty array
   const skipZones = Array.isArray(filter?.zones) && filter!.zones.length === 0;
-  if (technitium && !skipZones) {
-    const zones = await technitium.listZones();
-    const allowedZones = Array.isArray(filter?.zones) ? new Set(filter!.zones) : null;
-    for (const zone of zones.filter(z => !z.internal)) {
-      if (allowedZones && !allowedZones.has(zone.name)) continue;
-      const result = await technitium.getRecords(zone.name).catch(() => null);
-      dns_zones.push({
-        name: zone.name,
-        type: zone.type,
-        records: result?.records.map(r => ({
-          name: r.name,
-          type: r.type,
-          ttl: r.ttl,
-          rData: r.rData as Record<string, unknown>,
-        })) ?? [],
-      });
-    }
+  if (!skipZones) {
+    try {
+      const provider = createDnsProvider();
+      const zones = await provider.listZones();
+      const allowedZones = Array.isArray(filter?.zones) ? new Set(filter!.zones) : null;
+      for (const zone of zones) {
+        if (zone.internal) continue;
+        if (allowedZones && !allowedZones.has(zone.name)) continue;
+        const records = await provider.getRecords(zone.name).catch(() => []);
+        dns_zones.push({
+          name: zone.name,
+          type: 'Primary',
+          records: records.map(r => {
+            const out: BackupDnsRecord = { name: r.name, type: r.type, ttl: r.ttl, value: r.value };
+            if (r.priority !== undefined) out.priority = r.priority;
+            return out;
+          }),
+        });
+      }
+    } catch { /* provider not configured — export sites-only */ }
   }
 
   return {
-    version: 1,
+    version: 2,
     exported_at: new Date().toISOString(),
     sites,
     dns_zones,
   };
 }
+
+// ── Validate ──────────────────────────────────────────────────────────────────
 
 export async function validateBackup(data: unknown): Promise<ValidationResult> {
   const errors: string[] = [];
@@ -178,11 +245,12 @@ export async function validateBackup(data: unknown): Promise<ValidationResult> {
   }
 
   const b = data as Record<string, unknown>;
-  if (b.version !== 1) errors.push('version must be 1');
+  if (b.version !== 1 && b.version !== 2) errors.push('version must be 1 or 2');
   if (!Array.isArray(b.sites)) errors.push('sites must be an array');
   if (!Array.isArray(b.dns_zones)) errors.push('dns_zones must be an array');
   if (errors.length) return { valid: false, errors, warnings, summary: empty };
 
+  const isV1 = b.version === 1;
   const sites = b.sites as Record<string, unknown>[];
   const dns_zones = b.dns_zones as Record<string, unknown>[];
 
@@ -193,7 +261,6 @@ export async function validateBackup(data: unknown): Promise<ValidationResult> {
     if (!s.domain) {
       errors.push(`${p}: domain is required`);
     } else {
-      // Validate FQDN format — strip protocol first if present
       const bare = (s.domain as string).replace(/^https?:\/\//, '').replace(/\/.*$/, '');
       if (!FQDN_RE.test(bare)) {
         errors.push(`${p}: domain '${bare}' is not a valid FQDN`);
@@ -220,7 +287,11 @@ export async function validateBackup(data: unknown): Promise<ValidationResult> {
       if (!r.name) errors.push(`${rp}: name is required`);
       if (!r.type) errors.push(`${rp}: type is required`);
       if (r.ttl === undefined || r.ttl === null) errors.push(`${rp}: ttl is required`);
-      if (!r.rData) errors.push(`${rp}: rData is required`);
+      if (isV1) {
+        if (!r.rData) errors.push(`${rp}: rData is required`);
+      } else {
+        if (r.value === undefined || r.value === null) errors.push(`${rp}: value is required`);
+      }
       if (r.type && !KNOWN_RECORD_TYPES.has(r.type as string)) {
         warnings.push(`${rp}: unknown record type '${r.type}'`);
       }
@@ -232,7 +303,6 @@ export async function validateBackup(data: unknown): Promise<ValidationResult> {
 
   // Warn on live conflicts
   const coolify = createCoolifyClient();
-  const technitium = createTechnitiumClient();
 
   if (coolify) {
     try {
@@ -246,20 +316,21 @@ export async function validateBackup(data: unknown): Promise<ValidationResult> {
     } catch { /* non-fatal */ }
   }
 
-  if (technitium) {
-    try {
-      const liveZones = await technitium.listZones();
-      const liveNames = new Set(liveZones.map(z => z.name));
-      for (const z of dns_zones) {
-        if (liveNames.has(z.name as string)) {
-          warnings.push(`DNS zone '${z.name}' already exists — records will be merged`);
-        }
+  try {
+    const provider = createDnsProvider();
+    const liveZones = await provider.listZones();
+    const liveNames = new Set(liveZones.map(z => z.name));
+    for (const z of dns_zones) {
+      if (liveNames.has(z.name as string)) {
+        warnings.push(`DNS zone '${z.name}' already exists — records will be merged`);
       }
-    } catch { /* non-fatal */ }
-  }
+    }
+  } catch { /* provider not configured — skip DNS conflict check */ }
 
   return { valid: true, errors: [], warnings, summary };
 }
+
+// ── Import ────────────────────────────────────────────────────────────────────
 
 export async function importBackup(data: BackupFile): Promise<ImportResult> {
   const result: ImportResult = {
@@ -268,7 +339,6 @@ export async function importBackup(data: BackupFile): Promise<ImportResult> {
   };
 
   const coolify = createCoolifyClient();
-  const technitium = createTechnitiumClient();
 
   if (coolify) {
     const liveSites = await coolify.listApplications().catch(() => []);
@@ -279,12 +349,10 @@ export async function importBackup(data: BackupFile): Promise<ImportResult> {
     let destination_uuid = '';
     try { destination_uuid = readFileSync('/coolify-api-token/destination_uuid', 'utf8').trim(); } catch { /* ok */ }
 
-    // Resolve project_uuid — handle race where two imports both try to create the project
     const projects = await coolify.getProjects().catch(() => []);
     let project_uuid = projects[0]?.uuid ?? '';
     if (!project_uuid) {
       const p = await coolify.createProject('hermithost-sites').catch(async (err: Error) => {
-        // If creation raced, fetch again
         if (err.message.toLowerCase().includes('already exists')) {
           const retry = await coolify.getProjects().catch(() => []);
           return retry[0] ?? null;
@@ -307,9 +375,6 @@ export async function importBackup(data: BackupFile): Promise<ImportResult> {
         const resolvedRepo = site.deploy_auth === 'pat' && site.deploy_token
           ? embedPatInRepoUrl(site.git_repository, site.deploy_token)
           : site.git_repository;
-        // Note: Coolify's type field refers to repo auth method, not visibility.
-        // 'public' = PAT/no-key auth, 'private' = SSH key auth. Both use the same
-        // /applications/public endpoint in our CoolifyClient.
         const app = await coolify.createApplication({
           type: site.deploy_auth === 'pat' ? 'public' : 'private',
           name: site.name,
@@ -332,7 +397,6 @@ export async function importBackup(data: BackupFile): Promise<ImportResult> {
           await coolify.updateApplication(app.uuid, { domains: coolifyDomain, force_domain_override: true }).catch(() => {});
           const dnsErr = await provisionSiteDns(site.domain);
           if (dnsErr) {
-            // Site created but DNS failed — report with warning suffix so user knows
             result.sites.created.push(`${site.name} [DNS provision failed: ${dnsErr}]`);
             continue;
           }
@@ -344,56 +408,80 @@ export async function importBackup(data: BackupFile): Promise<ImportResult> {
     }
   }
 
-  if (technitium) {
-    for (const zone of data.dns_zones) {
+  // Normalize zones: migrate v1 rData → v2 normalized records
+  const zones: BackupDnsZone[] = data.version === 1
+    ? (data.dns_zones as unknown as Array<{ name: string; type: string; records: BackupDnsRecordV1[] }>).map(migrateV1Zone)
+    : data.dns_zones;
+
+  try {
+    const provider = createDnsProvider();
+
+    for (const zone of zones) {
       try {
-        await technitium.createZone(zone.name, zone.type).catch((err: Error) => {
-          if (!err.message.toLowerCase().includes('already exists')) throw err;
-        });
-      } catch (err) {
-        result.dns.failed.push(`zone ${zone.name}: ${(err as Error).message}`);
-        continue;
+        await provider.createZone(zone.name);
+      } catch {
+        // Zone may already exist — provider error messages vary. Verify by listing.
+        const allZones = await provider.listZones().catch(() => []);
+        if (!allZones.some(z => z.name === zone.name)) {
+          result.dns.failed.push(`zone ${zone.name}: zone not found and could not be created`);
+          continue;
+        }
+        // Zone exists — proceed with record import
       }
 
+      // Fetch existing records once per zone — used for SOA check and duplicate detection
+      const existing = await provider.getRecords(zone.name).catch(() => []);
+      const existingSoa = existing.some(r => r.type === 'SOA');
+
       for (const record of zone.records) {
+        // SOA: skip if provider already auto-provisioned one
+        if (record.type === 'SOA' && existingSoa) {
+          result.dns.created.push(`${zone.name} SOA ${record.name} [skipped — auto-provisioned]`);
+          continue;
+        }
+
         try {
-          const params = new URLSearchParams();
-          params.set('type', record.type);
-          params.set('ttl', String(record.ttl));
-          for (const [key, value] of Object.entries(record.rData)) {
-            if (value !== undefined && value !== null) {
-              params.set(key, String(value));
-            }
-          }
-          if (record.type === 'SOA') {
-            await technitium.updateRecord(zone.name, params);
-            result.dns.created.push(`${zone.name} ${record.type} ${record.name}`);
-          } else {
-            let alreadyExists = false;
-            await technitium.addRecord(zone.name, params).catch((err: Error) => {
-              const msg = err.message.toLowerCase();
-              if (msg.includes('already exists') || msg.includes('duplicate')) {
-                alreadyExists = true;
-              } else {
-                throw err;
-              }
-            });
-            if (alreadyExists) {
-              try {
-                await technitium.deleteRecord(zone.name, params);
-                await technitium.addRecord(zone.name, params);
-                result.dns.created.push(`${zone.name} ${record.type} ${record.name} [replaced]`);
-              } catch (replaceErr) {
-                result.dns.failed.push(`${zone.name} ${record.type} ${record.name}: replace failed — ${(replaceErr as Error).message}`);
-              }
+          await provider.addRecord(zone.name, {
+            type: record.type as import('../types').DnsRecordType,
+            name: record.name,
+            value: record.value,
+            ttl: record.ttl,
+            ...(record.priority !== undefined ? { priority: record.priority } : {}),
+          });
+          result.dns.created.push(`${zone.name} ${record.type} ${record.name}`);
+        } catch {
+          // Duplicate detection: re-fetch and look for a matching record
+          try {
+            const current = await provider.getRecords(zone.name).catch(() => []);
+            const dup = current.find(r =>
+              r.type === record.type &&
+              r.name === record.name &&
+              r.value === record.value
+            );
+            if (dup) {
+              await provider.deleteRecord(zone.name, dup.id);
+              await provider.addRecord(zone.name, {
+                type: record.type as import('../types').DnsRecordType,
+                name: record.name,
+                value: record.value,
+                ttl: record.ttl,
+                ...(record.priority !== undefined ? { priority: record.priority } : {}),
+              });
+              result.dns.created.push(`${zone.name} ${record.type} ${record.name} [replaced]`);
             } else {
-              result.dns.created.push(`${zone.name} ${record.type} ${record.name}`);
+              result.dns.failed.push(`${zone.name} ${record.type} ${record.name}: add failed — no duplicate found`);
             }
+          } catch (replaceErr) {
+            result.dns.failed.push(`${zone.name} ${record.type} ${record.name}: ${(replaceErr as Error).message}`);
           }
-        } catch (err) {
-          result.dns.failed.push(`${zone.name} ${record.type} ${record.name}: ${(err as Error).message}`);
         }
       }
+    }
+  } catch (err) {
+    // Provider not configured — DNS import skipped
+    const msg = (err as Error).message;
+    for (const zone of zones) {
+      result.dns.failed.push(`zone ${zone.name}: DNS provider error — ${msg}`);
     }
   }
 

--- a/api/src/services/dns/CloudflareProvider.ts
+++ b/api/src/services/dns/CloudflareProvider.ts
@@ -68,14 +68,16 @@ export class CloudflareProvider implements DnsProvider {
     return zoneId;
   }
 
-  private async getZoneAndName(domain: string): Promise<{ zoneId: string; recordName: string }> {
+
+
+  private async getZoneAndName(domain: string): Promise<{ zoneId: string; recordName: string; zoneName: string }> {
     const parts = domain.split('.');
     for (let i = 0; i < parts.length - 1; i++) {
       const candidate = parts.slice(i).join('.');
       if (this.zoneCache.has(candidate)) {
         const zoneId = this.zoneCache.get(candidate)!;
         const recordName = i === 0 ? '@' : parts.slice(0, i).join('.');
-        return { zoneId, recordName };
+        return { zoneId, recordName, zoneName: candidate };
       }
       const zones = await this.cfFetch<CfZone[]>(
         `/zones?name=${encodeURIComponent(candidate)}`
@@ -84,7 +86,7 @@ export class CloudflareProvider implements DnsProvider {
         const zoneId = zones[0].id;
         this.zoneCache.set(candidate, zoneId);
         const recordName = i === 0 ? '@' : parts.slice(0, i).join('.');
-        return { zoneId, recordName };
+        return { zoneId, recordName, zoneName: candidate };
       }
     }
     throw new DnsOperationError(`Cloudflare zone not found for domain: ${domain}`, null);
@@ -94,15 +96,24 @@ export class CloudflareProvider implements DnsProvider {
     'A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'SRV', 'CAA', 'SOA', 'PTR',
   ]);
 
-  private mapRecord(r: CfRecord): DnsRecord | null {
+  private mapRecord(r: CfRecord, zoneName?: string): DnsRecord | null {
     if (!CloudflareProvider.VALID_RECORD_TYPES.has(r.type)) {
       console.warn(`Skipping unsupported Cloudflare record type: ${r.type}`);
       return null;
     }
+    // Normalize FQDN → relative name (e.g. "www.example.com" → "www", "example.com" → "@")
+    let name = r.name;
+    if (zoneName) {
+      if (name === zoneName) {
+        name = '@';
+      } else if (name.endsWith(`.${zoneName}`)) {
+        name = name.slice(0, -(zoneName.length + 1));
+      }
+    }
     return {
       id: r.id,
       type: r.type as DnsRecordType,
-      name: r.name,
+      name,
       value: r.content,
       ttl: r.ttl,
       ...(r.priority !== undefined ? { priority: r.priority } : {}),
@@ -146,13 +157,13 @@ export class CloudflareProvider implements DnsProvider {
 
   async getRecords(domain: string): Promise<DnsRecord[]> {
     try {
-      const { zoneId, recordName } = await this.getZoneAndName(domain);
+      const { zoneId, recordName, zoneName } = await this.getZoneAndName(domain);
       // If domain is the zone apex, return all records. If it's a subdomain,
       // filter to only records for that specific name — prevents sites on the
       // same parent zone from seeing each other's records.
       const nameFilter = recordName === '@' ? '' : `&name=${encodeURIComponent(domain)}`;
       const records = await this.cfFetch<CfRecord[]>(`/zones/${zoneId}/dns_records?per_page=100${nameFilter}`);
-      return records.map((r) => this.mapRecord(r)).filter((r): r is DnsRecord => r !== null);
+      return records.map((r) => this.mapRecord(r, zoneName)).filter((r): r is DnsRecord => r !== null);
     } catch (err) {
       throw new DnsOperationError('Failed to retrieve Cloudflare DNS records', err);
     }

--- a/api/src/services/dns/DnsProvider.ts
+++ b/api/src/services/dns/DnsProvider.ts
@@ -3,6 +3,7 @@ import type { DnsRecord } from '../../types';
 export interface DnsZone {
   name: string;
   disabled?: boolean;
+  internal?: boolean;
 }
 
 export interface DnsProvider {

--- a/api/src/services/dns/TechnitiumProvider.ts
+++ b/api/src/services/dns/TechnitiumProvider.ts
@@ -82,7 +82,7 @@ export class TechnitiumProvider implements DnsProvider {
   async listZones(): Promise<DnsZone[]> {
     try {
       const zones = await this.client.listZones();
-      return zones.map((z) => ({ name: z.name, disabled: z.disabled }));
+      return zones.map((z) => ({ name: z.name, disabled: z.disabled, internal: z.internal }));
     } catch (err) {
       throw new DnsOperationError('Failed to list DNS zones', err);
     }


### PR DESCRIPTION
## Summary

- DNS backup/restore now works across Technitium **and** Cloudflare — user only interacts with the HermitHost UI, backend is transparent
- Backup schema bumped to v2 (`value`/`priority` fields replace provider-specific `rData` bag)
- v1 Technitium backups still import cleanly via migration shim — no manual conversion needed
- SOA records included in export; import skips auto-provisioned SOA, adds it only if absent
- Cloudflare record names normalized to relative form on `getRecords` (was returning FQDNs)
- Zone creation failure now uses verify-by-listing instead of error-string matching (Cloudflare error messages differ from Technitium)

## Test plan

- [x] TC-01: v2 schema validation accepted
- [x] TC-02: v1 schema validation accepted (migration shim)
- [x] TC-03: Invalid backup rejected with meaningful errors
- [x] TC-04: Technitium export — v2 format, relative names, SOA present
- [x] TC-05: Technitium → Cloudflare import — records created
- [x] TC-06: Cloudflare export — relative names (not FQDNs)
- [x] TC-07: Cloudflare → Technitium import — records created
- [x] TC-08: v1 rData migration imports correctly
- [x] TC-09: SOA skipped if auto-provisioned, added if absent
- [x] TC-10: Duplicate records replaced (not failed)
- [x] TC-11: Existing zone handled gracefully

QA report: `clients/self/projects/hermithost/qa/qa-provider-agnostic-backup-2026-04-20.md` — 21/21 passed, zero P1/P2 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)