### PR TITLE
feat(internal-mode): internal SSL/TLS, traffic analytics, live stats, and page analytics

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,6 +2,9 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
+# better-sqlite3 requires native compilation
+RUN apk add --no-cache python3 make g++
+
 COPY package.json ./
 RUN npm install
 
@@ -19,7 +22,8 @@ ENV PORT=3001
 ENV HOST=0.0.0.0
 
 # git required for cloning hosted sites
-RUN apk add --no-cache git
+# python3/make/g++ required for better-sqlite3 native compilation
+RUN apk add --no-cache git python3 make g++
 
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package.json ./package.json

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,11 +9,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@types/pg": "^8.20.0",
+        "better-sqlite3": "^11.10.0",
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "pg": "^8.20.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.10",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/node": "^20.12.7",
@@ -89,6 +91,16 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -315,6 +327,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -326,6 +369,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -374,6 +437,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -445,6 +532,12 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -522,6 +615,30 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -539,6 +656,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -590,6 +716,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -633,6 +768,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -680,6 +824,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -729,6 +879,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -797,6 +953,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -901,6 +1063,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -917,6 +1099,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -1066,6 +1254,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -1083,7 +1283,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1102,10 +1301,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -1115,6 +1326,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/normalize-path": {
@@ -1164,7 +1387,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -1343,6 +1565,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1354,6 +1603,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -1393,6 +1652,35 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -1469,6 +1757,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.2",
@@ -1593,6 +1893,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1632,6 +1977,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -1646,7 +2000,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1663,6 +2016,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/to-regex-range": {
@@ -1789,6 +2170,18 @@
         "strip-json-comments": "^2.0.0"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1831,6 +2224,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1860,7 +2259,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/xtend": {

--- a/api/package.json
+++ b/api/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@types/pg": "^8.20.0",
-    "better-sqlite3": "^9.6.0",
+    "better-sqlite3": "^11.10.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "pg": "^8.20.0"

--- a/api/package.json
+++ b/api/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "@types/pg": "^8.20.0",
+    "better-sqlite3": "^9.6.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "pg": "^8.20.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.10",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.12.7",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -9,6 +9,7 @@ import configRouter from './routes/config';
 import statsRouter from './routes/stats';
 import { getDeployedSite } from './services/githubDeploy';
 import { startStatsIngester } from './services/statsIngester';
+import { startLiveStats } from './services/liveStats';
 import { readNsHostname, readNsServerIp } from './routes/config';
 import { createTechnitiumClient } from './services/technitium';
 import { ensureNsGlueRecords, cleanBadNsRecords } from './routes/sites';
@@ -68,6 +69,8 @@ app.listen(PORT, () => {
 
   // Start stats ingester (reads Traefik access log → SQLite rollups)
   startStatsIngester();
+  // Start live stats scraper (Traefik Prometheus → SSE)
+  startLiveStats();
 
   // Non-blocking DNS startup fixup — sets dnsServerDomain, creates glue records,
   // and removes stale container-ID NS records left from unconfigured Technitium.

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -6,7 +6,9 @@ import hostedRouter from './routes/hosted';
 import dnsRouter from './routes/dns';
 import backupRouter from './routes/backup';
 import configRouter from './routes/config';
+import statsRouter from './routes/stats';
 import { getDeployedSite } from './services/githubDeploy';
+import { startStatsIngester } from './services/statsIngester';
 import { readNsHostname, readNsServerIp } from './routes/config';
 import { createTechnitiumClient } from './services/technitium';
 import { ensureNsGlueRecords, cleanBadNsRecords } from './routes/sites';
@@ -25,6 +27,7 @@ app.use('/api/hosted', hostedRouter);
 app.use('/api/dns', dnsRouter);
 app.use('/api/backup', backupRouter);
 app.use('/api/config', configRouter);
+app.use('/api/sites/:slug/stats', statsRouter);
 
 // Dynamic static file serving for deployed sites
 // GET /hosted/:slug/* → serves from the site's detected serveDir
@@ -62,6 +65,9 @@ app.listen(PORT, () => {
   } else {
     console.warn('[technitium] TECHNITIUM_URL not set — DNS routes will fail at startup');
   }
+
+  // Start stats ingester (reads Traefik access log → SQLite rollups)
+  startStatsIngester();
 
   // Non-blocking DNS startup fixup — sets dnsServerDomain, creates glue records,
   // and removes stale container-ID NS records left from unconfigured Technitium.

--- a/api/src/routes/config.ts
+++ b/api/src/routes/config.ts
@@ -9,6 +9,8 @@ const NS_HOSTNAME_FILE = '/coolify-api-token/ns_hostname';
 const DNS_PROVIDER_FILE = '/coolify-api-token/dns_provider';
 const CLOUDFLARE_TOKEN_FILE = '/coolify-api-token/cloudflare_token';
 const NETWORK_MODE_FILE = '/coolify-api-token/network_mode';
+const DNS_FORWARDER_1_FILE = '/coolify-api-token/dns_forwarder_1';
+const DNS_FORWARDER_2_FILE = '/coolify-api-token/dns_forwarder_2';
 
 // network_mode read precedence:
 // 1. File /coolify-api-token/network_mode
@@ -46,6 +48,17 @@ export function readNsServerIp(): string | null {
     if (val) return val;
   } catch { /* file not present */ }
   return process.env.NS_SERVER_IP ?? null;
+}
+
+export function readDnsForwarders(): [string, string] {
+  const read = (file: string, envKey: string): string => {
+    try {
+      const val = readFileSync(file, 'utf8').trim();
+      if (val) return val;
+    } catch { /* not set */ }
+    return process.env[envKey] ?? '';
+  };
+  return [read(DNS_FORWARDER_1_FILE, 'DNS_FORWARDER_1'), read(DNS_FORWARDER_2_FILE, 'DNS_FORWARDER_2')];
 }
 
 function readSetting(key: string): string | null {
@@ -109,6 +122,8 @@ router.get('/', async (_req: Request, res: Response) => {
 
     res.status(200).json({
       ns_hostname: readNsHostname(),
+      ns_server_ip: readNsServerIp(),
+      dns_forwarders: readDnsForwarders(),
       acme_email: process.env.ACME_EMAIL ?? null,
       coolify_url: process.env.COOLIFY_API_URL ?? null,
       coolify_status,
@@ -129,19 +144,23 @@ router.get('/', async (_req: Request, res: Response) => {
 router.put('/', async (req: Request, res: Response) => {
   const body = req.body as {
     ns_hostname?: unknown;
+    ns_server_ip?: unknown;
     dns_provider?: unknown;
     cloudflare_token?: unknown;
     network_mode?: unknown;
+    dns_forwarders?: unknown;
   };
 
   // Validate at least one known key is present
   const hasNsHostname = typeof body.ns_hostname === 'string' && body.ns_hostname.trim();
+  const hasNsServerIp = typeof body.ns_server_ip === 'string' && body.ns_server_ip.trim();
   const hasDnsProvider = typeof body.dns_provider === 'string' && body.dns_provider.trim();
   const hasCfToken = typeof body.cloudflare_token === 'string';
   const hasNetworkMode = typeof body.network_mode === 'string' && body.network_mode.trim();
+  const hasDnsForwarders = Array.isArray(body.dns_forwarders);
 
-  if (!hasNsHostname && !hasDnsProvider && !hasCfToken && !hasNetworkMode) {
-    res.status(400).json({ error: 'At least one field required: ns_hostname, dns_provider, cloudflare_token, network_mode' });
+  if (!hasNsHostname && !hasNsServerIp && !hasDnsProvider && !hasCfToken && !hasNetworkMode && !hasDnsForwarders) {
+    res.status(400).json({ error: 'At least one field required: ns_hostname, ns_server_ip, dns_provider, cloudflare_token, network_mode, dns_forwarders' });
     return;
   }
 
@@ -174,6 +193,25 @@ router.put('/', async (req: Request, res: Response) => {
         );
       }
       result.ns_hostname = value;
+    }
+
+    if (hasNsServerIp) {
+      const value = (body.ns_server_ip as string).trim();
+      writeFileSync(NS_SERVER_IP_FILE, value, 'utf8');
+      result.ns_server_ip = value;
+    }
+
+    if (hasDnsForwarders) {
+      const [f1, f2] = (body.dns_forwarders as unknown[]).map(f => String(f ?? '').trim());
+      writeFileSync(DNS_FORWARDER_1_FILE, f1 ?? '', 'utf8');
+      writeFileSync(DNS_FORWARDER_2_FILE, f2 ?? '', 'utf8');
+      const technitium = createTechnitiumClient();
+      if (technitium) {
+        technitium.setForwarders([f1 ?? '', f2 ?? '']).catch((e: Error) =>
+          console.warn('[config] setForwarders after PUT failed:', e.message)
+        );
+      }
+      result.dns_forwarders = JSON.stringify([f1 ?? '', f2 ?? '']);
     }
 
     if (hasDnsProvider) {

--- a/api/src/routes/config.ts
+++ b/api/src/routes/config.ts
@@ -8,6 +8,19 @@ const router = Router();
 const NS_HOSTNAME_FILE = '/coolify-api-token/ns_hostname';
 const DNS_PROVIDER_FILE = '/coolify-api-token/dns_provider';
 const CLOUDFLARE_TOKEN_FILE = '/coolify-api-token/cloudflare_token';
+const NETWORK_MODE_FILE = '/coolify-api-token/network_mode';
+
+// network_mode read precedence:
+// 1. File /coolify-api-token/network_mode
+// 2. process.env.NETWORK_MODE
+// 3. 'external'
+export function readNetworkMode(): 'external' | 'internal' {
+  try {
+    const val = readFileSync(NETWORK_MODE_FILE, 'utf8').trim();
+    if (val === 'internal') return 'internal';
+  } catch { /* file not present */ }
+  return process.env.NETWORK_MODE === 'internal' ? 'internal' : 'external';
+}
 
 // NS_HOSTNAME read precedence:
 // 1. File /coolify-api-token/ns_hostname
@@ -104,6 +117,7 @@ router.get('/', async (_req: Request, res: Response) => {
       dns_provider,
       cloudflare_status,
       cloudflare_token_set: !!cfToken,
+      network_mode: readNetworkMode(),
     });
   } catch (err) {
     console.error('[config] GET failed:', (err as Error).message);
@@ -117,21 +131,29 @@ router.put('/', async (req: Request, res: Response) => {
     ns_hostname?: unknown;
     dns_provider?: unknown;
     cloudflare_token?: unknown;
+    network_mode?: unknown;
   };
 
   // Validate at least one known key is present
   const hasNsHostname = typeof body.ns_hostname === 'string' && body.ns_hostname.trim();
   const hasDnsProvider = typeof body.dns_provider === 'string' && body.dns_provider.trim();
   const hasCfToken = typeof body.cloudflare_token === 'string';
+  const hasNetworkMode = typeof body.network_mode === 'string' && body.network_mode.trim();
 
-  if (!hasNsHostname && !hasDnsProvider && !hasCfToken) {
-    res.status(400).json({ error: 'At least one field required: ns_hostname, dns_provider, cloudflare_token' });
+  if (!hasNsHostname && !hasDnsProvider && !hasCfToken && !hasNetworkMode) {
+    res.status(400).json({ error: 'At least one field required: ns_hostname, dns_provider, cloudflare_token, network_mode' });
     return;
   }
 
   // Validate dns_provider enum if provided
   if (hasDnsProvider && !['technitium', 'cloudflare'].includes((body.dns_provider as string).trim())) {
     res.status(400).json({ error: 'dns_provider must be "technitium" or "cloudflare"' });
+    return;
+  }
+
+  // Validate network_mode enum if provided
+  if (hasNetworkMode && !['external', 'internal', 'mixed'].includes((body.network_mode as string).trim())) {
+    res.status(400).json({ error: 'network_mode must be "external" or "internal"' });
     return;
   }
 
@@ -168,10 +190,29 @@ router.put('/', async (req: Request, res: Response) => {
       result.cloudflare_status = cloudflare_status;
     }
 
+    if (hasNetworkMode) {
+      const value = (body.network_mode as string).trim() as 'external' | 'internal' | 'mixed';
+      writeFileSync(NETWORK_MODE_FILE, value, 'utf8');
+      result.network_mode = value;
+    }
+
     res.status(200).json(result);
   } catch (err) {
     console.error('[config] PUT failed:', (err as Error).message);
     res.status(500).json({ error: 'Failed to write config' });
+  }
+});
+
+// GET /api/config/trust-certificate
+router.get('/trust-certificate', (_req: Request, res: Response) => {
+  const certPath = '/home/step/certs/root_ca.crt';
+  try {
+    const cert = readFileSync(certPath);
+    res.setHeader('Content-Type', 'application/x-x509-ca-cert');
+    res.setHeader('Content-Disposition', 'attachment; filename="hermithost-trust.crt"');
+    res.send(cert);
+  } catch {
+    res.status(404).json({ error: 'Trust certificate not available — internal mode not configured' });
   }
 });
 

--- a/api/src/routes/dns.ts
+++ b/api/src/routes/dns.ts
@@ -14,7 +14,7 @@ router.get('/zones', async (_req: Request, res: Response) => {
   try {
     const provider = createDnsProvider();
     const zones = await provider.listZones();
-    res.status(200).json(zones);
+    res.status(200).json(zones.filter((z) => !z.internal && !z.name.endsWith('.arpa')));
   } catch (err) {
     console.error('[dns] GET /zones failed:', (err as Error).message);
     res.status(502).json({ error: 'Failed to retrieve zones from DNS server' });

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -576,8 +576,25 @@ router.post('/', async (req: Request, res: Response) => {
 router.delete('/:slug', async (req: Request, res: Response) => {
   try {
     const client = createCoolifyClient()!;
+    // Fetch domain before deleting so we can clean up DNS
+    const app = await client.getApplication(req.params.slug).catch(() => null);
+    const domain = app?.fqdn
+      ? app.fqdn.split(',')[0].trim().replace(/^https?:\/\//, '').replace(/\/.*$/, '')
+      : '';
+
     await client.deleteApplication(req.params.slug);
     removeTraefikRoute(req.params.slug);
+
+    // Non-fatal DNS teardown — delete zone created by provisionDns
+    if (domain) {
+      const provider = createDnsProvider();
+      if (provider) {
+        provider.deleteZone(domain).catch((err: unknown) => {
+          console.warn(`[dns-teardown] Failed to delete zone ${domain}:`, (err as Error).message);
+        });
+      }
+    }
+
     res.status(204).send();
   } catch (err) {
     console.error(`[coolify] DELETE /applications/${req.params.slug} failed:`, (err as Error).message);

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -42,6 +42,30 @@ function writeStoredDeployAuth(uuid: string, auth: 'ssh_key' | 'pat'): void {
   }
 }
 
+// ── Visibility sidecar (Option C stub) ────────────────────────────────────────
+// Persists per-site visibility so Option C (dual-mode) can be added without
+// changing site creation logic. Default matches current network_mode.
+// Values now: 'internal' | 'external'. Option C adds: 'both'.
+function readStoredVisibility(uuid: string): 'internal' | 'external' {
+  try {
+    const { mkdirSync: _mkdir } = require('fs') as typeof import('fs');
+    _mkdir(SITES_DIR, { recursive: true });
+    const val = readFileSync(path.join(SITES_DIR, `${uuid}.visibility`), 'utf8').trim();
+    if (val === 'internal' || val === 'external') return val;
+  } catch { /* not stored yet — fall through to default */ }
+  return readNetworkMode() === 'internal' ? 'internal' : 'external';
+}
+
+function writeStoredVisibility(uuid: string, visibility: 'internal' | 'external'): void {
+  try {
+    const { mkdirSync: _mkdir } = require('fs') as typeof import('fs');
+    _mkdir(SITES_DIR, { recursive: true });
+    writeFileSync(path.join(SITES_DIR, `${uuid}.visibility`), visibility, 'utf8');
+  } catch (err) {
+    console.warn(`[visibility] Could not write visibility sidecar for ${uuid}:`, (err as Error).message);
+  }
+}
+
 function mapSiteWithStoredAuth(
   app: Parameters<typeof mapSite>[0],
   deployments: Parameters<typeof mapSite>[1],
@@ -55,6 +79,7 @@ function mapSiteWithStoredAuth(
 
 // ── DNS auto-provisioning ─────────────────────────────────────────────────────
 // Creates a zone + A record for the given domain pointing at NS_SERVER_IP.
+// In internal mode: uses Technitium directly; zone is under .hh TLD.
 // Non-fatal: logs warnings but never throws — site ops should not fail due to DNS.
 export async function provisionDns(fqdn: string): Promise<void> {
   const serverIp = readNsServerIp();
@@ -65,6 +90,49 @@ export async function provisionDns(fqdn: string): Promise<void> {
   // Strip protocol and trailing slashes to get bare domain
   const domain = fqdn.replace(/^https?:\/\//, '').replace(/\/.*$/, '').trim();
   if (!domain) return;
+
+  const isInternal = readNetworkMode() === 'internal';
+
+  if (isInternal) {
+    // Internal mode: always use Technitium; ensure .hh root zone exists first
+    const technitium = createTechnitiumClient();
+    if (!technitium) {
+      console.warn('[dns-provision] Technitium not configured — skipping internal DNS provisioning');
+      return;
+    }
+    // Ensure .hh root zone exists (idempotent)
+    try {
+      await technitium.createZone('hh', 'Primary');
+      console.log('[dns-provision] .hh root zone ensured');
+    } catch (err) {
+      const msg = (err as Error).message ?? '';
+      if (!msg.toLowerCase().includes('already exists')) {
+        console.warn('[dns-provision] .hh root zone create warning:', msg);
+      }
+    }
+    // Create zone for this site (e.g. mysite.hh)
+    try {
+      await technitium.createZone(domain, 'Primary');
+      console.log(`[dns-provision] Internal zone created: ${domain}`);
+    } catch (err) {
+      const msg = (err as Error).message ?? '';
+      if (!msg.toLowerCase().includes('already exists')) {
+        console.warn(`[dns-provision] Internal zone create warning for ${domain}:`, msg);
+      }
+    }
+    // Add A record
+    try {
+      const params = new URLSearchParams();
+      params.set('type', 'A');
+      params.set('ttl', '3600');
+      params.set('ipAddress', serverIp);
+      await technitium.addRecord(domain, params);
+      console.log(`[dns-provision] Internal A record created: ${domain} → ${serverIp}`);
+    } catch (err) {
+      console.warn(`[dns-provision] Internal A record warning for ${domain}:`, (err as Error).message);
+    }
+    return;
+  }
 
   const provider = createDnsProvider();
 
@@ -479,7 +547,10 @@ router.post('/', async (req: Request, res: Response) => {
     }
 
     // fqdn is not accepted at creation time — patch it immediately after using 'domains' field
-    const resolvedFqdn = body.fqdn ?? body.domain;
+    // In internal mode, override domain to ${slug}.hh regardless of user input
+    const nameSlug = body.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    const internalDomain = readNetworkMode() === 'internal' ? `${nameSlug}.hh` : null;
+    const resolvedFqdn = internalDomain ?? (body.fqdn ?? body.domain);
     if (resolvedFqdn) {
       // Coolify requires full URL format — add https:// if no protocol present
       const coolifyDomain = /^https?:\/\//i.test(resolvedFqdn) ? resolvedFqdn : `https://${resolvedFqdn}`;
@@ -493,6 +564,7 @@ router.post('/', async (req: Request, res: Response) => {
       // Route file written after first deploy (container doesn't exist yet at creation time)
     }
     writeStoredDeployAuth(app.uuid, deployAuth);
+    writeStoredVisibility(app.uuid, readNetworkMode() === 'internal' ? 'internal' : 'external');
     res.status(201).json(mapSiteWithStoredAuth(app, []));
   } catch (err) {
     console.error('[coolify] POST /applications/public failed:', (err as Error).message);

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -12,7 +12,7 @@ import { mapSite, mapDeploy } from '../services/mapper';
 import { probeSite } from '../services/healthProbe';
 import { createDnsProvider, DnsOperationError } from '../services/dns';
 import { createTechnitiumClient, TechnitiumClient } from '../services/technitium';
-import { readNsHostname, readNsServerIp } from './config';
+import { readNsHostname, readNsServerIp, readNetworkMode } from './config';
 
 const router = Router();
 
@@ -227,7 +227,12 @@ function dockerGet(path: string): Promise<unknown> {
   });
 }
 
-export async function provisionTraefikRoute(slug: string, domain: string, port: number | string = 3000): Promise<void> {
+export async function provisionTraefikRoute(
+  slug: string,
+  domain: string,
+  port: number | string = 3000,
+  resolver: 'letsencrypt' | 'internal-ca' = 'letsencrypt'
+): Promise<void> {
   const confDir = TRAEFIK_CONF_DIR;
   const filePath = path.join(confDir, `site-${slug}.yml`);
   try {
@@ -254,7 +259,7 @@ export async function provisionTraefikRoute(slug: string, domain: string, port: 
       entryPoints:
         - https
       tls:
-        certResolver: letsencrypt
+        certResolver: ${resolver}
       service: site-${slug}
 
   services:
@@ -611,7 +616,8 @@ router.patch('/:slug', async (req: Request, res: Response) => {
     const currentDomain = app.fqdn ? app.fqdn.split(',')[0].trim().replace(/^https?:\/\//, '').replace(/\/.*$/, '') : '';
     if (currentDomain) {
       const port = (app as any).ports_exposes ?? 3000;
-      await provisionTraefikRoute(req.params.slug, currentDomain, port);
+      const resolver = readNetworkMode() === 'internal' ? 'internal-ca' : 'letsencrypt';
+      await provisionTraefikRoute(req.params.slug, currentDomain, port, resolver);
     }
     if (switchingAuth) writeStoredDeployAuth(req.params.slug, body.deploy_auth!);
     const result = mapSiteWithStoredAuth(app, []);
@@ -777,7 +783,8 @@ router.post('/:slug/deploy', async (req: Request, res: Response) => {
             const containers = await dockerGet(`/containers/json?filters=${filter}`) as Array<{ Names: string[]; State: string }>;
             const running = containers.find(c => c.State === 'running');
             if (running) {
-              await provisionTraefikRoute(slug, domain, port);
+              const resolver = readNetworkMode() === 'internal' ? 'internal-ca' : 'letsencrypt';
+              await provisionTraefikRoute(slug, domain, port, resolver);
               break;
             }
           } catch {

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from 'express';
 import { querySiteStats, queryPulse, StatRange } from '../services/stats';
+import { liveStatsEmitter, LiveSnapshot } from '../services/liveStats';
 
 const router = Router({ mergeParams: true });
 
@@ -38,6 +39,46 @@ router.get('/pulse', (req: Request, res: Response) => {
     console.error(`[stats] GET /stats/pulse for ${slug} failed:`, (err as Error).message);
     res.status(500).json({ error: 'Failed to query pulse stats' });
   }
+});
+
+// ── GET /api/sites/:slug/stats/live — Server-Sent Events ─────────────────────
+// Streams live Prometheus-derived stats every 3s.
+// Client connects once; server pushes updates until disconnect.
+router.get('/live', (req: Request, res: Response) => {
+  const { slug } = req.params;
+  const routerName = `site-${slug}`;
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no'); // disable nginx/proxy buffering
+  res.flushHeaders();
+
+  // Send a keep-alive comment every 20s to prevent proxy timeouts
+  const keepAlive = setInterval(() => {
+    res.write(': keep-alive\n\n');
+  }, 20_000);
+
+  const onSnapshot = (snapshots: LiveSnapshot[]) => {
+    const snap = snapshots.find(s => s.routerName === routerName);
+    const payload: LiveSnapshot = snap ?? {
+      routerName,
+      reqPerSec: 0,
+      avgLatencyMs: null,
+      activeConnections: 0,
+      bandwidthOutBps: 0,
+      bandwidthInBps: 0,
+      ts: Date.now(),
+    };
+    res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  };
+
+  liveStatsEmitter.on('snapshot', onSnapshot);
+
+  req.on('close', () => {
+    clearInterval(keepAlive);
+    liveStatsEmitter.off('snapshot', onSnapshot);
+  });
 });
 
 export default router;

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { querySiteStats, queryPulse, StatRange } from '../services/stats';
+import { querySiteStats, queryPulse, queryPageStats, StatRange } from '../services/stats';
 import { liveStatsEmitter, LiveSnapshot } from '../services/liveStats';
 
 const router = Router({ mergeParams: true });
@@ -79,6 +79,25 @@ router.get('/live', (req: Request, res: Response) => {
     clearInterval(keepAlive);
     liveStatsEmitter.off('snapshot', onSnapshot);
   });
+});
+
+// ── GET /api/sites/:slug/stats/pages?range=24h|7d|30d ────────────────────────
+router.get('/pages', (req: Request, res: Response) => {
+  const { slug } = req.params;
+  const range = (req.query.range as string) ?? '24h';
+
+  if (!VALID_RANGES.has(range as StatRange)) {
+    res.status(400).json({ error: 'range must be one of: 24h, 7d, 30d' });
+    return;
+  }
+
+  try {
+    const result = queryPageStats(`site-${slug}`, range as StatRange);
+    res.status(200).json(result);
+  } catch (err) {
+    console.error(`[stats] GET /pages for ${slug} failed:`, (err as Error).message);
+    res.status(500).json({ error: 'Failed to query page stats' });
+  }
 });
 
 export default router;

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -1,0 +1,43 @@
+import { Router, Request, Response } from 'express';
+import { querySiteStats, queryPulse, StatRange } from '../services/stats';
+
+const router = Router({ mergeParams: true });
+
+const VALID_RANGES = new Set<StatRange>(['24h', '7d', '30d']);
+
+// ── GET /api/sites/:slug/stats?range=24h|7d|30d ───────────────────────────────
+router.get('/', (req: Request, res: Response) => {
+  const { slug } = req.params;
+  const range = (req.query.range as string) ?? '24h';
+
+  if (!VALID_RANGES.has(range as StatRange)) {
+    res.status(400).json({ error: 'range must be one of: 24h, 7d, 30d' });
+    return;
+  }
+
+  try {
+    const routerName = `site-${slug}`;
+    const result = querySiteStats(routerName, range as StatRange);
+    res.status(200).json(result);
+  } catch (err) {
+    console.error(`[stats] GET /stats for ${slug} failed:`, (err as Error).message);
+    res.status(500).json({ error: 'Failed to query stats' });
+  }
+});
+
+// ── GET /api/sites/:slug/stats/pulse ─────────────────────────────────────────
+// Returns 96 × 15-min buckets for the pulse strip (last 24h)
+router.get('/pulse', (req: Request, res: Response) => {
+  const { slug } = req.params;
+
+  try {
+    const routerName = `site-${slug}`;
+    const result = queryPulse(routerName);
+    res.status(200).json(result);
+  } catch (err) {
+    console.error(`[stats] GET /stats/pulse for ${slug} failed:`, (err as Error).message);
+    res.status(500).json({ error: 'Failed to query pulse stats' });
+  }
+});
+
+export default router;

--- a/api/src/services/backup.ts
+++ b/api/src/services/backup.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { createCoolifyClient } from './coolify';
 import { createTechnitiumClient } from './technitium';
 import { embedPatInRepoUrl, linkGithubKey } from '../routes/sites';
-import { readNsHostname } from '../routes/config';
+import { readNsHostname, readNsServerIp, readNetworkMode } from '../routes/config';
 
 // Basic FQDN pattern — rejects bare hostnames, IPs, and embedded paths.
 // Allows subdomains (sub.example.com) and TLDs of 2-24 chars.
@@ -66,10 +66,12 @@ function extractPat(repoUrl: string): { cleanUrl: string; token: string } | null
 }
 
 // Provision DNS A record for a site domain — tracked version that returns success/failure.
+// In internal mode: uses NS_SERVER_IP (LAN IP), creates ${slug}.hh zone in Technitium.
 // Non-fatal: failures are returned as a string, never thrown.
 async function provisionSiteDns(domain: string): Promise<string | null> {
-  const serverIp = readNsHostname();
-  if (!serverIp) return 'NS_HOSTNAME not set';
+  const isInternal = readNetworkMode() === 'internal';
+  const serverIp = isInternal ? readNsServerIp() : readNsHostname();
+  if (!serverIp) return isInternal ? 'NS_SERVER_IP not set' : 'NS_HOSTNAME not set';
 
   const bare = domain.replace(/^https?:\/\//, '').replace(/\/.*$/, '').trim();
   if (!bare) return 'empty domain';
@@ -78,6 +80,12 @@ async function provisionSiteDns(domain: string): Promise<string | null> {
   if (!client) return 'Technitium not configured';
 
   try {
+    if (isInternal) {
+      // Ensure .hh root zone exists
+      await client.createZone('hh', 'Primary').catch((err: Error) => {
+        if (!err.message.toLowerCase().includes('already exists')) throw err;
+      });
+    }
     await client.createZone(bare, 'Primary').catch((err: Error) => {
       if (!err.message.toLowerCase().includes('already exists')) throw err;
     });

--- a/api/src/services/dns/DnsProvider.ts
+++ b/api/src/services/dns/DnsProvider.ts
@@ -3,6 +3,7 @@ import type { DnsRecord } from '../../types';
 export interface DnsZone {
   name: string;
   disabled?: boolean;
+  internal?: boolean;
 }
 
 export interface DnsProvider {

--- a/api/src/services/dns/TechnitiumProvider.ts
+++ b/api/src/services/dns/TechnitiumProvider.ts
@@ -82,7 +82,7 @@ export class TechnitiumProvider implements DnsProvider {
   async listZones(): Promise<DnsZone[]> {
     try {
       const zones = await this.client.listZones();
-      return zones.map((z) => ({ name: z.name, disabled: z.disabled }));
+      return zones.map((z) => ({ name: z.name, disabled: z.disabled, internal: z.internal }));
     } catch (err) {
       throw new DnsOperationError('Failed to list DNS zones', err);
     }

--- a/api/src/services/liveStats.ts
+++ b/api/src/services/liveStats.ts
@@ -1,0 +1,183 @@
+import { EventEmitter } from 'events';
+import http from 'http';
+
+const TRAEFIK_METRICS_URL = process.env.TRAEFIK_METRICS_URL ?? 'http://traefik:8080/metrics';
+const SCRAPE_INTERVAL_MS = Number(process.env.LIVE_STATS_INTERVAL_MS ?? 3_000);
+
+export const liveStatsEmitter = new EventEmitter();
+liveStatsEmitter.setMaxListeners(200); // support many concurrent SSE clients
+
+export interface LiveSnapshot {
+  routerName: string;    // "site-{slug}"
+  reqPerSec: number;
+  avgLatencyMs: number | null;
+  activeConnections: number; // aggregate entrypoint-level gauge
+  bandwidthOutBps: number;   // aggregate bytes/sec out
+  bandwidthInBps: number;    // aggregate bytes/sec in
+  ts: number;
+}
+
+// ── Prometheus text format parser ─────────────────────────────────────────────
+interface ParsedMetric {
+  name: string;
+  labels: Record<string, string>;
+  value: number;
+}
+
+function parsePrometheusText(text: string): ParsedMetric[] {
+  const results: ParsedMetric[] = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    // metric_name{label="val",...} 1234.5 [timestamp]
+    const m = trimmed.match(/^([a-zA-Z_:][a-zA-Z0-9_:]*)\{([^}]*)\}\s+([\d.e+\-]+(?:NaN|Inf)?)/);
+    if (!m) continue;
+    const value = parseFloat(m[3]);
+    if (isNaN(value)) continue;
+    const labels: Record<string, string> = {};
+    for (const kv of m[2].split(',')) {
+      const eq = kv.indexOf('=');
+      if (eq < 0) continue;
+      const k = kv.slice(0, eq).trim();
+      const v = kv.slice(eq + 1).trim().replace(/^"|"$/g, '');
+      labels[k] = v;
+    }
+    results.push({ name: m[1], labels, value });
+  }
+  return results;
+}
+
+// ── Previous counter values for delta computation ─────────────────────────────
+interface CounterState {
+  requestsTotal: Map<string, number>;        // key = routerName
+  durationSecsTotal: Map<string, number>;    // key = routerName
+  bytesSentTotal: number;
+  bytesReceivedTotal: number;
+  lastTs: number;
+}
+
+const prev: CounterState = {
+  requestsTotal: new Map(),
+  durationSecsTotal: new Map(),
+  bytesSentTotal: 0,
+  bytesReceivedTotal: 0,
+  lastTs: 0,
+};
+
+// ── Fetch metrics from Traefik ────────────────────────────────────────────────
+function fetchMetrics(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(TRAEFIK_METRICS_URL, (res) => {
+      let body = '';
+      res.on('data', (chunk: Buffer) => { body += chunk; });
+      res.on('end', () => resolve(body));
+    });
+    req.on('error', reject);
+    req.setTimeout(2500, () => { req.destroy(); reject(new Error('metrics fetch timeout')); });
+  });
+}
+
+// ── Main scrape function ──────────────────────────────────────────────────────
+async function scrape(): Promise<void> {
+  const now = Date.now();
+  let text: string;
+  try {
+    text = await fetchMetrics();
+  } catch {
+    // Traefik not reachable — emit zeros and return
+    liveStatsEmitter.emit('snapshot', [] as LiveSnapshot[]);
+    return;
+  }
+
+  const metrics = parsePrometheusText(text);
+  const intervalSecs = prev.lastTs > 0 ? (now - prev.lastTs) / 1000 : SCRAPE_INTERVAL_MS / 1000;
+
+  // Aggregate current counter values by router
+  const curRequests = new Map<string, number>();
+  const curDuration = new Map<string, number>();
+  let curBytesSent = 0;
+  let curBytesReceived = 0;
+  let activeConnections = 0;
+
+  for (const { name, labels, value } of metrics) {
+    switch (name) {
+      case 'traefik_router_requests_total': {
+        const router = labels['router'];
+        if (!router) break;
+        const existing = curRequests.get(router) ?? 0;
+        curRequests.set(router, existing + value);
+        break;
+      }
+      case 'traefik_router_request_duration_seconds_sum': {
+        const router = labels['router'];
+        if (!router) break;
+        const existing = curDuration.get(router) ?? 0;
+        curDuration.set(router, existing + value);
+        break;
+      }
+      case 'traefik_entrypoint_responses_bytes_total':
+        curBytesSent += value;
+        break;
+      case 'traefik_entrypoint_requests_bytes_total':
+        curBytesReceived += value;
+        break;
+      case 'traefik_entrypoint_open_connections':
+        activeConnections += value;
+        break;
+    }
+  }
+
+  // Compute aggregate bandwidth deltas
+  const bandwidthOutBps = prev.lastTs > 0
+    ? Math.max(0, (curBytesSent - prev.bytesSentTotal) / intervalSecs)
+    : 0;
+  const bandwidthInBps = prev.lastTs > 0
+    ? Math.max(0, (curBytesReceived - prev.bytesReceivedTotal) / intervalSecs)
+    : 0;
+
+  // Build per-router snapshots
+  const snapshots: LiveSnapshot[] = [];
+  for (const [router, curReqs] of curRequests) {
+    // Normalize: "site-myapp@file" → "site-myapp"
+    const routerName = router.replace(/@\w+$/, '');
+    if (!routerName.startsWith('site-')) continue;
+
+    const prevReqs = prev.requestsTotal.get(router) ?? curReqs;
+    const reqDelta = Math.max(0, curReqs - prevReqs);
+    const reqPerSec = prev.lastTs > 0 ? reqDelta / intervalSecs : 0;
+
+    const curDur = curDuration.get(router) ?? 0;
+    const prevDur = prev.durationSecsTotal.get(router) ?? curDur;
+    const durDelta = Math.max(0, curDur - prevDur);
+    const avgLatencyMs = reqDelta > 0 ? (durDelta / reqDelta) * 1000 : null;
+
+    snapshots.push({
+      routerName,
+      reqPerSec,
+      avgLatencyMs,
+      activeConnections,
+      bandwidthOutBps,
+      bandwidthInBps,
+      ts: now,
+    });
+  }
+
+  // Update prev state
+  prev.requestsTotal = curRequests;
+  prev.durationSecsTotal = curDuration;
+  prev.bytesSentTotal = curBytesSent;
+  prev.bytesReceivedTotal = curBytesReceived;
+  prev.lastTs = now;
+
+  liveStatsEmitter.emit('snapshot', snapshots);
+}
+
+// ── Start ─────────────────────────────────────────────────────────────────────
+export function startLiveStats(): void {
+  console.log(`[live-stats] Starting — url=${TRAEFIK_METRICS_URL}, interval=${SCRAPE_INTERVAL_MS}ms`);
+  setInterval(async () => {
+    try { await scrape(); } catch (err) {
+      console.warn('[live-stats] Scrape error:', (err as Error).message);
+    }
+  }, SCRAPE_INTERVAL_MS);
+}

--- a/api/src/services/stats.ts
+++ b/api/src/services/stats.ts
@@ -34,6 +34,33 @@ export function getDb(): Database.Database {
       file_offset  INTEGER NOT NULL DEFAULT 0
     );
     INSERT OR IGNORE INTO ingest_cursor (id, file_offset) VALUES (1, 0);
+
+    CREATE TABLE IF NOT EXISTS page_stats_rollup (
+      router_name  TEXT    NOT NULL,
+      bucket_ts    INTEGER NOT NULL,
+      path         TEXT    NOT NULL,
+      requests     INTEGER NOT NULL DEFAULT 0,
+      human_reqs   INTEGER NOT NULL DEFAULT 0,
+      bot_reqs     INTEGER NOT NULL DEFAULT 0,
+      bytes_out    INTEGER NOT NULL DEFAULT 0,
+      sum_ms       REAL    NOT NULL DEFAULT 0,
+      status_2xx   INTEGER NOT NULL DEFAULT 0,
+      status_4xx   INTEGER NOT NULL DEFAULT 0,
+      status_5xx   INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (router_name, bucket_ts, path)
+    );
+    CREATE INDEX IF NOT EXISTS idx_page_stats_router_bucket
+      ON page_stats_rollup (router_name, bucket_ts DESC);
+
+    CREATE TABLE IF NOT EXISTS referrer_stats_rollup (
+      router_name     TEXT    NOT NULL,
+      bucket_ts       INTEGER NOT NULL,
+      referrer_domain TEXT    NOT NULL,
+      requests        INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (router_name, bucket_ts, referrer_domain)
+    );
+    CREATE INDEX IF NOT EXISTS idx_referrer_stats_router_bucket
+      ON referrer_stats_rollup (router_name, bucket_ts DESC);
   `);
   return _db;
 }
@@ -198,4 +225,131 @@ export function queryPulse(routerName: string): { buckets: PulseBucket[]; max_re
 
   const max_requests = rows.reduce((m, r) => Math.max(m, r.requests), 0);
   return { buckets: rows, max_requests };
+}
+
+// ── Page-level stats ──────────────────────────────────────────────────────────
+
+export interface PageRollupIncrement {
+  router_name: string;
+  bucket_ts: number;
+  path: string;
+  requests: number;
+  human_reqs: number;
+  bot_reqs: number;
+  bytes_out: number;
+  sum_ms: number;
+  status_2xx: number;
+  status_4xx: number;
+  status_5xx: number;
+}
+
+export function writePageRollups(
+  pages: PageRollupIncrement[],
+  refs: Array<{ router_name: string; bucket_ts: number; referrer_domain: string; requests: number }>
+): void {
+  const db = getDb();
+  const upsertPage = db.prepare(`
+    INSERT INTO page_stats_rollup
+      (router_name, bucket_ts, path, requests, human_reqs, bot_reqs, bytes_out, sum_ms, status_2xx, status_4xx, status_5xx)
+    VALUES
+      (@router_name, @bucket_ts, @path, @requests, @human_reqs, @bot_reqs, @bytes_out, @sum_ms, @status_2xx, @status_4xx, @status_5xx)
+    ON CONFLICT(router_name, bucket_ts, path) DO UPDATE SET
+      requests   = requests   + excluded.requests,
+      human_reqs = human_reqs + excluded.human_reqs,
+      bot_reqs   = bot_reqs   + excluded.bot_reqs,
+      bytes_out  = bytes_out  + excluded.bytes_out,
+      sum_ms     = sum_ms     + excluded.sum_ms,
+      status_2xx = status_2xx + excluded.status_2xx,
+      status_4xx = status_4xx + excluded.status_4xx,
+      status_5xx = status_5xx + excluded.status_5xx
+  `);
+  const upsertRef = db.prepare(`
+    INSERT INTO referrer_stats_rollup (router_name, bucket_ts, referrer_domain, requests)
+    VALUES (@router_name, @bucket_ts, @referrer_domain, @requests)
+    ON CONFLICT(router_name, bucket_ts, referrer_domain) DO UPDATE SET
+      requests = requests + excluded.requests
+  `);
+  db.transaction(() => {
+    for (const p of pages) upsertPage.run(p);
+    for (const r of refs) upsertRef.run(r);
+  })();
+}
+
+export interface TopPage {
+  path: string;
+  requests: number;
+  human_requests: number;
+  avg_ms: number | null;
+  error_rate: number;
+  trend: number | null; // % change vs. prior period; null if no prior data
+}
+
+export interface PageStatsResult {
+  range: StatRange;
+  top_pages: TopPage[];
+  top_referrers: Array<{ referrer_domain: string; requests: number }>;
+}
+
+export function queryPageStats(routerName: string, range: StatRange, limit = 25): PageStatsResult {
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+  const since = toBucket(now - RANGE_SECS[range]);
+  const prevSince = toBucket(now - RANGE_SECS[range] * 2);
+
+  const pages = db.prepare(`
+    SELECT path,
+           SUM(requests)   AS requests,
+           SUM(human_reqs) AS human_requests,
+           SUM(sum_ms)     AS sum_ms,
+           SUM(status_4xx) + SUM(status_5xx) AS errors
+    FROM page_stats_rollup
+    WHERE router_name = ? AND bucket_ts >= ?
+    GROUP BY path
+    ORDER BY requests DESC
+    LIMIT ?
+  `).all(routerName, since, limit) as Array<{
+    path: string; requests: number; human_requests: number; sum_ms: number; errors: number;
+  }>;
+
+  // Prior period for trend computation
+  const prevPages = db.prepare(`
+    SELECT path, SUM(requests) AS requests
+    FROM page_stats_rollup
+    WHERE router_name = ? AND bucket_ts >= ? AND bucket_ts < ?
+    GROUP BY path
+  `).all(routerName, prevSince, since) as Array<{ path: string; requests: number }>;
+  const prevMap = new Map(prevPages.map(r => [r.path, r.requests]));
+
+  const refs = db.prepare(`
+    SELECT referrer_domain, SUM(requests) AS requests
+    FROM referrer_stats_rollup
+    WHERE router_name = ? AND bucket_ts >= ?
+    GROUP BY referrer_domain
+    ORDER BY requests DESC
+    LIMIT 20
+  `).all(routerName, since) as Array<{ referrer_domain: string; requests: number }>;
+
+  return {
+    range,
+    top_pages: pages.map(r => {
+      const prev = prevMap.get(r.path) ?? 0;
+      const trend = prev > 0 ? Math.round(((r.requests - prev) / prev) * 100) : null;
+      return {
+        path: r.path,
+        requests: r.requests,
+        human_requests: r.human_requests,
+        avg_ms: r.requests > 0 ? r.sum_ms / r.requests : null,
+        error_rate: r.requests > 0 ? r.errors / r.requests : 0,
+        trend,
+      };
+    }),
+    top_referrers: refs,
+  };
+}
+
+export function pruneOldPageStats(): void {
+  const db = getDb();
+  const cutoff = Math.floor(Date.now() / 1000) - 90 * 86400;
+  db.prepare('DELETE FROM page_stats_rollup WHERE bucket_ts < ?').run(cutoff);
+  db.prepare('DELETE FROM referrer_stats_rollup WHERE bucket_ts < ?').run(cutoff);
 }

--- a/api/src/services/stats.ts
+++ b/api/src/services/stats.ts
@@ -1,0 +1,201 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+import fs from 'fs';
+
+const DATA_DIR = process.env.STATS_DATA_DIR ?? '/app/data';
+const DB_PATH = path.join(DATA_DIR, 'stats.db');
+
+let _db: Database.Database | null = null;
+
+export function getDb(): Database.Database {
+  if (_db) return _db;
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+  _db = new Database(DB_PATH);
+  _db.pragma('journal_mode = WAL');
+  _db.exec(`
+    CREATE TABLE IF NOT EXISTS site_stats_rollup (
+      router_name TEXT NOT NULL,
+      bucket_ts   INTEGER NOT NULL,
+      requests    INTEGER NOT NULL DEFAULT 0,
+      human_reqs  INTEGER NOT NULL DEFAULT 0,
+      bot_reqs    INTEGER NOT NULL DEFAULT 0,
+      unique_ips  INTEGER NOT NULL DEFAULT 0,
+      bytes_in    INTEGER NOT NULL DEFAULT 0,
+      bytes_out   INTEGER NOT NULL DEFAULT 0,
+      sum_ms      REAL    NOT NULL DEFAULT 0,
+      status_2xx  INTEGER NOT NULL DEFAULT 0,
+      status_4xx  INTEGER NOT NULL DEFAULT 0,
+      status_5xx  INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (router_name, bucket_ts)
+    );
+
+    CREATE TABLE IF NOT EXISTS ingest_cursor (
+      id           INTEGER PRIMARY KEY CHECK (id = 1),
+      file_offset  INTEGER NOT NULL DEFAULT 0
+    );
+    INSERT OR IGNORE INTO ingest_cursor (id, file_offset) VALUES (1, 0);
+  `);
+  return _db;
+}
+
+// ── Bucket helpers ────────────────────────────────────────────────────────────
+const BUCKET_SECS = 900; // 15 minutes
+
+export function toBucket(unixSecs: number): number {
+  return Math.floor(unixSecs / BUCKET_SECS) * BUCKET_SECS;
+}
+
+// ── Write a batch of rollup increments ───────────────────────────────────────
+export interface RollupIncrement {
+  router_name: string;
+  bucket_ts: number;
+  requests: number;
+  human_reqs: number;
+  bot_reqs: number;
+  unique_ips: number;
+  bytes_in: number;
+  bytes_out: number;
+  sum_ms: number;
+  status_2xx: number;
+  status_4xx: number;
+  status_5xx: number;
+}
+
+const upsertStmt = (db: Database.Database) => db.prepare(`
+  INSERT INTO site_stats_rollup
+    (router_name, bucket_ts, requests, human_reqs, bot_reqs, unique_ips,
+     bytes_in, bytes_out, sum_ms, status_2xx, status_4xx, status_5xx)
+  VALUES
+    (@router_name, @bucket_ts, @requests, @human_reqs, @bot_reqs, @unique_ips,
+     @bytes_in, @bytes_out, @sum_ms, @status_2xx, @status_4xx, @status_5xx)
+  ON CONFLICT(router_name, bucket_ts) DO UPDATE SET
+    requests   = requests   + excluded.requests,
+    human_reqs = human_reqs + excluded.human_reqs,
+    bot_reqs   = bot_reqs   + excluded.bot_reqs,
+    unique_ips = unique_ips + excluded.unique_ips,
+    bytes_in   = bytes_in   + excluded.bytes_in,
+    bytes_out  = bytes_out  + excluded.bytes_out,
+    sum_ms     = sum_ms     + excluded.sum_ms,
+    status_2xx = status_2xx + excluded.status_2xx,
+    status_4xx = status_4xx + excluded.status_4xx,
+    status_5xx = status_5xx + excluded.status_5xx
+`);
+
+export function writeRollups(increments: RollupIncrement[], newOffset: number): void {
+  const db = getDb();
+  const upsert = upsertStmt(db);
+  const tx = db.transaction(() => {
+    for (const row of increments) {
+      upsert.run(row);
+    }
+    db.prepare('UPDATE ingest_cursor SET file_offset = ? WHERE id = 1').run(newOffset);
+  });
+  tx();
+}
+
+export function getCursor(): number {
+  return (getDb().prepare('SELECT file_offset FROM ingest_cursor WHERE id = 1').get() as { file_offset: number } | undefined)?.file_offset ?? 0;
+}
+
+// ── Query helpers ─────────────────────────────────────────────────────────────
+export type StatRange = '24h' | '7d' | '30d';
+
+const RANGE_SECS: Record<StatRange, number> = {
+  '24h': 86400,
+  '7d':  604800,
+  '30d': 2592000,
+};
+
+export interface SiteStatsResult {
+  range: StatRange;
+  requests: number;
+  human_requests: number;
+  bot_requests: number;
+  bandwidth_bytes: number;
+  error_rate: number;
+  avg_ms: number | null;
+  sparkline: Array<{ ts: number; requests: number }>;
+}
+
+export function querySiteStats(routerName: string, range: StatRange): SiteStatsResult {
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+  const since = now - RANGE_SECS[range];
+
+  const agg = db.prepare(`
+    SELECT
+      SUM(requests)   AS requests,
+      SUM(human_reqs) AS human_reqs,
+      SUM(bot_reqs)   AS bot_reqs,
+      SUM(bytes_out)  AS bytes_out,
+      SUM(status_4xx) + SUM(status_5xx) AS errors,
+      SUM(sum_ms)     AS sum_ms
+    FROM site_stats_rollup
+    WHERE router_name = ? AND bucket_ts >= ?
+  `).get(routerName, toBucket(since)) as {
+    requests: number | null;
+    human_reqs: number | null;
+    bot_reqs: number | null;
+    bytes_out: number | null;
+    errors: number | null;
+    sum_ms: number | null;
+  } | undefined;
+
+  const requests = agg?.requests ?? 0;
+  const human_requests = agg?.human_reqs ?? 0;
+  const bot_requests = agg?.bot_reqs ?? 0;
+  const bandwidth_bytes = agg?.bytes_out ?? 0;
+  const errors = agg?.errors ?? 0;
+  const sum_ms = agg?.sum_ms ?? 0;
+
+  const error_rate = requests > 0 ? errors / requests : 0;
+  const avg_ms = requests > 0 ? sum_ms / requests : null;
+
+  // Sparkline: for 24h → hourly buckets (4 per hour × 24 = 96 points)
+  //            for 7d  → 6h buckets  (4 per day × 7  = 28 points)
+  //            for 30d → daily buckets (1 per day × 30 = 30 points)
+  const sparkBucketSecs = range === '24h' ? 3600 : range === '7d' ? 21600 : 86400;
+
+  const sparkRows = db.prepare(`
+    SELECT
+      (bucket_ts / ?) * ? AS spark_ts,
+      SUM(requests) AS requests
+    FROM site_stats_rollup
+    WHERE router_name = ? AND bucket_ts >= ?
+    GROUP BY spark_ts
+    ORDER BY spark_ts ASC
+  `).all(sparkBucketSecs, sparkBucketSecs, routerName, toBucket(since)) as Array<{ spark_ts: number; requests: number }>;
+
+  return {
+    range,
+    requests,
+    human_requests,
+    bot_requests,
+    bandwidth_bytes,
+    error_rate,
+    avg_ms,
+    sparkline: sparkRows.map(r => ({ ts: r.spark_ts, requests: r.requests })),
+  };
+}
+
+// 96 × 15-min buckets = 24h for pulse strip
+export interface PulseBucket {
+  ts: number;
+  requests: number;
+}
+
+export function queryPulse(routerName: string): { buckets: PulseBucket[]; max_requests: number } {
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+  const since = now - 86400;
+
+  const rows = db.prepare(`
+    SELECT bucket_ts AS ts, requests
+    FROM site_stats_rollup
+    WHERE router_name = ? AND bucket_ts >= ?
+    ORDER BY bucket_ts ASC
+  `).all(routerName, toBucket(since)) as Array<{ ts: number; requests: number }>;
+
+  const max_requests = rows.reduce((m, r) => Math.max(m, r.requests), 0);
+  return { buckets: rows, max_requests };
+}

--- a/api/src/services/statsIngester.ts
+++ b/api/src/services/statsIngester.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { getCursor, writeRollups, toBucket, RollupIncrement } from './stats';
 
 const LOG_PATH = process.env.TRAEFIK_LOG_PATH ?? '/traefik-logs/traefik-access.log';
-const INTERVAL_MS = Number(process.env.STATS_INGEST_INTERVAL_MS ?? 60_000);
+const INTERVAL_MS = Number(process.env.STATS_INGEST_INTERVAL_MS ?? 5_000);
 
 // ── Bot UA patterns ───────────────────────────────────────────────────────────
 const BOT_PATTERNS = [

--- a/api/src/services/statsIngester.ts
+++ b/api/src/services/statsIngester.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { getCursor, writeRollups, toBucket, RollupIncrement } from './stats';
+import { getCursor, writeRollups, writePageRollups, pruneOldPageStats, toBucket, RollupIncrement, PageRollupIncrement } from './stats';
 
 const LOG_PATH = process.env.TRAEFIK_LOG_PATH ?? '/traefik-logs/traefik-access.log';
 const INTERVAL_MS = Number(process.env.STATS_INGEST_INTERVAL_MS ?? 5_000);
@@ -45,6 +45,18 @@ interface TraefikLogEntry {
   RequestContentSize?: number;
   StartUTC?: string;
   'request_User-Agent'?: string;
+  RequestPath?: string;
+  'request_Referer'?: string;
+}
+
+function normalizePath(raw: string): string {
+  if (!raw) return '/';
+  return (raw.split('?')[0].substring(0, 512).replace(/\/+/g, '/')) || '/';
+}
+
+function extractReferrerDomain(referer: string): string {
+  if (!referer) return '';
+  try { return new URL(referer).hostname.toLowerCase(); } catch { return ''; }
 }
 
 // ── Main ingest function ──────────────────────────────────────────────────────
@@ -80,6 +92,8 @@ function ingest(): void {
   // Track unique IPs per bucket per router using Sets
   type BucketKey = string; // `${routerName}|${bucketTs}`
   const acc = new Map<BucketKey, Omit<RollupIncrement, 'unique_ips'> & { ips: Set<string> }>();
+  const pageAcc = new Map<string, PageRollupIncrement>();
+  const refAcc = new Map<string, { router_name: string; bucket_ts: number; referrer_domain: string; requests: number }>();
 
   for (const line of lines) {
     const trimmed = line.trim();
@@ -143,6 +157,29 @@ function ingest(): void {
     else if (status >= 400 && status < 500) row.status_4xx++;
     else if (status >= 500) row.status_5xx++;
     if (clientIp) row.ips.add(clientIp);
+
+    // Page-level accumulation
+    const path = normalizePath(entry.RequestPath ?? '');
+    const pageKey = `${routerName}|${bucket}|${path}`;
+    let pr = pageAcc.get(pageKey);
+    if (!pr) {
+      pr = { router_name: routerName, bucket_ts: bucket, path, requests: 0, human_reqs: 0, bot_reqs: 0, bytes_out: 0, sum_ms: 0, status_2xx: 0, status_4xx: 0, status_5xx: 0 };
+      pageAcc.set(pageKey, pr);
+    }
+    pr.requests++;
+    if (bot) pr.bot_reqs++; else pr.human_reqs++;
+    pr.bytes_out += bytesOut;
+    pr.sum_ms += durationMs;
+    if (status >= 200 && status < 300) pr.status_2xx++;
+    else if (status >= 400 && status < 500) pr.status_4xx++;
+    else if (status >= 500) pr.status_5xx++;
+
+    // Referrer accumulation
+    const refDomain = extractReferrerDomain(entry['request_Referer'] ?? '');
+    const refKey = `${routerName}|${bucket}|${refDomain}`;
+    const rr = refAcc.get(refKey) ?? { router_name: routerName, bucket_ts: bucket, referrer_domain: refDomain, requests: 0 };
+    rr.requests++;
+    refAcc.set(refKey, rr);
   }
 
   if (acc.size === 0) {
@@ -158,7 +195,8 @@ function ingest(): void {
   }
 
   writeRollups(increments, newOffset);
-  console.log(`[stats-ingest] ${increments.length} bucket(s) updated, offset=${newOffset}`);
+  if (pageAcc.size > 0) writePageRollups([...pageAcc.values()], [...refAcc.values()]);
+  console.log(`[stats-ingest] ${increments.length} bucket(s) updated, ${pageAcc.size} page path(s), offset=${newOffset}`);
 }
 
 // ── Start ─────────────────────────────────────────────────────────────────────
@@ -173,4 +211,6 @@ export function startStatsIngester(): void {
       console.warn('[stats-ingest] Ingest error:', (err as Error).message);
     }
   }, INTERVAL_MS);
+  // Prune page stats older than 90 days, once per hour
+  setInterval(() => { try { pruneOldPageStats(); } catch {} }, 3_600_000);
 }

--- a/api/src/services/statsIngester.ts
+++ b/api/src/services/statsIngester.ts
@@ -1,0 +1,176 @@
+import fs from 'fs';
+import { getCursor, writeRollups, toBucket, RollupIncrement } from './stats';
+
+const LOG_PATH = process.env.TRAEFIK_LOG_PATH ?? '/traefik-logs/traefik-access.log';
+const INTERVAL_MS = Number(process.env.STATS_INGEST_INTERVAL_MS ?? 60_000);
+
+// ── Bot UA patterns ───────────────────────────────────────────────────────────
+const BOT_PATTERNS = [
+  /bot/i, /crawl/i, /spider/i, /slurp/i, /scrape/i,
+  /googlebot/i, /bingbot/i, /yandex/i, /baidu/i, /duckduckbot/i,
+  /facebookexternalhit/i, /twitterbot/i, /linkedinbot/i, /whatsapp/i,
+  /curl\//i, /wget\//i, /python-requests/i, /go-http-client/i,
+  /axios\//i, /libwww-perl/i, /java\//i, /jakarta/i,
+  /semrush/i, /ahrefs/i, /mj12bot/i, /dotbot/i, /petalbot/i,
+];
+
+function isBot(ua: string): boolean {
+  for (const pat of BOT_PATTERNS) {
+    if (pat.test(ua)) return true;
+  }
+  return false;
+}
+
+// ── Router name → slug ────────────────────────────────────────────────────────
+// Traefik appends @file or @docker to router names.
+// Routes provisioned by HermitHost follow the pattern: site-{slug}
+function normalizeRouterName(raw: string): string | null {
+  // Strip provider suffix: "site-myapp@file" → "site-myapp"
+  const name = raw.replace(/@\w+$/, '');
+  // Skip HTTP redirect routers
+  if (name.endsWith('-http')) return null;
+  // Only handle hermithost-provisioned site routes
+  if (!name.startsWith('site-')) return null;
+  return name; // keep as "site-{slug}" — used as the router_name key
+}
+
+// ── Traefik JSON log entry ────────────────────────────────────────────────────
+interface TraefikLogEntry {
+  RouterName?: string;
+  ClientHost?: string;
+  RequestMethod?: string;
+  DownstreamStatus?: number;
+  Duration?: number;          // nanoseconds
+  DownstreamContentSize?: number;
+  RequestContentSize?: number;
+  StartUTC?: string;
+  'request_User-Agent'?: string;
+}
+
+// ── Main ingest function ──────────────────────────────────────────────────────
+function ingest(): void {
+  if (!fs.existsSync(LOG_PATH)) return;
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(LOG_PATH);
+  } catch {
+    return;
+  }
+
+  const cursor = getCursor();
+
+  // Log was rotated — reset cursor
+  const offset = stat.size < cursor ? 0 : cursor;
+  if (stat.size === offset) return; // nothing new
+
+  const fd = fs.openSync(LOG_PATH, 'r');
+  const bufSize = Math.min(stat.size - offset, 8 * 1024 * 1024); // read up to 8MB per run
+  const buf = Buffer.allocUnsafe(bufSize);
+  const bytesRead = fs.readSync(fd, buf, 0, bufSize, offset);
+  fs.closeSync(fd);
+
+  if (bytesRead === 0) return;
+
+  const newOffset = offset + bytesRead;
+  const text = buf.subarray(0, bytesRead).toString('utf8');
+  const lines = text.split('\n');
+
+  // Accumulate per (router_name, bucket_ts) → increments
+  // Track unique IPs per bucket per router using Sets
+  type BucketKey = string; // `${routerName}|${bucketTs}`
+  const acc = new Map<BucketKey, Omit<RollupIncrement, 'unique_ips'> & { ips: Set<string> }>();
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let entry: TraefikLogEntry;
+    try {
+      entry = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+
+    const routerRaw = entry.RouterName ?? '';
+    const routerName = normalizeRouterName(routerRaw);
+    if (!routerName) continue;
+
+    const ua = entry['request_User-Agent'] ?? '';
+    const bot = isBot(ua);
+    const status = entry.DownstreamStatus ?? 0;
+    const durationMs = (entry.Duration ?? 0) / 1_000_000; // ns → ms
+    const bytesOut = entry.DownstreamContentSize ?? 0;
+    const bytesIn = entry.RequestContentSize ?? 0;
+    const clientIp = entry.ClientHost ?? '';
+
+    // Parse timestamp
+    let ts: number;
+    if (entry.StartUTC) {
+      ts = Math.floor(new Date(entry.StartUTC).getTime() / 1000);
+    } else {
+      ts = Math.floor(Date.now() / 1000);
+    }
+    const bucket = toBucket(ts);
+    if (isNaN(bucket)) continue;
+
+    const key: BucketKey = `${routerName}|${bucket}`;
+    let row = acc.get(key);
+    if (!row) {
+      row = {
+        router_name: routerName,
+        bucket_ts: bucket,
+        requests: 0,
+        human_reqs: 0,
+        bot_reqs: 0,
+        bytes_in: 0,
+        bytes_out: 0,
+        sum_ms: 0,
+        status_2xx: 0,
+        status_4xx: 0,
+        status_5xx: 0,
+        ips: new Set(),
+      };
+      acc.set(key, row);
+    }
+
+    row.requests++;
+    if (bot) row.bot_reqs++; else row.human_reqs++;
+    row.bytes_in += bytesIn;
+    row.bytes_out += bytesOut;
+    row.sum_ms += durationMs;
+    if (status >= 200 && status < 300) row.status_2xx++;
+    else if (status >= 400 && status < 500) row.status_4xx++;
+    else if (status >= 500) row.status_5xx++;
+    if (clientIp) row.ips.add(clientIp);
+  }
+
+  if (acc.size === 0) {
+    // Advance cursor even if no valid entries (skip bad log lines)
+    writeRollups([], newOffset);
+    return;
+  }
+
+  const increments: RollupIncrement[] = [];
+  for (const [, row] of acc) {
+    const { ips, ...rest } = row;
+    increments.push({ ...rest, unique_ips: ips.size });
+  }
+
+  writeRollups(increments, newOffset);
+  console.log(`[stats-ingest] ${increments.length} bucket(s) updated, offset=${newOffset}`);
+}
+
+// ── Start ─────────────────────────────────────────────────────────────────────
+export function startStatsIngester(): void {
+  console.log(`[stats-ingest] Starting — log=${LOG_PATH}, interval=${INTERVAL_MS}ms`);
+  // Run immediately on start, then on interval
+  try { ingest(); } catch (err) {
+    console.warn('[stats-ingest] Initial ingest error:', (err as Error).message);
+  }
+  setInterval(() => {
+    try { ingest(); } catch (err) {
+      console.warn('[stats-ingest] Ingest error:', (err as Error).message);
+    }
+  }, INTERVAL_MS);
+}

--- a/api/src/services/technitium.ts
+++ b/api/src/services/technitium.ts
@@ -232,6 +232,18 @@ export class TechnitiumClient {
       await handleResponse<TechnitiumDeleteResponse>(res, 'POST /api/settings/set');
     });
   }
+
+  async setForwarders(forwarderIps: string[]): Promise<void> {
+    return this.withTokenRetry(async () => {
+      const active = forwarderIps.filter(ip => ip.trim());
+      const body = this.buildParams({
+        forwarders: active.join(','),
+        enableForwarders: active.length > 0,
+      });
+      const res = await fetch(`${this.baseUrl}/api/settings/set`, { method: 'POST', headers: this.postHeaders, body });
+      await handleResponse<TechnitiumDeleteResponse>(res, 'POST /api/settings/set');
+    });
+  }
 }
 
 export function createTechnitiumClient(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,7 @@ services:
       - "--accesslog.format=json"
       - "--accesslog.fields.headers.defaultmode=drop"
       - "--accesslog.fields.headers.names.User-Agent=keep"
+      - "--accesslog.fields.headers.names.Referer=keep"
       # ── Prometheus metrics ──────────────────────────────────────────────────
       - "--metrics.prometheus=true"
       - "--metrics.prometheus.addEntryPointsLabels=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -266,6 +266,7 @@ services:
       - coolify-keys:/coolify-keys:ro
       - ./traefik/conf.d:/app/traefik-conf.d
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - step-ca-data:/home/step:ro
     networks:
       - hermithost-net
       - coolify

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,6 +209,12 @@ services:
       - "--certificatesresolvers.internal-ca.acme.httpchallenge.entrypoint=http"
       - "--certificatesresolvers.internal-ca.acme.email=internal@hermithost.hh"
       - "--certificatesresolvers.internal-ca.acme.storage=/acme/internal-acme.json"
+      # ── Access logging (JSON) ───────────────────────────────────────────────
+      - "--accesslog=true"
+      - "--accesslog.filepath=/logs/traefik-access.log"
+      - "--accesslog.format=json"
+      - "--accesslog.fields.headers.defaultmode=drop"
+      - "--accesslog.fields.headers.names.User-Agent=keep"
     environment:
       # Trust step-ca root CA so Lego can negotiate with it
       LEGO_CA_CERTIFICATES: "/home/step/certs/root_ca.crt"
@@ -221,6 +227,7 @@ services:
       - ./traefik/conf.d:/etc/traefik/conf.d
       - traefik-acme:/acme
       - step-ca-data:/home/step:ro
+      - traefik-logs:/logs
     networks:
       - hermithost-net
       - coolify
@@ -255,6 +262,8 @@ services:
       NS_HOSTNAME: "${NS_HOSTNAME:-}"
       NS_SERVER_IP: "${NS_SERVER_IP:-}"
       NETWORK_MODE: "${NETWORK_MODE:-external}"
+      TRAEFIK_LOG_PATH: "/traefik-logs/traefik-access.log"
+      STATS_INGEST_INTERVAL_MS: "${STATS_INGEST_INTERVAL_MS:-60000}"
       PGHOST: "coolify-db"
       PGPORT: "5432"
       PGDATABASE: "coolify"
@@ -267,6 +276,8 @@ services:
       - ./traefik/conf.d:/app/traefik-conf.d
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - step-ca-data:/home/step:ro
+      - traefik-logs:/traefik-logs:ro
+      - hermithost-stats:/app/data
     networks:
       - hermithost-net
       - coolify
@@ -315,3 +326,5 @@ volumes:
   coolify-api-token:
   ssh-bridge-host-keys:
   step-ca-data:
+  traefik-logs:
+  hermithost-stats:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,7 +209,9 @@ services:
       - "--certificatesresolvers.internal-ca.acme.httpchallenge.entrypoint=http"
       - "--certificatesresolvers.internal-ca.acme.email=internal@hermithost.hh"
       - "--certificatesresolvers.internal-ca.acme.storage=/acme/internal-acme.json"
-      - "--certificatesresolvers.internal-ca.acme.cabundle=/home/step/certs/root_ca.crt"
+    environment:
+      # Trust step-ca root CA so Lego can negotiate with it
+      LEGO_CA_CERTIFICATES: "/home/step/certs/root_ca.crt"
     ports:
       - "${TRAEFIK_HTTP_PORT:-8080}:80"
       - "${TRAEFIK_HTTPS_PORT:-8443}:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,34 @@ services:
       retries: 10
       timeout: 2s
 
+  # ── step-ca Init (one-shot) ───────────────────────────────────
+  # Generates the HermitHost root CA and ACME provisioner on first boot.
+  # Idempotent: skips if /home/step/config/ca.json already exists.
+  step-ca-init:
+    image: smallstep/step-ca:latest
+    user: root
+    entrypoint: ["/bin/sh", "/scripts/step-ca-init.sh"]
+    volumes:
+      - step-ca-data:/home/step
+      - ./scripts/step-ca-init.sh:/scripts/step-ca-init.sh:ro
+    networks:
+      - hermithost-net
+    restart: "no"
+
+  # ── step-ca (Local Certificate Authority) ─────────────────────
+  # Issues TLS certificates for .hh domains in internal mode.
+  # Traefik uses this as the ACME CA instead of Let's Encrypt.
+  step-ca:
+    image: smallstep/step-ca:latest
+    volumes:
+      - step-ca-data:/home/step
+    networks:
+      - hermithost-net
+    restart: unless-stopped
+    depends_on:
+      step-ca-init:
+        condition: service_completed_successfully
+
   # ── Coolify Keys Init (one-shot) ──────────────────────────────
   coolify-keys-init:
     image: alpine
@@ -175,6 +203,13 @@ services:
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http"
       - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
       - "--certificatesresolvers.letsencrypt.acme.storage=/acme/acme.json"
+      # ── Internal CA resolver (step-ca) ─────────────────────────
+      - "--certificatesresolvers.internal-ca.acme.caserver=https://step-ca:9000/acme/acme/directory"
+      - "--certificatesresolvers.internal-ca.acme.httpchallenge=true"
+      - "--certificatesresolvers.internal-ca.acme.httpchallenge.entrypoint=http"
+      - "--certificatesresolvers.internal-ca.acme.email=internal@hermithost.hh"
+      - "--certificatesresolvers.internal-ca.acme.storage=/acme/internal-acme.json"
+      - "--certificatesresolvers.internal-ca.acme.cabundle=/home/step/certs/root_ca.crt"
     ports:
       - "${TRAEFIK_HTTP_PORT:-8080}:80"
       - "${TRAEFIK_HTTPS_PORT:-8443}:443"
@@ -183,6 +218,7 @@ services:
     volumes:
       - ./traefik/conf.d:/etc/traefik/conf.d
       - traefik-acme:/acme
+      - step-ca-data:/home/step:ro
     networks:
       - hermithost-net
       - coolify
@@ -216,6 +252,7 @@ services:
       CLOUDFLARE_TOKEN: "${CLOUDFLARE_TOKEN:-}"
       NS_HOSTNAME: "${NS_HOSTNAME:-}"
       NS_SERVER_IP: "${NS_SERVER_IP:-}"
+      NETWORK_MODE: "${NETWORK_MODE:-external}"
       PGHOST: "coolify-db"
       PGPORT: "5432"
       PGDATABASE: "coolify"
@@ -274,3 +311,4 @@ volumes:
   coolify-keys:
   coolify-api-token:
   ssh-bridge-host-keys:
+  step-ca-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,11 @@ services:
       - "--accesslog.format=json"
       - "--accesslog.fields.headers.defaultmode=drop"
       - "--accesslog.fields.headers.names.User-Agent=keep"
+      # ── Prometheus metrics ──────────────────────────────────────────────────
+      - "--metrics.prometheus=true"
+      - "--metrics.prometheus.addEntryPointsLabels=true"
+      - "--metrics.prometheus.addRoutersLabels=true"
+      - "--metrics.prometheus.addServicesLabels=true"
     environment:
       # Trust step-ca root CA so Lego can negotiate with it
       LEGO_CA_CERTIFICATES: "/home/step/certs/root_ca.crt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hermithost",
       "version": "0.0.1",
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@sveltejs/adapter-node": "^5.0.1",
         "@sveltejs/kit": "^2.5.5",
         "@sveltejs/vite-plugin-svelte": "^3.1.0",
@@ -462,6 +463,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@sveltejs/adapter-node": "^5.0.1",
     "@sveltejs/kit": "^2.5.5",
     "@sveltejs/vite-plugin-svelte": "^3.1.0",

--- a/scripts/step-ca-init.sh
+++ b/scripts/step-ca-init.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# step-ca-init.sh — one-shot CA bootstrap for HermitHost internal mode.
+# Runs as an init container; idempotent (safe to restart or re-run).
+# Outputs root CA cert to /home/step/certs/root_ca.crt for Traefik + API.
+
+set -e
+
+export STEPPATH=/home/step
+
+# ── Idempotency check ─────────────────────────────────────────────────────────
+if [ -f "$STEPPATH/config/ca.json" ]; then
+  echo "[step-ca-init] CA already initialized — nothing to do."
+  exit 0
+fi
+
+echo "[step-ca-init] Initializing HermitHost CA (this runs once)..."
+
+# Need jq to patch ca.json after init
+apk add --no-cache jq -q 2>/dev/null
+
+# Write a stable CA key password to a temp file.
+# Not a secret — this CA only issues certs for .hh (homelab) and is
+# never exported or used outside the local network.
+CA_PASS="hermithost-internal-ca-key"
+mkdir -p "$STEPPATH/secrets"
+echo "$CA_PASS" > "$STEPPATH/secrets/password"
+
+# ── Initialize root + intermediate CA ────────────────────────────────────────
+step ca init \
+  --name="HermitHost CA" \
+  --dns="step-ca" \
+  --address=":9000" \
+  --provisioner="hermithost-admin" \
+  --password-file="$STEPPATH/secrets/password" \
+  --deployment-type=standalone
+
+# ── Add ACME provisioner with 90-day cert lifetime ────────────────────────────
+# The default JWK provisioner stays but is unused; Traefik will use 'acme'.
+# 90 days (2160h) balances security and homelab convenience.
+jq '.authority.provisioners += [{
+  "type": "ACME",
+  "name": "acme",
+  "forceCN": false,
+  "claims": {
+    "defaultTLSCertDuration": "2160h",
+    "maxTLSCertDuration": "8760h",
+    "minTLSCertDuration": "5m"
+  }
+}]' "$STEPPATH/config/ca.json" > /tmp/ca.json.tmp \
+  && mv /tmp/ca.json.tmp "$STEPPATH/config/ca.json"
+
+# Fix ownership so step-ca (uid 1000) can read all files
+chown -R 1000:1000 "$STEPPATH"
+
+echo "[step-ca-init] ACME provisioner added (name: acme, 90-day certs)"
+echo "[step-ca-init] Root CA: $STEPPATH/certs/root_ca.crt"
+echo "[step-ca-init] Done."

--- a/src/app.css
+++ b/src/app.css
@@ -19,6 +19,12 @@
 	--border-bright: #2d3f5e;
 	--font-ui: 'Inter', system-ui, sans-serif;
 	--font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+	--live-connected: #4caf50;
+	--live-disconnected: var(--text-muted);
+	--latency-warn: var(--warning);
+	--latency-crit: var(--danger);
+	--error-warn: var(--warning);
+	--error-crit: var(--danger);
 }
 
 *, *::before, *::after {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -196,6 +196,36 @@
 	$: warningSites = sites.filter(s => s.overallStatus === 'warning').length;
 	$: errorSites = sites.filter(s => s.overallStatus === 'error').length;
 	$: pendingSites = sites.filter(s => s.overallStatus === 'pending').length;
+
+	// ── Pulse strips ───────────────────────────────────────────────────────────
+	interface PulseBucket { ts: number; requests: number; }
+	let pulseData: Record<string, { buckets: PulseBucket[]; max: number }> = {};
+
+	async function loadPulse(slug: string): Promise<void> {
+		try {
+			const res = await fetch(`/api/sites/${slug}/stats/pulse`);
+			if (res.ok) {
+				const body: { buckets: PulseBucket[]; max_requests: number } = await res.json();
+				pulseData = { ...pulseData, [slug]: { buckets: body.buckets, max: body.max_requests } };
+			}
+		} catch { /* silently skip */ }
+	}
+
+	onMount(() => {
+		// Kick off pulse load for all sites (after status probes)
+		setTimeout(() => {
+			for (const s of data.sites) loadPulse(s.slug);
+		}, 500);
+	});
+
+	function pulseColor(requests: number, max: number): string {
+		if (max === 0 || requests === 0) return 'var(--bg-elevated)';
+		const ratio = requests / max;
+		if (ratio < 0.2) return 'rgba(76,175,130,0.25)';
+		if (ratio < 0.5) return 'rgba(76,175,130,0.5)';
+		if (ratio < 0.8) return 'rgba(76,175,130,0.75)';
+		return 'rgba(76,175,130,1)';
+	}
 </script>
 
 <svelte:window on:keydown={handleAddKeydown} />
@@ -232,6 +262,7 @@
 					<th>SSL</th>
 					<th>DNS</th>
 					<th>Last Deploy</th>
+					<th>Traffic (24h)</th>
 					<th>Server</th>
 					<th></th>
 				</tr>
@@ -271,6 +302,21 @@
 						</td>
 						<td>
 							<span class="{lastDeployClass(site)} mono">{lastDeployLabel(site)}{lastDeployStatus(site)}</span>
+						</td>
+						<td class="cell-pulse">
+							{@const pulse = pulseData[site.slug]}
+							{#if pulse && pulse.buckets.length > 0}
+								<div class="pulse-strip" title="Request volume — last 24h">
+									{#each pulse.buckets as bucket}
+										<span
+											class="pulse-col"
+											style="background:{pulseColor(bucket.requests, pulse.max)}"
+										></span>
+									{/each}
+								</div>
+							{:else}
+								<span class="text-muted mono" style="font-size:11px">—</span>
+							{/if}
 						</td>
 						<td>
 							<span class="mono text-secondary">{site.server}</span>
@@ -789,5 +835,27 @@
 		background: var(--bg-elevated);
 		padding: 1px 4px;
 		border-radius: 3px;
+	}
+
+	/* Pulse strip */
+	.cell-pulse {
+		width: 120px;
+		min-width: 100px;
+	}
+
+	.pulse-strip {
+		display: flex;
+		gap: 1px;
+		align-items: flex-end;
+		height: 20px;
+		width: 100%;
+	}
+
+	.pulse-col {
+		flex: 1;
+		height: 100%;
+		border-radius: 1px;
+		min-width: 1px;
+		transition: background 0.2s;
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -271,6 +271,7 @@
 				{#each sites as rawSite}
 					{@const site = effectiveSite(rawSite)}
 					{@const probing = probePending.has(rawSite.slug)}
+					{@const pulse = pulseData[rawSite.slug]}
 					<tr class="site-row" class:row-error={site.overallStatus === 'error'} class:row-warning={site.overallStatus === 'warning'}>
 						<td class="cell-site">
 							<div class="site-name-row">
@@ -304,7 +305,6 @@
 							<span class="{lastDeployClass(site)} mono">{lastDeployLabel(site)}{lastDeployStatus(site)}</span>
 						</td>
 						<td class="cell-pulse">
-							{@const pulse = pulseData[site.slug]}
 							{#if pulse && pulse.buckets.length > 0}
 								<div class="pulse-strip" title="Request volume — last 24h">
 									{#each pulse.buckets as bucket}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -19,6 +19,7 @@
 
 	// ── Config section ─────────────────────────────────────────────────────────
 	let nsHostname = '';
+	let nsServerIp = '';
 	let acmeEmail = '';
 	let coolifyStatus: 'connected' | 'error' | 'not_configured' = 'not_configured';
 	let technitiumStatus: 'connected' | 'error' | 'not_configured' = 'not_configured';
@@ -38,6 +39,11 @@
 	let networkModeWarning = '';
 	let showTrustInstall = false;
 	let downloadingTrustCert = false;
+	let dnsForwarder1 = '';
+	let dnsForwarder2 = '';
+	let savingForwarders = false;
+	let forwarderSaveSuccess = false;
+	let forwarderSaveError = '';
 	let savingDnsProvider = false;
 	let dnsProviderError = '';
 	let savingCloudflareToken = false;
@@ -131,6 +137,8 @@
 			if (configRes.ok) {
 				const cfg = await configRes.json() as {
 					ns_hostname?: string;
+					ns_server_ip?: string;
+					dns_forwarders?: [string, string];
 					acme_email?: string;
 					coolify_url?: string;
 					coolify_status?: 'connected' | 'error' | 'not_configured';
@@ -142,6 +150,9 @@
 					network_mode?: 'external' | 'internal';
 				};
 				nsHostname = cfg.ns_hostname ?? '';
+				nsServerIp = cfg.ns_server_ip ?? '';
+				dnsForwarder1 = cfg.dns_forwarders?.[0] ?? '';
+				dnsForwarder2 = cfg.dns_forwarders?.[1] ?? '';
 				acmeEmail = cfg.acme_email ?? '';
 				coolifyUrl = cfg.coolify_url ?? '';
 				coolifyStatus = cfg.coolify_status ?? 'not_configured';
@@ -165,7 +176,7 @@
 			const res = await fetch('/api/config', {
 				method: 'PUT',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ ns_hostname: nsHostname }),
+				body: JSON.stringify({ ns_hostname: nsHostname, ns_server_ip: nsServerIp }),
 			});
 			if (!res.ok) {
 				const body = await res.json().catch(() => ({})) as { error?: string };
@@ -281,6 +292,29 @@
 			networkModeError = (err as Error).message;
 		} finally {
 			downloadingTrustCert = false;
+		}
+	}
+
+	async function saveForwarders() {
+		savingForwarders = true;
+		forwarderSaveError = '';
+		forwarderSaveSuccess = false;
+		try {
+			const res = await fetch('/api/config', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ dns_forwarders: [dnsForwarder1.trim(), dnsForwarder2.trim()] }),
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({})) as { error?: string };
+				throw new Error(body.error ?? `HTTP ${res.status}`);
+			}
+			forwarderSaveSuccess = true;
+			setTimeout(() => { forwarderSaveSuccess = false; }, 3000);
+		} catch (err) {
+			forwarderSaveError = (err as Error).message;
+		} finally {
+			savingForwarders = false;
 		}
 	}
 
@@ -463,6 +497,21 @@
 							placeholder="ns1.example.com"
 							bind:value={nsHostname}
 						/>
+					</div>
+				</div>
+				<div class="field-group">
+					<label class="field-label" for="ns-server-ip">Server IP</label>
+					<p class="field-hint">IP address used for DNS A records when provisioning new sites.</p>
+					<div class="input-row">
+						<input
+							id="ns-server-ip"
+							class="text-input"
+							type="text"
+							placeholder="203.0.113.10"
+							bind:value={nsServerIp}
+						/>
+					</div>
+					<div class="input-row" style="margin-top: 12px;">
 						<button class="btn btn-primary" on:click={saveConfig} disabled={savingConfig}>
 							{#if savingConfig}
 								<span class="spinner"></span> Saving…
@@ -707,6 +756,50 @@
 						<span class="tld-badge">.hh</span>
 						<span class="chip-text">Sites on this stack get private addresses (e.g. <code>mysite.hh</code>). Only devices on your local network can reach them.</span>
 					</div>
+				</div>
+
+				<div class="field-group" style="margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--border);">
+					<label class="field-label">DNS Forwarders</label>
+					<p class="field-hint">Technitium uses these addresses to resolve external domains (e.g. google.com). Without forwarders, only your .hh sites will resolve.</p>
+					<div class="field-row" style="margin-top: 8px;">
+						<div class="field-group">
+							<label class="field-label" for="dns-forwarder-1">Primary</label>
+							<input
+								id="dns-forwarder-1"
+								class="text-input"
+								type="text"
+								inputmode="decimal"
+								placeholder="1.1.1.1"
+								bind:value={dnsForwarder1}
+							/>
+						</div>
+						<div class="field-group">
+							<label class="field-label" for="dns-forwarder-2">Secondary</label>
+							<input
+								id="dns-forwarder-2"
+								class="text-input"
+								type="text"
+								inputmode="decimal"
+								placeholder="1.0.0.1"
+								bind:value={dnsForwarder2}
+							/>
+						</div>
+					</div>
+					<div class="input-row" style="margin-top: 12px;">
+						<button class="btn btn-primary" on:click={saveForwarders} disabled={savingForwarders}>
+							{#if savingForwarders}
+								<span class="spinner"></span> Saving…
+							{:else}
+								Save
+							{/if}
+						</button>
+					</div>
+					{#if forwarderSaveSuccess}
+						<p class="inline-success">Saved.</p>
+					{/if}
+					{#if forwarderSaveError}
+						<p class="error-msg">{forwarderSaveError}</p>
+					{/if}
 				</div>
 			{/if}
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -32,6 +32,12 @@
 	let dnsProvider: 'technitium' | 'cloudflare' = 'technitium';
 	let cloudflareStatus: 'connected' | 'disconnected' | 'unconfigured' = 'unconfigured';
 	let cloudflareTokenInput = '';
+	let networkMode: 'external' | 'internal' = 'external';
+	let savingNetworkMode = false;
+	let networkModeError = '';
+	let networkModeWarning = '';
+	let showTrustInstall = false;
+	let downloadingTrustCert = false;
 	let savingDnsProvider = false;
 	let dnsProviderError = '';
 	let savingCloudflareToken = false;
@@ -133,6 +139,7 @@
 					dns_provider?: 'technitium' | 'cloudflare';
 					cloudflare_status?: 'connected' | 'disconnected' | 'unconfigured';
 					cloudflare_token_set?: boolean;
+					network_mode?: 'external' | 'internal';
 				};
 				nsHostname = cfg.ns_hostname ?? '';
 				acmeEmail = cfg.acme_email ?? '';
@@ -142,6 +149,7 @@
 				technitiumStatus = cfg.technitium_status ?? 'not_configured';
 				dnsProvider = cfg.dns_provider ?? 'technitium';
 				cloudflareStatus = cfg.cloudflare_status ?? 'unconfigured';
+				networkMode = cfg.network_mode ?? 'external';
 			}
 		} catch {
 			// non-fatal; page still renders
@@ -224,6 +232,55 @@
 			cloudflareTokenError = (err as Error).message;
 		} finally {
 			savingCloudflareToken = false;
+		}
+	}
+
+	async function onNetworkModeChange(event: Event) {
+		const select = event.currentTarget as HTMLSelectElement;
+		const newMode = select.value as 'external' | 'internal';
+		if (newMode === networkMode) return;
+
+		networkModeWarning = newMode === 'internal'
+			? 'New sites will use .hh addresses and the local CA. Existing sites are not updated automatically.'
+			: "Switching to internet mode. New sites will use Let's Encrypt. Existing .hh sites are not updated.";
+
+		savingNetworkMode = true;
+		networkModeError = '';
+		try {
+			const res = await fetch('/api/config', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ network_mode: newMode }),
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({})) as { error?: string };
+				throw new Error(body.error ?? `HTTP ${res.status}`);
+			}
+			networkMode = newMode;
+		} catch (err) {
+			networkModeError = (err as Error).message;
+			select.value = networkMode;
+		} finally {
+			savingNetworkMode = false;
+		}
+	}
+
+	async function downloadTrustCert() {
+		downloadingTrustCert = true;
+		try {
+			const res = await fetch('/api/config/trust-certificate');
+			if (!res.ok) throw new Error(`HTTP ${res.status}`);
+			const blob = await res.blob();
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = 'hermithost-trust.crt';
+			a.click();
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			networkModeError = (err as Error).message;
+		} finally {
+			downloadingTrustCert = false;
 		}
 	}
 
@@ -563,6 +620,96 @@
 					</div>
 				</div>
 			{/if}
+		</div>
+	</section>
+
+	<!-- ── Network Mode ──────────────────────────────────────────────────────── -->
+	<section class="card" style="margin-bottom: 16px;">
+		<div class="card-header">
+			<div class="card-title-row">
+				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+					<path d="M5 12.55a11 11 0 0 1 14.08 0"/>
+					<path d="M1.42 9a16 16 0 0 1 21.16 0"/>
+					<path d="M8.53 16.11a6 6 0 0 1 6.95 0"/>
+					<line x1="12" y1="20" x2="12.01" y2="20"/>
+				</svg>
+				<h2 class="card-title">Network Mode</h2>
+			</div>
+			<p class="card-desc">Run on a private network with local certificates, or connect to the internet with Let's Encrypt.</p>
+		</div>
+		<div class="section">
+
+			<div class="field-group">
+				<label class="field-label" for="network-mode">Mode</label>
+				<p class="field-hint">Affects new sites only. Existing sites are not updated automatically.</p>
+				<div class="input-row">
+					<select
+						id="network-mode"
+						class="text-input select-input"
+						on:change={onNetworkModeChange}
+						disabled={savingNetworkMode}
+						value={networkMode}
+					>
+						<option value="external">Internet (Let's Encrypt)</option>
+						<option value="internal">Private network (.hh)</option>
+					</select>
+					{#if savingNetworkMode}
+						<span class="spinner"></span>
+					{/if}
+				</div>
+				{#if networkModeWarning}
+					<p class="provider-warning">{networkModeWarning}</p>
+				{/if}
+				{#if networkModeError}
+					<p class="error-msg">{networkModeError}</p>
+				{/if}
+			</div>
+
+			{#if networkMode === 'internal'}
+				<div class="field-group" style="margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--border);">
+					<label class="field-label">Trust Certificate</label>
+					<p class="field-hint">
+						Install on every device that needs access to your private sites.
+						Browsers won't trust <code>.hh</code> addresses without it.
+					</p>
+					<div class="input-row" style="margin-top: 8px;">
+						<button
+							class="btn btn-primary"
+							on:click={downloadTrustCert}
+							disabled={downloadingTrustCert}
+						>
+							{#if downloadingTrustCert}
+								<span class="spinner"></span> Downloading…
+							{:else}
+								Download trust certificate
+							{/if}
+						</button>
+						<button
+							class="btn btn-ghost"
+							on:click={() => { showTrustInstall = !showTrustInstall; }}
+						>
+							{showTrustInstall ? 'Hide' : 'How to install'}
+						</button>
+					</div>
+
+					{#if showTrustInstall}
+						<div class="trust-install-guide" style="margin-top: 12px;">
+							<ul class="install-list">
+								<li><strong>Mac:</strong> Double-click the .crt file → Keychain Access → right-click → Get Info → Trust → Always Trust</li>
+								<li><strong>Windows:</strong> Double-click → Install Certificate → Local Machine → Trusted Root Certification Authorities</li>
+								<li><strong>iPhone / iPad:</strong> AirDrop or email the file → tap to install profile → Settings → General → VPN &amp; Device Management → trust it</li>
+								<li><strong>Android:</strong> Settings → Security → Install from storage → select the .crt file</li>
+							</ul>
+						</div>
+					{/if}
+
+					<div class="hh-chip" style="margin-top: 12px;">
+						<span class="tld-badge">.hh</span>
+						<span class="chip-text">Sites on this stack get private addresses (e.g. <code>mysite.hh</code>). Only devices on your local network can reach them.</span>
+					</div>
+				</div>
+			{/if}
+
 		</div>
 	</section>
 
@@ -1356,5 +1503,46 @@
 
 	.cf-token-row {
 		padding: 12px;
+	}
+
+	/* ── Trust cert install guide ───────────────────────────────── */
+	.install-list {
+		margin: 0;
+		padding-left: 18px;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		font-size: 13px;
+		color: var(--text-muted);
+		line-height: 1.5;
+	}
+
+	/* ── .hh chip ───────────────────────────────────────────────── */
+	.hh-chip {
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+		padding: 10px 12px;
+		background: var(--bg-elevated);
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		font-size: 13px;
+	}
+
+	.tld-badge {
+		font-family: monospace;
+		font-size: 12px;
+		font-weight: 600;
+		background: var(--accent-teal);
+		color: #fff;
+		padding: 2px 6px;
+		border-radius: 4px;
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	.chip-text {
+		color: var(--text-muted);
+		line-height: 1.5;
 	}
 </style>

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -318,6 +318,7 @@
 
 	// ── Traffic stats ─────────────────────────────────────────────────────────
 	type StatRange = '24h' | '7d' | '30d';
+	const statRanges: StatRange[] = ['24h', '7d', '30d'];
 	let statsRange: StatRange = '24h';
 	let statsLoading = false;
 
@@ -618,7 +619,7 @@
 				<div class="stats-panel-header">
 					<h2 class="stats-panel-title">Traffic</h2>
 					<div class="range-toggle">
-						{#each (['24h', '7d', '30d'] as StatRange[]) as r}
+						{#each statRanges as r}
 							<button
 								class="range-btn"
 								class:range-btn-active={statsRange === r}

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -409,22 +409,53 @@
 		window.open(`https://github.com/${ownerRepo}/settings/keys/new`, '_blank');
 	}
 
-	onMount(async () => {
-		try {
-			const res = await fetch('/api/config/deploy-key');
-			if (res.ok) {
-				const body: { public_key: string } = await res.json();
-				deployPublicKey = body.public_key;
-			}
-		} catch {
-			// silently fail — key will be empty
-		}
+	// ── Live stats (SSE) ──────────────────────────────────────────────────────
+	let liveConnected = false;
+	let liveReqPerSec = 0;
+	let liveBandwidthOutBps = 0;
+	let liveBandwidthInBps = 0;
+	let liveActiveConnections = 0;
+	let liveAvgLatencyMs: number | null = null;
+
+	function formatBps(bps: number): string {
+		if (bps >= 1_000_000) return `${(bps / 1_000_000).toFixed(1)} MB/s`;
+		if (bps >= 1_000) return `${(bps / 1_000).toFixed(1)} KB/s`;
+		return `${Math.round(bps)} B/s`;
+	}
+
+	onMount(() => {
+		// Fetch deploy key (async, fire-and-forget)
+		fetch('/api/config/deploy-key')
+			.then(res => res.ok ? res.json() : null)
+			.then((body: { public_key: string } | null) => {
+				if (body) deployPublicKey = body.public_key;
+			})
+			.catch(() => { /* silently fail */ });
+
 		// Load stats for overview tab
 		loadStats(statsRange);
 
 		// Poll stats every 60s
 		const statsPollTimer = setInterval(() => loadStats(statsRange), 60_000);
-		return () => clearInterval(statsPollTimer);
+
+		// Live stats via SSE
+		const es = new EventSource(`/api/sites/${site.slug}/stats/live`);
+		es.onopen = () => { liveConnected = true; };
+		es.onmessage = (e: MessageEvent) => {
+			const snap = JSON.parse(e.data);
+			liveReqPerSec = snap.reqPerSec;
+			liveBandwidthOutBps = snap.bandwidthOutBps;
+			liveBandwidthInBps = snap.bandwidthInBps;
+			liveActiveConnections = snap.activeConnections;
+			liveAvgLatencyMs = snap.avgLatencyMs;
+			liveConnected = true;
+		};
+		es.onerror = () => { liveConnected = false; };
+
+		return () => {
+			clearInterval(statsPollTimer);
+			es.close();
+		};
 	});
 </script>
 
@@ -610,6 +641,20 @@
 						<button class="btn btn-ghost btn-sm mt-8" on:click={() => openLog(latest)}>View log</button>
 					{:else}
 						<div class="status-card-value mono text-muted">Never deployed</div>
+					{/if}
+				</div>
+			</div>
+
+			<!-- Live Stats Bar -->
+			<div class="live-bar" class:live-bar-active={liveConnected}>
+				<span class="live-badge">● LIVE</span>
+				<div class="live-metrics">
+					<span><span class="live-num">{liveReqPerSec.toFixed(1)}</span> req/s</span>
+					<span><span class="live-num">{formatBps(liveBandwidthOutBps)}</span> out</span>
+					<span><span class="live-num">{formatBps(liveBandwidthInBps)}</span> in</span>
+					<span><span class="live-num">{liveActiveConnections}</span> active</span>
+					{#if liveAvgLatencyMs !== null}
+						<span><span class="live-num">{Math.round(liveAvgLatencyMs)}ms</span> avg</span>
 					{/if}
 				</div>
 			</div>
@@ -1852,6 +1897,46 @@
 		word-break: break-all;
 		white-space: pre-wrap;
 		display: block;
+	}
+
+	/* Live stats bar */
+	.live-bar {
+		display: flex;
+		align-items: center;
+		gap: 16px;
+		background: var(--bg-surface);
+		border: 1px solid var(--border);
+		border-radius: 8px;
+		padding: 10px 16px;
+		margin-bottom: 12px;
+		opacity: 0.5;
+		transition: opacity 0.3s;
+	}
+	.live-bar-active {
+		opacity: 1;
+		border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+	}
+	.live-badge {
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		color: var(--text-muted);
+		white-space: nowrap;
+	}
+	.live-bar-active .live-badge {
+		color: #4caf50;
+	}
+	.live-metrics {
+		display: flex;
+		gap: 20px;
+		flex-wrap: wrap;
+		font-size: 12px;
+		color: var(--text-secondary);
+	}
+	.live-num {
+		font-family: var(--font-mono, monospace);
+		font-weight: 600;
+		color: var(--text-primary);
 	}
 
 	/* Traffic stats panel */

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -316,6 +316,62 @@
 		}
 	}
 
+	// ── Traffic stats ─────────────────────────────────────────────────────────
+	type StatRange = '24h' | '7d' | '30d';
+	let statsRange: StatRange = '24h';
+	let statsLoading = false;
+
+	interface SiteStats {
+		range: StatRange;
+		requests: number;
+		human_requests: number;
+		bot_requests: number;
+		bandwidth_bytes: number;
+		error_rate: number;
+		avg_ms: number | null;
+		sparkline: Array<{ ts: number; requests: number }>;
+	}
+
+	let stats: SiteStats | null = null;
+	let statsError = false;
+
+	async function loadStats(range: StatRange): Promise<void> {
+		statsLoading = true;
+		statsError = false;
+		try {
+			const res = await fetch(`/api/sites/${site.slug}/stats?range=${range}`);
+			if (res.ok) {
+				stats = await res.json();
+			} else {
+				statsError = true;
+			}
+		} catch {
+			statsError = true;
+		} finally {
+			statsLoading = false;
+		}
+	}
+
+	function setStatsRange(r: StatRange): void {
+		statsRange = r;
+		loadStats(r);
+	}
+
+	function formatBytes(bytes: number): string {
+		if (bytes < 1024) return `${bytes} B`;
+		if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+		if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+		return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+	}
+
+	function sparklinePath(points: Array<{ ts: number; requests: number }>, w: number, h: number): string {
+		if (points.length < 2) return '';
+		const maxReq = Math.max(...points.map(p => p.requests), 1);
+		const xs = points.map((_, i) => (i / (points.length - 1)) * w);
+		const ys = points.map(p => h - (p.requests / maxReq) * (h - 2) - 1);
+		return xs.map((x, i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${ys[i].toFixed(1)}`).join(' ');
+	}
+
 	// Deploy key
 	let deployPublicKey = '';
 	let deployKeyCopied = false;
@@ -362,6 +418,12 @@
 		} catch {
 			// silently fail — key will be empty
 		}
+		// Load stats for overview tab
+		loadStats(statsRange);
+
+		// Poll stats every 60s
+		const statsPollTimer = setInterval(() => loadStats(statsRange), 60_000);
+		return () => clearInterval(statsPollTimer);
 	});
 </script>
 
@@ -549,6 +611,80 @@
 						<div class="status-card-value mono text-muted">Never deployed</div>
 					{/if}
 				</div>
+			</div>
+
+			<!-- Traffic Stats Panel -->
+			<div class="stats-panel">
+				<div class="stats-panel-header">
+					<h2 class="stats-panel-title">Traffic</h2>
+					<div class="range-toggle">
+						{#each (['24h', '7d', '30d'] as StatRange[]) as r}
+							<button
+								class="range-btn"
+								class:range-btn-active={statsRange === r}
+								on:click={() => setStatsRange(r)}
+							>{r}</button>
+						{/each}
+					</div>
+				</div>
+
+				{#if statsError}
+					<p class="stats-empty">No traffic data yet — starts collecting once Traefik access logging is active.</p>
+				{:else if stats !== null}
+					<div class="stats-row">
+						<div class="stat-item">
+							<span class="stat-label">Requests</span>
+							<span class="stat-value mono">{stats.requests.toLocaleString()}</span>
+						</div>
+						<div class="stat-item">
+							<span class="stat-label">Visitors</span>
+							<span class="stat-value mono">{stats.human_requests.toLocaleString()}</span>
+							{#if stats.bot_requests > 0}
+								<span class="stat-sub text-secondary">{stats.bot_requests.toLocaleString()} bots</span>
+							{/if}
+						</div>
+						<div class="stat-item">
+							<span class="stat-label">Data served</span>
+							<span class="stat-value mono">{formatBytes(stats.bandwidth_bytes)}</span>
+						</div>
+						<div class="stat-item">
+							<span class="stat-label">Avg response</span>
+							<span class="stat-value mono">{stats.avg_ms !== null ? `${Math.round(stats.avg_ms)}ms` : '—'}</span>
+						</div>
+						<div class="stat-item">
+							<span class="stat-label">Error rate</span>
+							<span
+								class="stat-value mono"
+								class:text-danger={stats.error_rate > 0.05}
+								class:text-warning={stats.error_rate > 0.01 && stats.error_rate <= 0.05}
+							>{stats.requests > 0 ? `${(stats.error_rate * 100).toFixed(1)}%` : '—'}</span>
+						</div>
+					</div>
+
+					{#if stats.sparkline.length >= 2}
+						<div class="sparkline-wrap">
+							<svg
+								width="100%"
+								height="48"
+								viewBox="0 0 600 48"
+								preserveAspectRatio="none"
+								aria-hidden="true"
+							>
+								<path
+									d={sparklinePath(stats.sparkline, 600, 48)}
+									fill="none"
+									stroke="var(--accent-teal)"
+									stroke-width="1.5"
+									stroke-linejoin="round"
+									stroke-linecap="round"
+									opacity="0.8"
+								/>
+							</svg>
+						</div>
+					{/if}
+				{:else if statsLoading}
+					<p class="stats-loading text-secondary">Loading…</p>
+				{/if}
 			</div>
 
 			{#if site.overallStatus === 'warning' || site.overallStatus === 'error'}
@@ -1715,5 +1851,129 @@
 		word-break: break-all;
 		white-space: pre-wrap;
 		display: block;
+	}
+
+	/* Traffic stats panel */
+	.stats-panel {
+		background: var(--bg-surface);
+		border: 1px solid var(--border);
+		border-radius: 8px;
+		padding: 16px 20px;
+		margin-bottom: 20px;
+	}
+
+	.stats-panel-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 16px;
+	}
+
+	.stats-panel-title {
+		font-size: 13px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.07em;
+		color: var(--text-secondary);
+	}
+
+	.range-toggle {
+		display: flex;
+		border: 1px solid var(--border-bright);
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	.range-btn {
+		background: transparent;
+		border: none;
+		border-right: 1px solid var(--border-bright);
+		color: var(--text-secondary);
+		font-size: 11px;
+		font-weight: 500;
+		padding: 4px 10px;
+		cursor: pointer;
+		transition: background 0.1s, color 0.1s;
+		font-family: var(--font-mono);
+	}
+
+	.range-btn:last-child {
+		border-right: none;
+	}
+
+	.range-btn:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.range-btn-active {
+		background: var(--accent-teal);
+		color: #fff;
+	}
+
+	.range-btn-active:hover {
+		background: var(--accent-teal-dim);
+		color: #fff;
+	}
+
+	.stats-row {
+		display: flex;
+		gap: 32px;
+		flex-wrap: wrap;
+		margin-bottom: 16px;
+	}
+
+	.stat-item {
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+		min-width: 80px;
+	}
+
+	.stat-label {
+		font-size: 11px;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.07em;
+		color: var(--text-muted);
+	}
+
+	.stat-value {
+		font-size: 22px;
+		font-weight: 500;
+		color: var(--text-primary);
+		line-height: 1.1;
+	}
+
+	.stat-sub {
+		font-size: 11px;
+		font-family: var(--font-mono);
+	}
+
+	.sparkline-wrap {
+		width: 100%;
+		height: 48px;
+		border-top: 1px solid var(--border);
+		padding-top: 8px;
+		overflow: hidden;
+	}
+
+	.sparkline-wrap svg {
+		display: block;
+		width: 100%;
+		height: 40px;
+	}
+
+	.stats-empty {
+		font-size: 12px;
+		color: var(--text-secondary);
+		padding: 8px 0;
+		margin: 0;
+	}
+
+	.stats-loading {
+		font-size: 12px;
+		padding: 8px 0;
+		margin: 0;
 	}
 </style>

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -373,6 +373,48 @@
 		return xs.map((x, i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${ys[i].toFixed(1)}`).join(' ');
 	}
 
+	function sparklineAreaPoints(
+		points: Array<{ ts: number; requests: number }>,
+		w: number,
+		h: number
+	): string {
+		if (points.length < 2) return '';
+		const maxReq = Math.max(...points.map(p => p.requests), 1);
+		const xs = points.map((_, i) => (i / (points.length - 1)) * w);
+		const ys = points.map(p => h - (p.requests / maxReq) * (h - 2) - 1);
+		return xs.map((x, i) => `${x.toFixed(1)},${ys[i].toFixed(1)}`).join(' ') +
+			` ${w},${h} `;
+	}
+
+	let tooltipVisible = false;
+	let tooltipX: number | null = null;
+	let tooltipLeft = 0;
+	let tooltipData: { ts: number; requests: number } | null = null;
+
+	function handleSparklineMousemove(e: MouseEvent): void {
+		const svg = e.currentTarget as SVGSVGElement;
+		const rect = svg.getBoundingClientRect();
+		const svgX = ((e.clientX - rect.left) / rect.width) * 200;
+		tooltipX = svgX;
+		tooltipLeft = e.clientX - rect.left;
+		const points = stats?.sparkline ?? [];
+		if (points.length < 2) return;
+		const idx = Math.round((svgX / 200) * (points.length - 1));
+		const clamped = Math.max(0, Math.min(points.length - 1, idx));
+		tooltipData = points[clamped];
+		tooltipVisible = true;
+	}
+
+	function handleSparklineMouseleave(): void {
+		tooltipVisible = false;
+		tooltipX = null;
+		tooltipData = null;
+	}
+
+	function formatTooltipTime(ts: number): string {
+		return new Date(ts * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+	}
+
 	// Deploy key
 	let deployPublicKey = '';
 	let deployKeyCopied = false;
@@ -645,17 +687,43 @@
 				</div>
 			</div>
 
-			<!-- Live Stats Bar -->
-			<div class="live-bar" class:live-bar-active={liveConnected}>
-				<span class="live-badge">● LIVE</span>
-				<div class="live-metrics">
-					<span><span class="live-num">{liveReqPerSec.toFixed(1)}</span> req/s</span>
-					<span><span class="live-num">{formatBps(liveBandwidthOutBps)}</span> out</span>
-					<span><span class="live-num">{formatBps(liveBandwidthInBps)}</span> in</span>
-					<span><span class="live-num">{liveActiveConnections}</span> active</span>
-					{#if liveAvgLatencyMs !== null}
-						<span><span class="live-num">{Math.round(liveAvgLatencyMs)}ms</span> avg</span>
-					{/if}
+			<!-- Live Zone -->
+			<div class="live-zone" class:live-zone-active={liveConnected}>
+				<div class="live-zone-header">
+					<div class="live-zone-label">
+						<span class="live-dot" class:live-dot-connected={liveConnected}></span>
+						<span class="live-badge-text">{liveConnected ? 'LIVE' : 'OFFLINE'}</span>
+					</div>
+					<span class="live-zone-sub">Real-time · aggregate across all connections</span>
+				</div>
+				<div class="live-zone-metrics">
+					<div class="live-metric">
+						<span class="live-metric-value">{liveReqPerSec.toFixed(1)}</span>
+						<span class="live-metric-label">req/s</span>
+					</div>
+					<div class="live-metric-divider"></div>
+					<div class="live-metric">
+						<span
+							class="live-metric-value"
+							class:text-warning={liveAvgLatencyMs !== null && liveAvgLatencyMs > 500 && liveAvgLatencyMs <= 2000}
+							class:text-danger={liveAvgLatencyMs !== null && liveAvgLatencyMs > 2000}
+						>{liveAvgLatencyMs !== null ? `${Math.round(liveAvgLatencyMs)}ms` : '—'}</span>
+						<span class="live-metric-label">latency</span>
+					</div>
+					<div class="live-metric-divider"></div>
+					<div class="live-metric">
+						<span class="live-metric-value">{formatBps(liveBandwidthOutBps)}</span>
+						<span class="live-metric-label">out</span>
+					</div>
+					<div class="live-metric">
+						<span class="live-metric-value">{formatBps(liveBandwidthInBps)}</span>
+						<span class="live-metric-label">in</span>
+					</div>
+					<div class="live-metric-divider"></div>
+					<div class="live-metric">
+						<span class="live-metric-value">{liveActiveConnections}</span>
+						<span class="live-metric-label">connections (total)</span>
+					</div>
 				</div>
 			</div>
 
@@ -663,11 +731,13 @@
 			<div class="stats-panel">
 				<div class="stats-panel-header">
 					<h2 class="stats-panel-title">Traffic</h2>
-					<div class="range-toggle">
+					<div class="stat-tabs" role="tablist" aria-label="Stats time range">
 						{#each statRanges as r}
 							<button
-								class="range-btn"
-								class:range-btn-active={statsRange === r}
+								class="stat-tab"
+								class:stat-tab-active={statsRange === r}
+								role="tab"
+								aria-selected={statsRange === r}
 								on:click={() => setStatsRange(r)}
 							>{r}</button>
 						{/each}
@@ -677,57 +747,102 @@
 				{#if statsError}
 					<p class="stats-empty">No traffic data yet — starts collecting once Traefik access logging is active.</p>
 				{:else if stats !== null}
-					<div class="stats-row">
-						<div class="stat-item">
-							<span class="stat-label">Requests</span>
-							<span class="stat-value mono">{stats.requests.toLocaleString()}</span>
+					<div class="metric-grid">
+					<!-- Requests -->
+					<div class="metric-card">
+						<div class="metric-card-header">
+							<span class="metric-card-label">Requests</span>
 						</div>
-						<div class="stat-item">
-							<span class="stat-label">Visitors</span>
-							<span class="stat-value mono">{stats.human_requests.toLocaleString()}</span>
-							{#if stats.bot_requests > 0}
-								<span class="stat-sub text-secondary">{stats.bot_requests.toLocaleString()} bots</span>
-							{/if}
-						</div>
-						<div class="stat-item">
-							<span class="stat-label">Data served</span>
-							<span class="stat-value mono">{formatBytes(stats.bandwidth_bytes)}</span>
-						</div>
-						<div class="stat-item">
-							<span class="stat-label">Avg response</span>
-							<span class="stat-value mono">{stats.avg_ms !== null ? `${Math.round(stats.avg_ms)}ms` : '—'}</span>
-						</div>
-						<div class="stat-item">
-							<span class="stat-label">Error rate</span>
-							<span
-								class="stat-value mono"
-								class:text-danger={stats.error_rate > 0.05}
-								class:text-warning={stats.error_rate > 0.01 && stats.error_rate <= 0.05}
-							>{stats.requests > 0 ? `${(stats.error_rate * 100).toFixed(1)}%` : '—'}</span>
-						</div>
+						<span class="metric-card-value">{stats.requests.toLocaleString()}</span>
+						{#if stats.sparkline.length >= 2}
+							<div class="metric-card-sparkline-wrap">
+								<svg
+									class="metric-sparkline"
+									width="100%"
+									height="36"
+									viewBox="0 0 200 36"
+									preserveAspectRatio="none"
+									aria-hidden="true"
+									on:mousemove={handleSparklineMousemove}
+									on:mouseleave={handleSparklineMouseleave}
+								>
+									<defs>
+										<linearGradient id="sparkline-fill-requests" x1="0" y1="0" x2="0" y2="1">
+											<stop offset="0%" stop-color="var(--accent-teal)" stop-opacity="0.5" />
+											<stop offset="100%" stop-color="var(--accent-teal)" stop-opacity="0" />
+										</linearGradient>
+									</defs>
+									<polygon
+										points="{sparklineAreaPoints(stats.sparkline, 200, 34)}0,34"
+										fill="url(#sparkline-fill-requests)"
+									/>
+									<path
+										d={sparklinePath(stats.sparkline, 200, 34)}
+										fill="none"
+										stroke="var(--accent-teal)"
+										stroke-width="1.5"
+										stroke-linejoin="round"
+										stroke-linecap="round"
+									/>
+									{#if tooltipX !== null}
+										<line class="sparkline-crosshair" x1={tooltipX} y1="0" x2={tooltipX} y2="36" />
+									{/if}
+								</svg>
+								{#if tooltipVisible && tooltipData}
+									<div class="sparkline-tooltip" style="left: {tooltipLeft}px;">
+										<span class="sparkline-tooltip-val">{tooltipData.requests.toLocaleString()}</span>
+										<span class="sparkline-tooltip-ts">{formatTooltipTime(tooltipData.ts)}</span>
+									</div>
+								{/if}
+							</div>
+						{/if}
 					</div>
 
-					{#if stats.sparkline.length >= 2}
-						<div class="sparkline-wrap">
-							<svg
-								width="100%"
-								height="48"
-								viewBox="0 0 600 48"
-								preserveAspectRatio="none"
-								aria-hidden="true"
-							>
-								<path
-									d={sparklinePath(stats.sparkline, 600, 48)}
-									fill="none"
-									stroke="var(--accent-teal)"
-									stroke-width="1.5"
-									stroke-linejoin="round"
-									stroke-linecap="round"
-									opacity="0.8"
-								/>
-							</svg>
+					<!-- Visitors -->
+					<div class="metric-card">
+						<div class="metric-card-header">
+							<span class="metric-card-label">Visitors</span>
+							{#if stats.bot_requests > 0}
+								<span class="metric-card-badge">{stats.bot_requests.toLocaleString()} bots</span>
+							{/if}
 						</div>
-					{/if}
+						<span class="metric-card-value">{stats.human_requests.toLocaleString()}</span>
+					</div>
+
+					<!-- Avg Latency -->
+					<div class="metric-card">
+						<div class="metric-card-header">
+							<span class="metric-card-label">Avg Latency</span>
+						</div>
+						<span
+							class="metric-card-value"
+							class:text-warning={stats.avg_ms !== null && stats.avg_ms > 500 && stats.avg_ms <= 2000}
+							class:text-danger={stats.avg_ms !== null && stats.avg_ms > 2000}
+						>{stats.avg_ms !== null ? `${Math.round(stats.avg_ms)}ms` : '—'}</span>
+						{#if stats.avg_ms !== null && stats.avg_ms > 500}
+							<span class="metric-card-threshold-label">
+								{stats.avg_ms > 2000 ? 'Critical (>2s)' : 'Elevated (>500ms)'}
+							</span>
+						{/if}
+					</div>
+
+					<!-- Error Rate -->
+					<div class="metric-card">
+						<div class="metric-card-header">
+							<span class="metric-card-label">Error Rate</span>
+						</div>
+						<span
+							class="metric-card-value"
+							class:text-warning={stats.error_rate > 0.01 && stats.error_rate <= 0.05}
+							class:text-danger={stats.error_rate > 0.05}
+						>{stats.requests > 0 ? `${(stats.error_rate * 100).toFixed(1)}%` : '—'}</span>
+					</div>
+				</div>
+
+				<div class="stats-bandwidth-row">
+					<span class="stats-bandwidth-label">Data served</span>
+					<span class="stats-bandwidth-value mono">{formatBytes(stats.bandwidth_bytes)}</span>
+				</div>
 				{:else if statsLoading}
 					<p class="stats-loading text-secondary">Loading…</p>
 				{/if}
@@ -1899,46 +2014,6 @@
 		display: block;
 	}
 
-	/* Live stats bar */
-	.live-bar {
-		display: flex;
-		align-items: center;
-		gap: 16px;
-		background: var(--bg-surface);
-		border: 1px solid var(--border);
-		border-radius: 8px;
-		padding: 10px 16px;
-		margin-bottom: 12px;
-		opacity: 0.5;
-		transition: opacity 0.3s;
-	}
-	.live-bar-active {
-		opacity: 1;
-		border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
-	}
-	.live-badge {
-		font-size: 10px;
-		font-weight: 700;
-		letter-spacing: 0.08em;
-		color: var(--text-muted);
-		white-space: nowrap;
-	}
-	.live-bar-active .live-badge {
-		color: #4caf50;
-	}
-	.live-metrics {
-		display: flex;
-		gap: 20px;
-		flex-wrap: wrap;
-		font-size: 12px;
-		color: var(--text-secondary);
-	}
-	.live-num {
-		font-family: var(--font-mono, monospace);
-		font-weight: 600;
-		color: var(--text-primary);
-	}
-
 	/* Traffic stats panel */
 	.stats-panel {
 		background: var(--bg-surface);
@@ -1963,93 +2038,6 @@
 		color: var(--text-secondary);
 	}
 
-	.range-toggle {
-		display: flex;
-		border: 1px solid var(--border-bright);
-		border-radius: 4px;
-		overflow: hidden;
-	}
-
-	.range-btn {
-		background: transparent;
-		border: none;
-		border-right: 1px solid var(--border-bright);
-		color: var(--text-secondary);
-		font-size: 11px;
-		font-weight: 500;
-		padding: 4px 10px;
-		cursor: pointer;
-		transition: background 0.1s, color 0.1s;
-		font-family: var(--font-mono);
-	}
-
-	.range-btn:last-child {
-		border-right: none;
-	}
-
-	.range-btn:hover {
-		background: var(--bg-hover);
-		color: var(--text-primary);
-	}
-
-	.range-btn-active {
-		background: var(--accent-teal);
-		color: #fff;
-	}
-
-	.range-btn-active:hover {
-		background: var(--accent-teal-dim);
-		color: #fff;
-	}
-
-	.stats-row {
-		display: flex;
-		gap: 32px;
-		flex-wrap: wrap;
-		margin-bottom: 16px;
-	}
-
-	.stat-item {
-		display: flex;
-		flex-direction: column;
-		gap: 3px;
-		min-width: 80px;
-	}
-
-	.stat-label {
-		font-size: 11px;
-		font-weight: 500;
-		text-transform: uppercase;
-		letter-spacing: 0.07em;
-		color: var(--text-muted);
-	}
-
-	.stat-value {
-		font-size: 22px;
-		font-weight: 500;
-		color: var(--text-primary);
-		line-height: 1.1;
-	}
-
-	.stat-sub {
-		font-size: 11px;
-		font-family: var(--font-mono);
-	}
-
-	.sparkline-wrap {
-		width: 100%;
-		height: 48px;
-		border-top: 1px solid var(--border);
-		padding-top: 8px;
-		overflow: hidden;
-	}
-
-	.sparkline-wrap svg {
-		display: block;
-		width: 100%;
-		height: 40px;
-	}
-
 	.stats-empty {
 		font-size: 12px;
 		color: var(--text-secondary);
@@ -2061,5 +2049,294 @@
 		font-size: 12px;
 		padding: 8px 0;
 		margin: 0;
+	}
+
+	/* ── Live Zone ─────────────────────────────────────────────────────────── */
+	.live-zone {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		background: var(--bg-surface);
+		border: 1px solid var(--border);
+		border-left: 3px solid var(--live-disconnected);
+		border-radius: 8px;
+		padding: 12px 16px;
+		margin-bottom: 12px;
+		opacity: 0.55;
+		transition: opacity 0.3s ease, border-color 0.3s ease;
+	}
+	.live-zone-active {
+		opacity: 1;
+		border-left-color: var(--live-connected);
+		background: color-mix(in srgb, var(--live-connected) 4%, var(--bg-surface));
+	}
+	.live-zone-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+	.live-zone-label {
+		display: flex;
+		align-items: center;
+		gap: 7px;
+	}
+	.live-badge-text {
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		color: var(--live-disconnected);
+		font-family: var(--font-mono);
+	}
+	.live-zone-active .live-badge-text {
+		color: var(--live-connected);
+	}
+	.live-zone-sub {
+		font-size: 11px;
+		color: var(--text-muted);
+	}
+	.live-zone-metrics {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		row-gap: 8px;
+	}
+	.live-metric {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: 0 16px 0 0;
+	}
+	.live-metric-value {
+		font-family: var(--font-mono);
+		font-size: 20px;
+		font-weight: 600;
+		color: var(--text-primary);
+		line-height: 1;
+	}
+	.live-metric-label {
+		font-size: 10px;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.07em;
+		color: var(--text-muted);
+	}
+	.live-metric-divider {
+		width: 1px;
+		height: 28px;
+		background: var(--border-bright);
+		margin: 0 16px 0 0;
+		flex-shrink: 0;
+		align-self: center;
+	}
+	.live-dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background: var(--live-disconnected);
+		flex-shrink: 0;
+		transition: background 0.3s;
+	}
+	.live-dot-connected {
+		background: var(--live-connected);
+		animation: live-pulse 1.8s ease-in-out infinite;
+	}
+	@keyframes live-pulse {
+		0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--live-connected) 70%, transparent); }
+		60%  { box-shadow: 0 0 0 6px color-mix(in srgb, var(--live-connected) 0%, transparent); }
+		100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--live-connected) 0%, transparent); }
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.live-dot-connected { animation: none; }
+	}
+
+	/* ── Metric Grid ─────────────────────────────────────────────────────────── */
+	.metric-grid {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 10px;
+		margin-bottom: 12px;
+	}
+	.metric-card {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		background: var(--bg-elevated);
+		border: 1px solid var(--border);
+		border-radius: 8px;
+		padding: 12px 14px 10px;
+		min-height: 100px;
+		position: relative;
+		overflow: hidden;
+	}
+	.metric-card-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 6px;
+	}
+	.metric-card-label {
+		font-size: 10px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.09em;
+		color: var(--text-muted);
+	}
+	.metric-card-badge {
+		font-size: 10px;
+		font-family: var(--font-mono);
+		color: var(--text-secondary);
+		background: var(--bg-hover);
+		border-radius: 3px;
+		padding: 1px 5px;
+	}
+	.metric-card-value {
+		font-family: var(--font-mono);
+		font-size: 26px;
+		font-weight: 600;
+		color: var(--text-primary);
+		line-height: 1.1;
+		letter-spacing: -0.01em;
+	}
+	.metric-card-threshold-label {
+		font-size: 10px;
+		color: var(--text-muted);
+		font-family: var(--font-mono);
+	}
+	.metric-card-sparkline-wrap {
+		margin-top: auto;
+		padding-top: 8px;
+		position: relative;
+	}
+	.metric-sparkline {
+		display: block;
+		width: 100%;
+		height: 36px;
+		cursor: crosshair;
+	}
+	.sparkline-crosshair {
+		stroke: var(--text-muted);
+		stroke-width: 1;
+		stroke-dasharray: 2 2;
+		pointer-events: none;
+	}
+	.sparkline-tooltip {
+		position: absolute;
+		bottom: calc(100% + 4px);
+		transform: translateX(-50%);
+		background: var(--bg-elevated);
+		border: 1px solid var(--border-bright);
+		border-radius: 5px;
+		padding: 4px 8px;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1px;
+		pointer-events: none;
+		white-space: nowrap;
+		z-index: 10;
+	}
+	.sparkline-tooltip-val {
+		font-family: var(--font-mono);
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+	.sparkline-tooltip-ts {
+		font-size: 10px;
+		color: var(--text-secondary);
+	}
+
+	/* ── Bandwidth row ───────────────────────────────────────────────────────── */
+	.stats-bandwidth-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 0 4px;
+		border-top: 1px solid var(--border);
+		margin-top: 4px;
+	}
+	.stats-bandwidth-label {
+		font-size: 11px;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.07em;
+	}
+	.stats-bandwidth-value {
+		font-size: 13px;
+		color: var(--text-secondary);
+	}
+
+	/* ── Range Tabs ──────────────────────────────────────────────────────────── */
+	.stat-tabs {
+		display: flex;
+		gap: 2px;
+		background: var(--bg-elevated);
+		border: 1px solid var(--border-bright);
+		border-radius: 6px;
+		padding: 3px;
+	}
+	.stat-tab {
+		background: transparent;
+		border: none;
+		border-radius: 4px;
+		color: var(--text-secondary);
+		font-size: 11px;
+		font-weight: 500;
+		font-family: var(--font-mono);
+		padding: 4px 10px;
+		min-height: 36px;
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s;
+		line-height: 1;
+	}
+	.stat-tab:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+	.stat-tab-active {
+		background: var(--accent-teal);
+		color: #fff;
+	}
+	.stat-tab-active:hover {
+		background: var(--accent-teal-dim);
+		color: #fff;
+	}
+	.stat-tab:focus-visible {
+		outline: 2px solid var(--accent-teal);
+		outline-offset: 1px;
+	}
+
+	/* ── Mobile ──────────────────────────────────────────────────────────────── */
+	@media (max-width: 768px) {
+		.live-zone-metrics {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 8px;
+		}
+		.live-metric-divider {
+			width: 100%;
+			height: 1px;
+			margin: 0;
+		}
+		.live-zone-header {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 2px;
+		}
+		.metric-grid {
+			grid-template-columns: repeat(2, 1fr);
+		}
+		.metric-card-value {
+			font-size: 22px;
+		}
+		.stat-tabs {
+			flex-wrap: wrap;
+		}
+	}
+	@media (max-width: 480px) {
+		.metric-grid {
+			grid-template-columns: 1fr;
+		}
 	}
 </style>

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -356,6 +356,30 @@
 	function setStatsRange(r: StatRange): void {
 		statsRange = r;
 		loadStats(r);
+		loadPageStats(r);
+	}
+
+	// ── Page analytics ─────────────────────────────────────────────────────────
+	interface TopPage {
+		path: string;
+		requests: number;
+		human_requests: number;
+		avg_ms: number | null;
+		error_rate: number;
+		trend: number | null;
+	}
+	interface PageStatsData {
+		range: StatRange;
+		top_pages: TopPage[];
+		top_referrers: Array<{ referrer_domain: string; requests: number }>;
+	}
+	let pageStats: PageStatsData | null = null;
+
+	async function loadPageStats(range: StatRange): Promise<void> {
+		try {
+			const res = await fetch(`/api/sites/${site.slug}/stats/pages?range=${range}`);
+			if (res.ok) pageStats = await res.json();
+		} catch { /* silently fail */ }
 	}
 
 	function formatBytes(bytes: number): string {
@@ -476,6 +500,7 @@
 
 		// Load stats for overview tab
 		loadStats(statsRange);
+		loadPageStats(statsRange);
 
 		// Poll stats every 60s
 		const statsPollTimer = setInterval(() => loadStats(statsRange), 60_000);
@@ -860,6 +885,65 @@
 					</div>
 				</div>
 			{/if}
+
+			<!-- Top Pages Panel -->
+			<div class="stats-panel">
+				<div class="stats-panel-header">
+					<h2 class="stats-panel-title">Top Pages</h2>
+				</div>
+				{#if pageStats === null}
+					<p class="stats-empty">Page analytics will appear here once traffic is recorded.</p>
+				{:else if pageStats.top_pages.length === 0}
+					<p class="stats-empty">No page data for this period yet.</p>
+				{:else}
+					<div class="top-pages-list">
+						{#each pageStats.top_pages as page, i}
+							{@const pct = pageStats.top_pages[0].requests > 0
+								? (page.requests / pageStats.top_pages[0].requests) * 100 : 0}
+							<div class="top-page-row">
+								<span class="page-rank text-muted mono">{i + 1}</span>
+								<div class="page-bar-wrap">
+									<div class="page-bar" style="width: {pct}%"></div>
+									<span class="page-path mono" title={page.path}>{page.path}</span>
+								</div>
+								<span class="page-count mono">{page.requests.toLocaleString()}</span>
+								{#if page.trend !== null}
+									<span class="page-trend" class:trend-up={page.trend > 0} class:trend-down={page.trend < 0}>
+										{page.trend > 0 ? '▲' : '▼'} {Math.abs(page.trend)}%
+									</span>
+								{/if}
+								{#if page.avg_ms !== null}
+									<span class="page-ms text-muted mono">{Math.round(page.avg_ms)}ms</span>
+								{/if}
+								<span
+									class="page-error mono"
+									class:text-warning={page.error_rate > 0.01 && page.error_rate <= 0.05}
+									class:text-danger={page.error_rate > 0.05}
+								>{(page.error_rate * 100).toFixed(1)}% err</span>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
+			<!-- Top Referrers Panel -->
+			<div class="stats-panel">
+				<div class="stats-panel-header">
+					<h2 class="stats-panel-title">Top Referrers</h2>
+				</div>
+				{#if pageStats === null || pageStats.top_referrers.length === 0}
+					<p class="stats-empty">No referrer data for this period yet.</p>
+				{:else}
+					<div class="referrers-list">
+						{#each pageStats.top_referrers.slice(0, 10) as ref}
+							<div class="referrer-row">
+								<span class="referrer-domain mono">{ref.referrer_domain || 'direct'}</span>
+								<span class="mono text-secondary">{ref.requests.toLocaleString()}</span>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
 		</div>
 	{/if}
 
@@ -2266,6 +2350,23 @@
 		font-size: 13px;
 		color: var(--text-secondary);
 	}
+
+	/* ── Top Pages + Referrers ───────────────────────────────────────────────── */
+	.top-pages-list { display: flex; flex-direction: column; gap: 6px; }
+	.top-page-row { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+	.page-rank { width: 16px; text-align: right; color: var(--text-muted); font-size: 11px; flex-shrink: 0; }
+	.page-bar-wrap { flex: 1; position: relative; min-width: 0; }
+	.page-bar { position: absolute; left: 0; top: 0; bottom: 0; background: color-mix(in srgb, var(--accent-teal) 20%, transparent); border-radius: 2px; pointer-events: none; }
+	.page-path { position: relative; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: block; padding: 3px 6px; color: var(--text-primary); }
+	.page-count { color: var(--text-secondary); white-space: nowrap; flex-shrink: 0; }
+	.page-ms { font-size: 11px; white-space: nowrap; flex-shrink: 0; }
+	.page-error { font-size: 11px; white-space: nowrap; flex-shrink: 0; color: var(--text-muted); }
+	.page-trend { font-size: 10px; font-family: var(--font-mono); white-space: nowrap; flex-shrink: 0; }
+	.trend-up { color: var(--success); }
+	.trend-down { color: var(--danger); }
+	.referrers-list { display: flex; flex-direction: column; gap: 4px; }
+	.referrer-row { display: flex; justify-content: space-between; align-items: center; font-size: 12px; padding: 2px 0; }
+	.referrer-domain { color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 	/* ── Range Tabs ──────────────────────────────────────────────────────────── */
 	.stat-tabs {


### PR DESCRIPTION
## Summary

- **Internal Mode (step-ca)** — self-signed CA bootstrap, Traefik internal-ca resolver, internal TLD DNS provisioning, resolver-aware route generation, network_mode config field, trust-certificate endpoint, Network Mode settings UI
- **Traffic Analytics** — Traefik access log ingestion → SQLite rollups (15-min buckets), per-site stats (requests, bandwidth, latency, error rate), sparkline charts, 24h/7d/30d range toggle
- **Live Stats** — Traefik Prometheus scraper (3s interval) → SSE endpoint → real-time Live Zone card (req/s, latency, bandwidth, connections) with pulsing indicator
- **Page Analytics** — per-path rollups, top pages with trend deltas vs. prior period, top referrers, separate panels with empty states
- **Stats UI redesign** — metric card grid, filled area sparklines with hover crosshair tooltip, color-coded latency/error thresholds, mobile responsive layout

## Test plan

- [ ] `docker compose up -d --build` — all services start cleanly
- [ ] Internal mode: step-ca bootstrap succeeds, Traefik issues internal certs
- [ ] Traffic panel: requests/bandwidth/latency/error rate populate after generating traffic
- [ ] Live Zone: LIVE badge turns green within 3s of page load
- [ ] Top Pages: paths appear after traffic hits multiple URLs
- [ ] Top Referrers: referrer domains appear when Referer header is sent
- [ ] Range tabs (24h/7d/30d) update all three panels simultaneously
- [ ] TypeScript build: `cd api && npx tsc --noEmit` — clean
- [ ] Frontend build: `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)