### PR TITLE
feat(services): container management view, lifecycle checkpoint, and CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
 
   build-api:
     name: Build API

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   typecheck-api:
     name: Typecheck API
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: api
@@ -25,7 +25,7 @@ jobs:
 
   typecheck-frontend:
     name: Typecheck Frontend
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -38,7 +38,7 @@ jobs:
 
   build-frontend:
     name: Build Frontend
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: typecheck-frontend
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
 
   build-api:
     name: Build API
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: typecheck-api
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build frontend image
-        run: docker build --tag hermithost-frontend:ci-${{ github.sha }} .
+        run: docker buildx build --tag hermithost-frontend:ci-${{ github.sha }} .
       - name: Build API image
-        run: docker build --tag hermithost-api:ci-${{ github.sha }} ./api
+        run: docker buildx build --tag hermithost-api:ci-${{ github.sha }} ./api
       - name: Clean up CI images
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build frontend image
-        run: docker buildx build --tag hermithost-frontend:ci-${{ github.sha }} .
+        run: docker build -t hermithost-frontend:ci-${{ github.sha }} .
       - name: Build API image
-        run: docker buildx build --tag hermithost-api:ci-${{ github.sha }} ./api
+        run: docker build -t hermithost-api:ci-${{ github.sha }} ./api
       - name: Clean up CI images
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,24 +68,17 @@ jobs:
 
   docker-build:
     name: Docker Build
-    runs-on: ubuntu-latest
+    # Self-hosted for persistent layer cache — images don't need to be pushed here
+    runs-on: self-hosted
     needs: [build-frontend, build-api]
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
       - name: Build frontend image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          dockerfile: Dockerfile
-          push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        run: docker build --tag hermithost-frontend:ci-${{ github.sha }} .
       - name: Build API image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./api
-          dockerfile: api/Dockerfile
-          push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        run: docker build --tag hermithost-api:ci-${{ github.sha }} ./api
+      - name: Clean up CI images
+        if: always()
+        run: |
+          docker rmi hermithost-frontend:ci-${{ github.sha }} || true
+          docker rmi hermithost-api:ci-${{ github.sha }} || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,9 @@ on:
     branches: [main]
 
 jobs:
-  typecheck-api:
-    name: Typecheck API
+  # ── API: typecheck + build in one job (avoids double npm ci) ──────────────
+  api:
+    name: API — Typecheck & Build
     runs-on: self-hosted
     defaults:
       run:
@@ -17,70 +18,58 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: api/package-lock.json
       - run: npm ci
-      - run: npx tsc --noEmit
+      - name: Typecheck
+        run: npx tsc --noEmit
+      - name: Build
+        run: npm run build
 
-  typecheck-frontend:
-    name: Typecheck Frontend
+  # ── Frontend: typecheck + svelte-check + build ───────────────────────────
+  frontend:
+    name: Frontend — Typecheck & Build
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx svelte-kit sync
-      - run: npx tsc --noEmit
-
-  build-frontend:
-    name: Build Frontend
-    runs-on: self-hosted
-    needs: typecheck-frontend
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - run: npm ci
-      - run: npm run build
+      - name: Sync SvelteKit
+        run: npx svelte-kit sync
+      - name: Typecheck
+        run: npx tsc --noEmit
+      - name: Svelte Check
+        run: npx svelte-check --threshold warning
+      - name: Build
+        run: npm run build
         env:
           NODE_OPTIONS: --max-old-space-size=4096
 
-  build-api:
-    name: Build API
+  # ── Docker: validate both images build cleanly ───────────────────────────
+  docker:
+    name: Docker — Image Build
     runs-on: self-hosted
-    needs: typecheck-api
-    defaults:
-      run:
-        working-directory: api
+    needs: [api, frontend]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: api/package-lock.json
-      - run: npm ci
-      - run: npm run build
-
-  docker-build:
-    name: Docker Build
-    # Self-hosted for persistent layer cache — images don't need to be pushed here
-    runs-on: self-hosted
-    needs: [build-frontend, build-api]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build frontend image
-        run: docker build -t hermithost-frontend:ci-${{ github.sha }} .
       - name: Build API image
-        run: docker build -t hermithost-api:ci-${{ github.sha }} ./api
+        run: |
+          docker buildx build \
+            --load \
+            --tag hermithost-api:ci-${{ github.sha }} \
+            ./api
+      - name: Build Frontend image
+        run: |
+          docker buildx build \
+            --load \
+            --tag hermithost-frontend:ci-${{ github.sha }} \
+            .
       - name: Clean up CI images
         if: always()
         run: |
-          docker rmi hermithost-frontend:ci-${{ github.sha }} || true
           docker rmi hermithost-api:ci-${{ github.sha }} || true
+          docker rmi hermithost-frontend:ci-${{ github.sha }} || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Typecheck
         run: npx tsc --noEmit
       - name: Svelte Check
-        run: npx svelte-check --threshold warning
+        run: npx svelte-check --threshold error
       - name: Build
         run: npm run build
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,107 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+# Only one deploy at a time — cancel queued if a newer commit lands
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to Hammer
+    runs-on: self-hosted
+    environment: production
+    env:
+      # Existing stack .env lives here — contains secrets not stored in Actions
+      STACK_ENV: /Users/rdemeritt/projects/ai/hermithost/.env
+      # Compose project name must match the running stack
+      COMPOSE_PROJECT: hermithost
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Build new images from checked-out source ──────────────────────────
+      - name: Build API image
+        run: |
+          docker build \
+            --tag hermithost-api:${{ github.sha }} \
+            --tag hermithost-api:latest \
+            ./api
+
+      - name: Build Frontend image
+        run: |
+          docker build \
+            --tag hermithost-frontend:${{ github.sha }} \
+            --tag hermithost-frontend:latest \
+            .
+
+      # ── Snapshot running container IDs for rollback ───────────────────────
+      - name: Snapshot current containers
+        id: snapshot
+        run: |
+          API_ID=$(docker ps -q --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" \
+                                --filter "label=com.docker.compose.service=api" | head -1)
+          FE_ID=$(docker ps -q  --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" \
+                                --filter "label=com.docker.compose.service=frontend" | head -1)
+          echo "api_id=$API_ID"   >> $GITHUB_OUTPUT
+          echo "fe_id=$FE_ID"     >> $GITHUB_OUTPUT
+
+      # ── Hot-swap: replace only api + frontend, leave everything else alone ─
+      - name: Deploy API
+        run: |
+          docker compose \
+            -p $COMPOSE_PROJECT \
+            --env-file $STACK_ENV \
+            up -d --no-deps --no-build api
+
+      - name: Deploy Frontend
+        run: |
+          docker compose \
+            -p $COMPOSE_PROJECT \
+            --env-file $STACK_ENV \
+            up -d --no-deps --no-build frontend
+
+      # ── Health checks ─────────────────────────────────────────────────────
+      - name: Wait for API
+        run: |
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:3001/api/health > /dev/null; then
+              echo "API healthy after ${i}s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "API health check failed after 30s"
+          exit 1
+
+      - name: Wait for Frontend
+        run: |
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:3000 > /dev/null; then
+              echo "Frontend healthy after ${i}s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Frontend health check failed after 30s"
+          exit 1
+
+      # ── Rollback on failure ───────────────────────────────────────────────
+      - name: Rollback on failure
+        if: failure() && steps.snapshot.outputs.api_id != ''
+        run: |
+          echo "Deploy or health check failed — rolling back"
+          docker compose \
+            -p $COMPOSE_PROJECT \
+            --env-file $STACK_ENV \
+            up -d --no-deps --no-build api frontend || true
+          echo "Rollback attempted — manual inspection may be needed"
+
+      # ── Clean up old images (keep last 3 tagged by sha) ──────────────────
+      - name: Prune old images
+        if: success()
+        run: |
+          docker image prune -f --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,104 +4,129 @@ on:
   push:
     branches: [main]
 
-# Only one deploy at a time — cancel queued if a newer commit lands
+# One deploy at a time — queue rather than cancel
 concurrency:
   group: deploy-production
   cancel-in-progress: false
 
 jobs:
   deploy:
-    name: Deploy to Hammer
+    name: Deploy to Production
     runs-on: self-hosted
     environment: production
+
     env:
-      # Existing stack .env lives here — contains secrets not stored in Actions
-      STACK_ENV: /Users/rdemeritt/projects/ai/hermithost/.env
-      # Compose project name must match the running stack
       COMPOSE_PROJECT: hermithost
+      # Path to the live stack on this machine — contains secrets not in Actions
+      # Override via GitHub Actions variable STACK_DIR if the path changes
+      STACK_DIR: ${{ vars.STACK_DIR || '/Users/rdemeritt/projects/ai/hermithost' }}
 
     steps:
       - uses: actions/checkout@v4
 
+      # ── Record current image IDs for rollback ─────────────────────────────
+      - name: Snapshot current image IDs
+        id: snapshot
+        run: |
+          API_IMG=$(docker inspect \
+            $(docker ps -q \
+              --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" \
+              --filter "label=com.docker.compose.service=api" | head -1) \
+            --format '{{.Image}}' 2>/dev/null || echo "")
+          FE_IMG=$(docker inspect \
+            $(docker ps -q \
+              --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" \
+              --filter "label=com.docker.compose.service=frontend" | head -1) \
+            --format '{{.Image}}' 2>/dev/null || echo "")
+          echo "api_image=$API_IMG" >> $GITHUB_OUTPUT
+          echo "fe_image=$FE_IMG"   >> $GITHUB_OUTPUT
+          echo "Current API image:      $API_IMG"
+          echo "Current Frontend image: $FE_IMG"
+
       # ── Build new images from checked-out source ──────────────────────────
+      # docker compose build tags images as {project}-{service} automatically.
+      # Using --no-cache on deploy ensures we pick up dependency updates.
       - name: Build API image
         run: |
-          docker build \
-            --tag hermithost-api:${{ github.sha }} \
-            --tag hermithost-api:latest \
-            ./api
+          docker compose \
+            -p $COMPOSE_PROJECT \
+            --env-file $STACK_DIR/.env \
+            build --no-cache api
 
       - name: Build Frontend image
         run: |
-          docker build \
-            --tag hermithost-frontend:${{ github.sha }} \
-            --tag hermithost-frontend:latest \
-            .
+          docker compose \
+            -p $COMPOSE_PROJECT \
+            --env-file $STACK_DIR/.env \
+            build --no-cache frontend
 
-      # ── Snapshot running container IDs for rollback ───────────────────────
-      - name: Snapshot current containers
-        id: snapshot
-        run: |
-          API_ID=$(docker ps -q --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" \
-                                --filter "label=com.docker.compose.service=api" | head -1)
-          FE_ID=$(docker ps -q  --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" \
-                                --filter "label=com.docker.compose.service=frontend" | head -1)
-          echo "api_id=$API_ID"   >> $GITHUB_OUTPUT
-          echo "fe_id=$FE_ID"     >> $GITHUB_OUTPUT
-
-      # ── Hot-swap: replace only api + frontend, leave everything else alone ─
+      # ── Hot-swap containers — infra (DB, Redis, Coolify) untouched ────────
       - name: Deploy API
         run: |
           docker compose \
             -p $COMPOSE_PROJECT \
-            --env-file $STACK_ENV \
+            --env-file $STACK_DIR/.env \
             up -d --no-deps --no-build api
 
       - name: Deploy Frontend
         run: |
           docker compose \
             -p $COMPOSE_PROJECT \
-            --env-file $STACK_ENV \
+            --env-file $STACK_DIR/.env \
             up -d --no-deps --no-build frontend
 
-      # ── Health checks ─────────────────────────────────────────────────────
-      - name: Wait for API
+      # ── Health checks (30s window, 2s interval) ───────────────────────────
+      - name: Health check — API
         run: |
           for i in $(seq 1 15); do
             if curl -sf http://localhost:3001/api/health > /dev/null; then
-              echo "API healthy after ${i}s"
+              echo "✓ API healthy (attempt $i)"
               exit 0
             fi
+            echo "  waiting... ($i/15)"
             sleep 2
           done
-          echo "API health check failed after 30s"
+          echo "✗ API health check failed after 30s"
           exit 1
 
-      - name: Wait for Frontend
+      - name: Health check — Frontend
         run: |
           for i in $(seq 1 15); do
             if curl -sf http://localhost:3000 > /dev/null; then
-              echo "Frontend healthy after ${i}s"
+              echo "✓ Frontend healthy (attempt $i)"
               exit 0
             fi
+            echo "  waiting... ($i/15)"
             sleep 2
           done
-          echo "Frontend health check failed after 30s"
+          echo "✗ Frontend health check failed after 30s"
           exit 1
 
-      # ── Rollback on failure ───────────────────────────────────────────────
-      - name: Rollback on failure
-        if: failure() && steps.snapshot.outputs.api_id != ''
+      # ── Rollback: restore previous image IDs on any failure ──────────────
+      - name: Rollback
+        if: failure() && steps.snapshot.outputs.api_image != ''
         run: |
-          echo "Deploy or health check failed — rolling back"
-          docker compose \
-            -p $COMPOSE_PROJECT \
-            --env-file $STACK_ENV \
-            up -d --no-deps --no-build api frontend || true
-          echo "Rollback attempted — manual inspection may be needed"
+          echo "Deploy failed — restoring previous images"
+          API_IMG="${{ steps.snapshot.outputs.api_image }}"
+          FE_IMG="${{ steps.snapshot.outputs.fe_image }}"
 
-      # ── Clean up old images (keep last 3 tagged by sha) ──────────────────
-      - name: Prune old images
+          if [ -n "$API_IMG" ]; then
+            docker tag "$API_IMG" hermithost-api:rollback
+            docker compose \
+              -p $COMPOSE_PROJECT \
+              --env-file $STACK_DIR/.env \
+              up -d --no-deps --no-build api
+          fi
+          if [ -n "$FE_IMG" ]; then
+            docker tag "$FE_IMG" hermithost-frontend:rollback
+            docker compose \
+              -p $COMPOSE_PROJECT \
+              --env-file $STACK_DIR/.env \
+              up -d --no-deps --no-build frontend
+          fi
+          echo "Rollback complete — verify stack manually"
+
+      # ── Prune dangling images left by old builds ──────────────────────────
+      - name: Prune dangling images
         if: success()
-        run: |
-          docker image prune -f --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" || true
+        run: docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,9 @@ test-dns-*.js
 test-results-*.json
 test-cname-bug-results.json
 
+# Lifecycle checkpoint data (runtime files — not source)
+data/*
+!data/.gitkeep
+
 # Harness workspace (should live in molt-and-deploy-harness, not here)
 clients/

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,6 +7,7 @@ import dnsRouter from './routes/dns';
 import backupRouter from './routes/backup';
 import configRouter from './routes/config';
 import statsRouter from './routes/stats';
+import servicesRouter from './routes/services';
 import { getDeployedSite } from './services/githubDeploy';
 import { startStatsIngester } from './services/statsIngester';
 import { startLiveStats } from './services/liveStats';
@@ -29,6 +30,7 @@ app.use('/api/dns', dnsRouter);
 app.use('/api/backup', backupRouter);
 app.use('/api/config', configRouter);
 app.use('/api/sites/:slug/stats', statsRouter);
+app.use('/api/services', servicesRouter);
 
 // Dynamic static file serving for deployed sites
 // GET /hosted/:slug/* → serves from the site's detected serveDir

--- a/api/src/routes/services.ts
+++ b/api/src/routes/services.ts
@@ -1,0 +1,260 @@
+import { Router, Request, Response } from 'express';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
+import * as path from 'path';
+import { dockerGet, dockerPost, dockerDelete } from '../services/docker';
+import { createCoolifyClient } from '../services/coolify';
+import { ServiceContainer, ContainerStatus, ServiceGroup, ServicesResponse, RestoreEvent } from '../types';
+
+const router = Router();
+
+const DATA_DIR = process.env.DATA_DIR ?? '/app/data';
+const RESTORE_EVENT_FILE = path.join(DATA_DIR, 'restore-event.json');
+const RESTORE_CONTAINERS_FILE = path.join(DATA_DIR, 'restore-containers.json');
+
+// ── Docker container shape (subset) ──────────────────────────────────────────
+interface DockerContainer {
+  Id: string;
+  Names: string[];
+  Image: string;
+  State: string;
+  Status: string;
+  Labels: Record<string, string>;
+}
+
+function mapStatus(state: string): ContainerStatus {
+  switch (state.toLowerCase()) {
+    case 'running':    return 'running';
+    case 'exited':     return 'exited';
+    case 'paused':     return 'paused';
+    case 'restarting': return 'restarting';
+    case 'dead':       return 'dead';
+    default:           return 'stopped';
+  }
+}
+
+function shortenImage(image: string): string {
+  // Strip registry prefix (e.g. ghcr.io/foo/bar:tag → foo/bar:tag)
+  return image.replace(/^[^/]+\.[^/]+\//, '');
+}
+
+function extractDomain(labels: Record<string, string>): string | null {
+  // Prefer caddy_0 label: "https://probablyfine.570n3r.com"
+  const caddy = labels['caddy_0'];
+  if (caddy) return caddy.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+  // Fall back to traefik rule: Host(`domain.com`)
+  for (const [key, val] of Object.entries(labels)) {
+    if (key.startsWith('traefik.http.routers.') && key.endsWith('.rule')) {
+      const m = val.match(/Host\(`([^`]+)`\)/);
+      if (m) return m[1];
+    }
+  }
+  return null;
+}
+
+function mapContainer(c: DockerContainer, group: ServiceContainer['group']): ServiceContainer {
+  return {
+    id: c.Id.slice(0, 12),
+    name: (c.Names[0] ?? '').replace(/^\//, ''),
+    image: shortenImage(c.Image),
+    status: mapStatus(c.State),
+    state: c.State,
+    uptime: c.Status ?? null,
+    group,
+    siteSlug: c.Labels['coolify.name'] ?? null,
+  };
+}
+
+// ── Stack grouping ────────────────────────────────────────────────────────────
+// Groups hermithost stack containers by logical function using service name.
+const STACK_GROUP_MAP: { id: string; name: string; match: (svc: string) => boolean }[] = [
+  { id: 'coolify',        name: 'Coolify',          match: s => s.startsWith('coolify') },
+  { id: 'hermithost',     name: 'HermitHost',       match: s => s === 'api' || s === 'frontend' },
+  { id: 'infrastructure', name: 'Infrastructure',   match: () => true }, // catch-all
+];
+
+function groupStackContainers(containers: DockerContainer[]): ServiceGroup[] {
+  const groups = new Map<string, ServiceGroup>();
+  for (const def of STACK_GROUP_MAP) {
+    groups.set(def.id, { id: def.id, name: def.name, domain: null, abandoned: false, containers: [] });
+  }
+  for (const c of containers) {
+    const svcName = c.Labels['com.docker.compose.service'] ?? '';
+    const def = STACK_GROUP_MAP.find(d => d.match(svcName)) ?? STACK_GROUP_MAP[STACK_GROUP_MAP.length - 1];
+    groups.get(def.id)!.containers.push(mapContainer(c, 'hermithost-stack'));
+  }
+  return Array.from(groups.values()).filter(g => g.containers.length > 0);
+}
+
+// ── Site grouping ─────────────────────────────────────────────────────────────
+// A site group is "abandoned" if:
+//   - container has no coolify.applicationId label, OR
+//   - coolify.resourceName is absent, OR
+//   - the applicationId is not found in the live Coolify application list
+//     (i.e. the app was deleted in Coolify but the container was not cleaned up)
+// Containers that belong to the hermithost compose stack are excluded — they appear
+// in Stack Services already and are Coolify infrastructure, not deployed user sites.
+function groupBySite(containers: DockerContainer[], liveAppIds: Set<string> | null): ServiceGroup[] {
+  const groups = new Map<string, ServiceGroup>();
+  for (const c of containers) {
+    // Skip hermithost stack containers — they're Coolify infra, not user sites
+    if (c.Labels['com.docker.compose.project'] === 'hermithost') continue;
+    // Skip Coolify's own infrastructure containers (proxy, sentinel, etc.)
+    if (c.Labels['com.docker.compose.project'] === 'coolify') continue;
+
+    const slug = c.Labels['coolify.name'] ?? c.Id.slice(0, 12);
+    const resourceName = c.Labels['coolify.resourceName'];
+    const appId = c.Labels['coolify.applicationId'];
+    const name = resourceName ?? slug;
+    // Abandoned: missing labels, OR (if Coolify is reachable) app not in live app list
+    const abandoned = !resourceName || !appId || (liveAppIds !== null && !liveAppIds.has(appId));
+    if (!groups.has(slug)) {
+      groups.set(slug, { id: slug, name, domain: extractDomain(c.Labels), abandoned, containers: [] });
+    }
+    groups.get(slug)!.containers.push(mapContainer(c, 'deployed-sites'));
+  }
+  return Array.from(groups.values());
+}
+
+function readAndClearRestoreEvent(): RestoreEvent | null {
+  try {
+    if (!existsSync(RESTORE_EVENT_FILE)) return null;
+    const raw = readFileSync(RESTORE_EVENT_FILE, 'utf8');
+    const event = JSON.parse(raw) as RestoreEvent;
+    unlinkSync(RESTORE_EVENT_FILE);
+    return event;
+  } catch {
+    return null;
+  }
+}
+
+// ── GET /api/services — list all containers in both groups ───────────────────
+router.get('/', async (_req: Request, res: Response) => {
+  try {
+    const stackFilter = encodeURIComponent(JSON.stringify({ label: ['com.docker.compose.project=hermithost'] }));
+    const sitesFilter = encodeURIComponent(JSON.stringify({ label: ['coolify.managed=true'] }));
+
+    // Fetch Docker containers and live Coolify app list in parallel.
+    // If Coolify is unreachable, liveAppIds is null — fall back to label-only detection.
+    const coolify = createCoolifyClient();
+    const [stackRaw, sitesRaw, coolifyApps] = await Promise.all([
+      dockerGet(`/containers/json?all=true&filters=${stackFilter}`) as Promise<DockerContainer[]>,
+      dockerGet(`/containers/json?all=true&filters=${sitesFilter}`) as Promise<DockerContainer[]>,
+      coolify ? coolify.listApplications().catch(() => null) : Promise.resolve(null),
+    ]);
+
+    // null = Coolify unreachable; skip UUID cross-check to avoid false positives
+    const liveAppIds: Set<string> | null = coolifyApps ? new Set(coolifyApps.map(a => a.uuid)) : null;
+
+    const response: ServicesResponse = {
+      stackGroups: groupStackContainers(stackRaw),
+      siteGroups: groupBySite(sitesRaw, liveAppIds),
+      restoreEvent: readAndClearRestoreEvent(),
+    };
+    res.status(200).json(response);
+  } catch (err) {
+    console.error('[services] GET / failed:', (err as Error).message);
+    res.status(502).json({ error: 'Failed to list containers from Docker' });
+  }
+});
+
+// ── POST /api/services/:id/start ─────────────────────────────────────────────
+router.post('/:id/start', async (req: Request, res: Response) => {
+  try {
+    await dockerPost(`/containers/${req.params.id}/start`);
+    res.status(204).send();
+  } catch (err) {
+    console.error(`[services] start ${req.params.id} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Failed to start container' });
+  }
+});
+
+// ── POST /api/services/:id/stop ──────────────────────────────────────────────
+router.post('/:id/stop', async (req: Request, res: Response) => {
+  try {
+    await dockerPost(`/containers/${req.params.id}/stop?t=10`);
+    res.status(204).send();
+  } catch (err) {
+    console.error(`[services] stop ${req.params.id} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Failed to stop container' });
+  }
+});
+
+// ── POST /api/services/:id/restart ───────────────────────────────────────────
+router.post('/:id/restart', async (req: Request, res: Response) => {
+  try {
+    await dockerPost(`/containers/${req.params.id}/restart?t=10`);
+    res.status(204).send();
+  } catch (err) {
+    console.error(`[services] restart ${req.params.id} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Failed to restart container' });
+  }
+});
+
+// ── DELETE /api/services/:id — remove an abandoned container ─────────────────
+// Uses force=true to handle running containers; intended only for abandoned ones.
+router.delete('/:id', async (req: Request, res: Response) => {
+  try {
+    // Force-remove: stops if running, then physically deletes
+    await dockerDelete(`/containers/${req.params.id}?force=true`);
+    res.status(204).send();
+  } catch (err) {
+    const msg = (err as Error).message;
+    // 404 / "no such container" = already gone — idempotent success
+    if (msg.includes('404') || msg.toLowerCase().includes('no such container')) {
+      res.status(204).send();
+      return;
+    }
+    console.error(`[services] delete ${req.params.id} failed:`, msg);
+    res.status(502).json({ error: msg });
+  }
+});
+
+// ── POST /api/services/shutdown ──────────────────────────────────────────────
+// Stops all coolify-managed containers, writes checkpoint, then shuts down stack.
+router.post('/shutdown', async (_req: Request, res: Response) => {
+  try {
+    // List running coolify-managed containers
+    const filter = encodeURIComponent(JSON.stringify({ label: ['coolify.managed=true'], status: ['running'] }));
+    const runningContainers = await dockerGet(`/containers/json?filters=${filter}`) as DockerContainer[];
+
+    // Write restore checkpoint
+    try {
+      mkdirSync(DATA_DIR, { recursive: true });
+      const checkpoint = runningContainers.map(c => ({ id: c.Id.slice(0, 12), name: (c.Names[0] ?? '').replace(/^\//, '') }));
+      writeFileSync(RESTORE_CONTAINERS_FILE, JSON.stringify(checkpoint, null, 2), 'utf8');
+      console.log(`[shutdown] Checkpoint written: ${checkpoint.length} container(s)`);
+    } catch (err) {
+      console.warn('[shutdown] Failed to write checkpoint:', (err as Error).message);
+    }
+
+    // Stop coolify containers
+    await Promise.all(runningContainers.map(c => dockerPost(`/containers/${c.Id.slice(0, 12)}/stop?t=10`).catch(() => {})));
+    console.log(`[shutdown] Stopped ${runningContainers.length} coolify container(s)`);
+
+    // Respond before self-shutdown
+    res.status(202).json({ message: 'Coolify containers stopped. Stack shutting down.', stopped: runningContainers.length });
+
+    // After response flushes, stop the hermithost stack via docker socket
+    setTimeout(async () => {
+      try {
+        const stackFilter = encodeURIComponent(JSON.stringify({ label: ['com.docker.compose.project=hermithost'], status: ['running'] }));
+        const stackContainers = await dockerGet(`/containers/json?filters=${stackFilter}`) as DockerContainer[];
+        // Stop all except self (api container) last
+        const selfName = process.env.HOSTNAME ?? '';
+        const others = stackContainers.filter(c => !c.Names.some(n => n.includes('api')));
+        const self = stackContainers.filter(c => c.Names.some(n => n.includes('api')));
+        await Promise.all(others.map(c => dockerPost(`/containers/${c.Id.slice(0, 12)}/stop?t=10`).catch(() => {})));
+        await Promise.all(self.map(c => dockerPost(`/containers/${c.Id.slice(0, 12)}/stop?t=5`).catch(() => {})));
+        console.log(`[shutdown] Stack stopped (${stackContainers.length} containers)`);
+      } catch (err) {
+        console.error('[shutdown] Failed to stop stack:', (err as Error).message);
+      }
+    }, 1500);
+
+  } catch (err) {
+    console.error('[services] shutdown failed:', (err as Error).message);
+    res.status(502).json({ error: 'Failed to initiate shutdown' });
+  }
+});
+
+export default router;

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { readFileSync, writeFileSync, unlinkSync } from 'fs';
-import * as http from 'http';
 import * as path from 'path';
+import { dockerGet } from '../services/docker';
 import { DnsRecord } from '../types';
 import {
   createCoolifyClient,
@@ -276,24 +276,6 @@ export async function unlinkGithubKey(appUuid: string): Promise<void> {
 // then writes (or removes) a Traefik conf.d route file so the site domain
 // is proxied to the correct container. Non-fatal.
 const TRAEFIK_CONF_DIR = process.env.TRAEFIK_CONF_DIR ?? '/app/traefik-conf.d';
-
-function dockerGet(path: string): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    const req = http.get(
-      { socketPath: '/var/run/docker.sock', path, headers: { Host: 'localhost' } },
-      (res) => {
-        let body = '';
-        res.on('data', (d: Buffer) => { body += d; });
-        res.on('end', () => {
-          try { resolve(JSON.parse(body)); }
-          catch { reject(new Error(`Docker API parse error: ${body.slice(0, 200)}`)); }
-        });
-      }
-    );
-    req.on('error', reject);
-    req.setTimeout(3000, () => { req.destroy(); reject(new Error('Docker API timeout')); });
-  });
-}
 
 export async function provisionTraefikRoute(
   slug: string,

--- a/api/src/services/docker.ts
+++ b/api/src/services/docker.ts
@@ -1,0 +1,75 @@
+import * as http from 'http';
+
+export function dockerGet(path: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(
+      { socketPath: '/var/run/docker.sock', path, headers: { Host: 'localhost' } },
+      (res) => {
+        let body = '';
+        res.on('data', (d: Buffer) => { body += d; });
+        res.on('end', () => {
+          try { resolve(JSON.parse(body)); }
+          catch { reject(new Error(`Docker API parse error: ${body.slice(0, 200)}`)); }
+        });
+      }
+    );
+    req.on('error', reject);
+    req.setTimeout(3000, () => { req.destroy(); reject(new Error('Docker API timeout')); });
+  });
+}
+
+export function dockerDelete(path: string): Promise<{ statusCode: number }> {
+  return new Promise((resolve, reject) => {
+    const options: http.RequestOptions = {
+      socketPath: '/var/run/docker.sock',
+      path,
+      method: 'DELETE',
+      headers: { Host: 'localhost' },
+    };
+    const req = http.request(options, (res) => {
+      let body = '';
+      res.on('data', (d: Buffer) => { body += d; });
+      res.on('end', () => {
+        const code = res.statusCode ?? 0;
+        if (code >= 200 && code < 300) {
+          resolve({ statusCode: code });
+        } else {
+          let message = `Docker API error ${code}`;
+          try { message = (JSON.parse(body) as { message?: string }).message ?? message; } catch {}
+          reject(new Error(message));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(10000, () => { req.destroy(); reject(new Error('Docker API timeout')); });
+    req.end();
+  });
+}
+
+export function dockerPost(path: string, body?: object): Promise<{ statusCode: number | undefined }> {
+  return new Promise((resolve, reject) => {
+    const payload = body ? JSON.stringify(body) : '';
+    const options: http.RequestOptions = {
+      socketPath: '/var/run/docker.sock',
+      path,
+      method: 'POST',
+      headers: {
+        Host: 'localhost',
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+    };
+    const req = http.request(options, (res) => {
+      let responseBody = '';
+      res.on('data', (d: Buffer) => { responseBody += d; });
+      res.on('end', () => {
+        // Docker returns 204 No Content for start/stop/restart
+        resolve({ statusCode: res.statusCode });
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(5000, () => { req.destroy(); reject(new Error('Docker API timeout')); });
+    if (payload) req.write(payload);
+    req.end();
+  });
+}

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -1,6 +1,41 @@
 // HermitHost internal type definitions.
 // All types mirror the TypeScript interfaces in the frontend src/lib/types.ts exactly.
 
+export type ContainerStatus = 'running' | 'stopped' | 'exited' | 'paused' | 'restarting' | 'dead';
+export type ContainerGroup = 'hermithost-stack' | 'deployed-sites';
+
+export interface ServiceContainer {
+  id: string;           // 12-char Docker short ID
+  name: string;         // container name, leading slash stripped
+  image: string;
+  status: ContainerStatus;
+  state: string;        // raw Docker state
+  uptime: string | null;  // Docker "Status" field e.g. "Up 3 hours"
+  group: ContainerGroup;
+  siteSlug: string | null;  // coolify.name label value
+}
+
+export interface ServiceGroup {
+  id: string;            // stable identifier for keying
+  name: string;          // display name
+  domain: string | null; // only set for deployed site groups
+  abandoned: boolean;    // true if no matching Coolify application found
+  containers: ServiceContainer[];
+}
+
+export interface RestoreEvent {
+  total: number;
+  restored: number;
+  failed: string[];  // container names that failed to start
+  at: string;        // ISO timestamp
+}
+
+export interface ServicesResponse {
+  stackGroups: ServiceGroup[];
+  siteGroups: ServiceGroup[];
+  restoreEvent: RestoreEvent | null;
+}
+
 export type SiteStatus = 'healthy' | 'warning' | 'error' | 'pending';
 export type DeployStatus = 'success' | 'failed' | 'running' | 'pending';
 export type DnsRecordType = 'A' | 'AAAA' | 'CNAME' | 'MX' | 'TXT' | 'NS' | 'SRV' | 'CAA' | 'SOA' | 'PTR';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -270,6 +270,7 @@ services:
       NETWORK_MODE: "${NETWORK_MODE:-external}"
       TRAEFIK_LOG_PATH: "/traefik-logs/traefik-access.log"
       STATS_INGEST_INTERVAL_MS: "${STATS_INGEST_INTERVAL_MS:-60000}"
+      DATA_DIR: "/app/data/lifecycle"
       PGHOST: "coolify-db"
       PGPORT: "5432"
       PGDATABASE: "coolify"
@@ -280,10 +281,11 @@ services:
       - coolify-api-token:/coolify-api-token
       - coolify-keys:/coolify-keys:ro
       - ./traefik/conf.d:/app/traefik-conf.d
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/run/docker.sock:/var/run/docker.sock
       - step-ca-data:/home/step:ro
       - traefik-logs:/traefik-logs:ro
       - hermithost-stats:/app/data
+      - ./data:/app/data/lifecycle
     networks:
       - hermithost-net
       - coolify
@@ -293,6 +295,58 @@ services:
         condition: service_healthy
       coolify-server-setup:
         condition: service_completed_successfully
+
+  # ── Sites Restore (one-shot) ───────────────────────────────────
+  # Restores coolify-managed containers checkpointed by stack-down.sh.
+  # Only acts if data/restore-containers.json exists (written by controlled shutdown).
+  sites-restore:
+    image: docker:cli
+    restart: "no"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./data:/restore-data
+    depends_on:
+      coolify:
+        condition: service_healthy
+      coolify-server-setup:
+        condition: service_completed_successfully
+    command: >
+      sh -c "
+        FILE=/restore-data/restore-containers.json
+        EVENT_FILE=/restore-data/restore-event.json
+        if [ ! -f \"$$FILE\" ]; then
+          echo '[sites-restore] No restore checkpoint — skipping.'
+          exit 0
+        fi
+        TOTAL=$$(cat \"$$FILE\" | grep -c '\"id\"' || echo 0)
+        if [ \"$$TOTAL\" -eq 0 ]; then
+          echo '[sites-restore] Empty restore list — skipping.'
+          rm -f \"$$FILE\"
+          exit 0
+        fi
+        echo \"[sites-restore] Restoring $$TOTAL container(s)...\"
+        RESTORED=0
+        FAILED=''
+        while IFS= read -r line; do
+          ID=$$(echo \"$$line\" | sed 's/.*\"id\": *\"\([^\"]*\)\".*/\1/' | grep -E '^[a-f0-9]+$$')
+          NAME=$$(echo \"$$line\" | sed 's/.*\"name\": *\"\([^\"]*\)\".*/\1/')
+          [ -z \"$$ID\" ] && continue
+          if docker start \"$$ID\" > /dev/null 2>&1; then
+            echo \"[sites-restore] Started: $$NAME ($$ID)\"
+            RESTORED=$$((RESTORED+1))
+          else
+            echo \"[sites-restore] Failed: $$NAME ($$ID)\"
+            FAILED=\"$$FAILED,\\\"$$NAME\\\"\"
+          fi
+        done < <(cat \"$$FILE\" | tr '{' '\n' | grep '\"id\"')
+        FAILED_JSON=\"[$$(echo $$FAILED | sed 's/^,//')]\";
+        printf '{\"total\":%d,\"restored\":%d,\"failed\":%s,\"at\":\"%s\"}' \
+          $$TOTAL $$RESTORED \"$$FAILED_JSON\" \"$$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$$EVENT_FILE\"
+        rm -f \"$$FILE\"
+        echo '[sites-restore] Done.'
+      "
+    networks:
+      - hermithost-net
 
   # ── Technitium DNS Server ──────────────────────────────────────
   technitium:

--- a/scripts/coolify-setup.sh
+++ b/scripts/coolify-setup.sh
@@ -205,6 +205,19 @@ psql -c "INSERT INTO private_keys (id, uuid, name, description, private_key, is_
 echo "[setup] PrivateKey id=0 ensured for Coolify localhost server validation."
 
 
+# ── 7b. Disable Coolify's built-in proxy and sentinel ────────────────────────
+# HermitHost uses Traefik — Coolify's Caddy proxy (coolify-proxy) conflicts.
+# Setting proxy_type=NONE prevents Coolify from spawning coolify-proxy.
+echo "[setup] Disabling Coolify built-in proxy (HermitHost uses Traefik)..."
+psql -c "UPDATE servers SET proxy_type='NONE' WHERE uuid='$SERVER_UUID';" > /dev/null
+echo "[setup] Proxy type set to NONE."
+
+# coolify-sentinel is spawned by ServerManagerJob every ~60s when is_metrics_enabled
+# or is_server_api_enabled is true. Disable both to stop sentinel from being recreated.
+echo "[setup] Disabling Coolify sentinel (metrics + server API not needed)..."
+psql -c "UPDATE server_settings SET is_metrics_enabled=false, is_server_api_enabled=false WHERE server_id=(SELECT id FROM servers WHERE uuid='$SERVER_UUID');" > /dev/null
+echo "[setup] Sentinel disabled."
+
 # ── 8. Validate server ────────────────────────────────────────────────────────
 echo "[setup] Validating server (may take a few seconds)..."
 sleep 3

--- a/scripts/stack-down.sh
+++ b/scripts/stack-down.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Full hermithost shutdown — checkpoints and stops coolify-managed containers first,
+# then brings down the hermithost stack.
+#
+# Usage: ./scripts/stack-down.sh [docker compose down flags]
+# Example: ./scripts/stack-down.sh --volumes
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DATA_DIR="$PROJECT_DIR/data"
+RESTORE_FILE="$DATA_DIR/restore-containers.json"
+
+mkdir -p "$DATA_DIR"
+
+echo "[stack-down] Checkpointing running coolify-managed containers..."
+docker ps --filter label=coolify.managed=true --format '{{.ID}} {{.Names}}' > /tmp/coolify-running.txt
+
+if [ -s /tmp/coolify-running.txt ]; then
+  COUNT=$(wc -l < /tmp/coolify-running.txt | tr -d ' ')
+  python3 -c "
+import json
+rows = [l.strip().split(None, 1) for l in open('/tmp/coolify-running.txt') if l.strip()]
+print(json.dumps([{'id': r[0], 'name': r[1].lstrip('/')} for r in rows if len(r) == 2]))
+" > "$RESTORE_FILE"
+  echo "[stack-down] Checkpointed $COUNT container(s) → $RESTORE_FILE"
+
+  echo "[stack-down] Stopping coolify-managed containers..."
+  awk '{print $1}' /tmp/coolify-running.txt | xargs docker stop -t 10
+  echo "[stack-down] Coolify containers stopped."
+else
+  echo "[stack-down] No running coolify-managed containers."
+  echo "[]" > "$RESTORE_FILE"
+fi
+
+rm -f /tmp/coolify-running.txt
+
+echo "[stack-down] Bringing down hermithost stack..."
+cd "$PROJECT_DIR"
+docker compose down "$@"
+echo "[stack-down] Done. Run 'docker compose up -d' to restart and restore."

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,0 +1,2 @@
+// Global type declarations for Vite define() replacements
+declare const __GIT_COMMIT__: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,38 @@
+export type ContainerStatus = 'running' | 'stopped' | 'exited' | 'paused' | 'restarting' | 'dead';
+export type ContainerGroup = 'hermithost-stack' | 'deployed-sites';
+
+export interface ServiceContainer {
+	id: string;
+	name: string;
+	image: string;
+	status: ContainerStatus;
+	state: string;
+	uptime: string | null;
+	group: ContainerGroup;
+	siteSlug: string | null;
+}
+
+export interface ServiceGroup {
+	id: string;
+	name: string;
+	domain: string | null;
+	abandoned: boolean;
+	containers: ServiceContainer[];
+}
+
+export interface RestoreEvent {
+	total: number;
+	restored: number;
+	failed: string[];
+	at: string;
+}
+
+export interface ServicesResponse {
+	stackGroups: ServiceGroup[];
+	siteGroups: ServiceGroup[];
+	restoreEvent: RestoreEvent | null;
+}
+
 export type SiteStatus = 'healthy' | 'warning' | 'error' | 'pending';
 export type DeployStatus = 'success' | 'failed' | 'running' | 'pending';
 export type DnsRecordType = 'A' | 'AAAA' | 'CNAME' | 'MX' | 'TXT' | 'NS' | 'SRV' | 'SOA' | 'CAA' | 'PTR';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import '../app.css';
 	import { page } from '$app/stores';
-	declare const __GIT_COMMIT__: string;
 </script>
 
 <div class="app-shell">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -41,11 +41,10 @@
 				Health
 				<span class="badge-soon">soon</span>
 			</span>
-			<span class="nav-item nav-disabled">
-				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/><path d="M4.93 4.93a10 10 0 0 0 0 14.14"/></svg>
-				Servers
-				<span class="badge-soon">soon</span>
-			</span>
+			<a href="/services" class="nav-item" class:active={$page.url.pathname.startsWith('/services')}>
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="4" rx="1"/><rect x="2" y="10" width="20" height="4" rx="1"/><rect x="2" y="17" width="20" height="4" rx="1"/></svg>
+				Services
+			</a>
 		</div>
 
 		<div class="sidebar-footer">

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,6 +1,8 @@
 import type { PageLoad } from './$types';
 import type { Site } from '$lib/types';
 
+export const ssr = false;
+
 export const load: PageLoad = async ({ fetch }) => {
 	const res = await fetch('/api/sites');
 	if (!res.ok) {

--- a/src/routes/dns/+page.svelte
+++ b/src/routes/dns/+page.svelte
@@ -99,8 +99,8 @@
 				addZoneError = body.error ?? `Create failed (${res.status})`;
 				return;
 			}
-			const created: DnsZone = await res.json();
-			const fullZone: DnsZone = { disabled: false, internal: false, dnssecStatus: 'Unsigned', ...created };
+			const data = await res.json() as Partial<DnsZone>;
+			const fullZone: DnsZone = { name: data.name ?? '', type: data.type ?? '', disabled: data.disabled ?? false, internal: data.internal ?? false, dnssecStatus: data.dnssecStatus ?? 'Unsigned' };
 			zones = [...zones, fullZone];
 			newZoneName = '';
 			showAddZone = false;

--- a/src/routes/dns/+page.ts
+++ b/src/routes/dns/+page.ts
@@ -13,6 +13,8 @@ export interface DnsPageData {
   nsHostname: string | null;
 }
 
+export const ssr = false;
+
 export const load: PageLoad = async ({ fetch }): Promise<DnsPageData> => {
   const [zonesRes, configRes] = await Promise.all([
     fetch('/api/dns/zones'),

--- a/src/routes/services/+page.svelte
+++ b/src/routes/services/+page.svelte
@@ -1,0 +1,1007 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { invalidateAll } from '$app/navigation';
+	import type { PageData } from './$types';
+	import type { ServiceContainer, ServiceGroup, ServicesResponse, RestoreEvent } from '$lib/types';
+
+	export let data: PageData;
+
+	$: services = data.services as ServicesResponse;
+	$: stackGroups = services.stackGroups ?? [];
+	$: siteGroups = services.siteGroups ?? [];
+	$: allStackContainers = stackGroups.flatMap(g => g.containers);
+	$: allSiteContainers = siteGroups.flatMap(g => g.containers);
+	$: restoreEvent = services.restoreEvent as RestoreEvent | null;
+
+	// ── Section collapse state ────────────────────────────────────────────────
+	$: allStackHealthy = allStackContainers.every(c => c.status === 'running');
+	let stackExpanded = true;
+	let sitesExpanded = true;
+	$: stackExpanded = !allStackHealthy; // auto-expand when degraded
+
+	// ── Per-container action pending state ───────────────────────────────────
+	let pending: Record<string, string> = {};
+
+	// ── Auto-refresh ─────────────────────────────────────────────────────────
+	let lastUpdated = new Date();
+	let lastUpdatedLabel = 'just now';
+	let pollTimer: ReturnType<typeof setInterval>;
+	let labelTimer: ReturnType<typeof setInterval>;
+
+	function startPolling() {
+		pollTimer = setInterval(async () => {
+			if (document.visibilityState === 'hidden') return;
+			await invalidateAll();
+			lastUpdated = new Date();
+		}, 10_000);
+		labelTimer = setInterval(() => {
+			const secs = Math.round((Date.now() - lastUpdated.getTime()) / 1000);
+			lastUpdatedLabel = secs < 5 ? 'just now' : `${secs}s ago`;
+		}, 1000);
+	}
+
+	function handleVisibilityChange() {
+		if (document.visibilityState === 'visible') {
+			invalidateAll().then(() => { lastUpdated = new Date(); });
+		}
+	}
+
+	onMount(() => {
+		startPolling();
+		document.addEventListener('visibilitychange', handleVisibilityChange);
+	});
+
+	onDestroy(() => {
+		clearInterval(pollTimer);
+		clearInterval(labelTimer);
+		document.removeEventListener('visibilitychange', handleVisibilityChange);
+	});
+
+	async function refresh() {
+		await invalidateAll();
+		lastUpdated = new Date();
+	}
+
+	// ── Restore banner dismiss ────────────────────────────────────────────────
+	let restoreDismissed = false;
+	let restoreAutoDismissTimer: ReturnType<typeof setTimeout>;
+	$: if (restoreEvent && !restoreDismissed) {
+		clearTimeout(restoreAutoDismissTimer);
+		if (restoreEvent.failed.length === 0) {
+			restoreAutoDismissTimer = setTimeout(() => { restoreDismissed = true; }, 60_000);
+		}
+	}
+
+	// ── Container actions ─────────────────────────────────────────────────────
+	async function containerAction(id: string, action: 'start' | 'stop' | 'restart') {
+		pending = { ...pending, [id]: action };
+		try {
+			await fetch(`/api/services/${id}/${action}`, { method: 'POST' });
+			await new Promise(r => setTimeout(r, 300));
+			await invalidateAll();
+			lastUpdated = new Date();
+		} finally {
+			const { [id]: _, ...rest } = pending;
+			pending = rest;
+		}
+	}
+
+	// ── Stop confirmation modal ───────────────────────────────────────────────
+	let stopTarget: ServiceContainer | null = null;
+
+	function promptStop(container: ServiceContainer) {
+		stopTarget = container;
+	}
+
+	async function confirmStop() {
+		if (!stopTarget) return;
+		const id = stopTarget.id;
+		stopTarget = null;
+		await containerAction(id, 'stop');
+	}
+
+	// ── Delete confirmation modal ─────────────────────────────────────────────
+	let deleteTarget: ServiceContainer | null = null;
+
+	function promptDelete(container: ServiceContainer) {
+		deleteTarget = container;
+	}
+
+	async function confirmDelete() {
+		if (!deleteTarget) return;
+		const id = deleteTarget.id;
+		deleteTarget = null;
+		pending = { ...pending, [id]: 'delete' };
+		try {
+			await fetch(`/api/services/${id}`, { method: 'DELETE' });
+			await new Promise(r => setTimeout(r, 300));
+			await invalidateAll();
+			lastUpdated = new Date();
+		} finally {
+			const { [id]: _, ...rest } = pending;
+			pending = rest;
+		}
+	}
+
+	// ── Overflow menu ─────────────────────────────────────────────────────────
+	let openMenu: string | null = null;
+
+	function toggleMenu(id: string) {
+		openMenu = openMenu === id ? null : id;
+	}
+
+	function closeMenus() { openMenu = null; }
+
+	// ── Shutdown modal ────────────────────────────────────────────────────────
+	let showShutdownModal = false;
+	let shutdownConfirmText = '';
+	let shutdownInProgress = false;
+	let shutdownDone = false;
+
+	$: shutdownConfirmValid = shutdownConfirmText.trim() === 'shutdown all';
+
+	async function executeShutdown() {
+		if (!shutdownConfirmValid) return;
+		shutdownInProgress = true;
+		try {
+			await fetch('/api/services/shutdown', { method: 'POST' });
+			shutdownDone = true;
+		} catch {
+			// Connection likely dropped — stack is shutting down
+			shutdownDone = true;
+		}
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+	function statusClass(status: string): string {
+		if (status === 'running') return 'badge-running';
+		if (status === 'exited' || status === 'dead') return 'badge-exited';
+		return 'badge-stopped';
+	}
+
+	function formatUptime(uptime: string | null, status: string): string {
+		if (!uptime) return '—';
+		if (status !== 'running') {
+			// Docker gives "Exited (137) 12 minutes ago" — extract time part
+			const m = uptime.match(/(\d+\s+\w+\s+ago)/);
+			return m ? `stopped ${m[1]}` : uptime;
+		}
+		// Running: "Up 3 hours" → "3 hours"
+		return uptime.replace(/^Up\s+/, '');
+	}
+</script>
+
+<svelte:window on:click={closeMenus} />
+
+<div class="page">
+	<!-- ── Page header ──────────────────────────────────────────────────────── -->
+	<div class="page-header">
+		<h1 class="page-title">Services</h1>
+		<div class="header-actions">
+			<span class="updated-label">Updated {lastUpdatedLabel}</span>
+			<button class="btn-secondary" on:click={refresh}>Refresh</button>
+			<button class="btn-danger" on:click={() => { showShutdownModal = true; shutdownConfirmText = ''; shutdownDone = false; }}>
+				Shutdown Stack
+			</button>
+		</div>
+	</div>
+
+	<!-- ── Restore banner ───────────────────────────────────────────────────── -->
+	{#if restoreEvent && !restoreDismissed}
+		<div class="restore-banner" class:restore-partial={restoreEvent.failed.length > 0}>
+			{#if restoreEvent.failed.length === 0}
+				<span>Full stack restored — {restoreEvent.restored}/{restoreEvent.total} containers online</span>
+			{:else}
+				<span>
+					Restore incomplete — {restoreEvent.restored}/{restoreEvent.total} containers online —
+					failed: {restoreEvent.failed.join(', ')}
+				</span>
+			{/if}
+			<button class="banner-dismiss" on:click={() => { restoreDismissed = true; }}>✕</button>
+		</div>
+	{/if}
+
+	<!-- ── Stack Services (grouped) ────────────────────────────────────────── -->
+	<div class="section">
+		<button
+			class="section-header"
+			aria-expanded={stackExpanded}
+			on:click={() => { stackExpanded = !stackExpanded; }}
+		>
+			<span class="section-title">Stack Services</span>
+			<span class="section-meta">
+				{allStackContainers.filter(c => c.status === 'running').length}/{allStackContainers.length} running
+				{#if allStackHealthy}
+					<span class="badge-healthy">healthy</span>
+				{:else}
+					<span class="badge-degraded">degraded</span>
+				{/if}
+			</span>
+			<svg class="chevron" class:rotated={!stackExpanded} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<polyline points="6 9 12 15 18 9"/>
+			</svg>
+		</button>
+
+		{#if stackExpanded}
+			{#if stackGroups.length === 0}
+				<div class="empty-sites">No stack services found</div>
+			{:else}
+				{#each stackGroups as group (group.id)}
+					<div class="site-group">
+						<div class="site-group-header">
+							<div class="site-group-identity">
+								<span class="site-group-name">{group.name}</span>
+							</div>
+							<span class="site-group-meta">
+								{group.containers.filter(c => c.status === 'running').length}/{group.containers.length} running
+							</span>
+						</div>
+						<table class="site-table">
+							<thead>
+								<tr>
+									<th class="th-indent">Service</th>
+									<th>Status</th>
+									<th>Uptime</th>
+									<th>Image</th>
+									<th style="text-align:right">Actions</th>
+								</tr>
+							</thead>
+							<tbody aria-live="polite">
+								{#each group.containers as container (container.id)}
+									<tr>
+										<td class="td-indent cell-name">{container.name}</td>
+										<td>
+											<span class="status-badge {statusClass(container.status)}">
+												{container.status}
+											</span>
+										</td>
+										<td class="cell-muted">{formatUptime(container.uptime, container.status)}</td>
+										<td class="cell-mono cell-muted">{container.image}</td>
+										<td class="cell-actions">
+											{#if container.status !== 'running'}
+												<button
+													class="btn-action btn-start"
+													disabled={!!pending[container.id]}
+													aria-label="Start {container.name}"
+													on:click={() => containerAction(container.id, 'start')}
+												>
+													{pending[container.id] === 'start' ? '…' : 'Start'}
+												</button>
+											{:else}
+												<div class="action-group">
+													<button
+														class="btn-action btn-restart"
+														disabled={!!pending[container.id]}
+														aria-label="Restart {container.name}"
+														on:click={() => containerAction(container.id, 'restart')}
+													>
+														{pending[container.id] === 'restart' ? '…' : 'Restart'}
+													</button>
+													<div class="overflow-wrap">
+														<button
+															class="btn-overflow"
+															aria-label="More actions for {container.name}"
+															on:click|stopPropagation={() => toggleMenu(container.id)}
+														>⋯</button>
+														{#if openMenu === container.id}
+															<div class="overflow-menu">
+																<button
+																	class="overflow-item overflow-danger"
+																	on:click|stopPropagation={() => { closeMenus(); promptStop(container); }}
+																>Stop</button>
+															</div>
+														{/if}
+													</div>
+												</div>
+											{/if}
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				{/each}
+			{/if}
+		{/if}
+	</div>
+
+	<!-- ── Sites Rail (Deployed Sites — grouped by site) ───────────────────── -->
+	<div class="section">
+		<button
+			class="section-header"
+			aria-expanded={sitesExpanded}
+			on:click={() => { sitesExpanded = !sitesExpanded; }}
+		>
+			<span class="section-title">Deployed Sites</span>
+			<span class="section-meta">
+				{allSiteContainers.filter(c => c.status === 'running').length}/{allSiteContainers.length} running
+				· {siteGroups.length} site{siteGroups.length !== 1 ? 's' : ''}
+			</span>
+			<svg class="chevron" class:rotated={!sitesExpanded} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<polyline points="6 9 12 15 18 9"/>
+			</svg>
+		</button>
+
+		{#if sitesExpanded}
+			{#if siteGroups.length === 0}
+				<div class="empty-sites">No deployed site containers found</div>
+			{:else}
+				{#each siteGroups as group (group.id)}
+					<div class="site-group">
+						<!-- Site header row -->
+						<div class="site-group-header" class:site-group-abandoned={group.abandoned}>
+							<div class="site-group-identity">
+								<span class="site-group-name">{group.name}</span>
+								{#if group.abandoned}
+									<span class="badge-abandoned">abandoned</span>
+								{:else if group.domain}
+									<a
+										class="site-group-domain"
+										href="https://{group.domain}"
+										target="_blank"
+										rel="noopener noreferrer"
+									>{group.domain}</a>
+								{/if}
+							</div>
+							<span class="site-group-meta">
+								{group.containers.filter(c => c.status === 'running').length}/{group.containers.length} running
+							</span>
+						</div>
+						<!-- Containers under this site -->
+						<table class="site-table">
+							<thead>
+								<tr>
+									<th class="th-indent">Container</th>
+									<th>Status</th>
+									<th>Uptime</th>
+									<th>Image</th>
+									<th style="text-align:right">Actions</th>
+								</tr>
+							</thead>
+							<tbody aria-live="polite">
+								{#each group.containers as container (container.id)}
+									<tr>
+										<td class="td-indent">
+											<span class="cell-mono cell-dim">{container.name}</span>
+										</td>
+										<td>
+											<span class="status-badge {statusClass(container.status)}">
+												{container.status}
+											</span>
+										</td>
+										<td class="cell-muted">{formatUptime(container.uptime, container.status)}</td>
+										<td class="cell-mono cell-muted">{container.image}</td>
+										<td class="cell-actions">
+											{#if group.abandoned}
+												<button
+													class="btn-action btn-delete"
+													disabled={!!pending[container.id]}
+													aria-label="Delete {container.name}"
+													on:click={() => promptDelete(container)}
+												>
+													{pending[container.id] === 'delete' ? '…' : 'Delete'}
+												</button>
+											{:else if container.status !== 'running'}
+												<button
+													class="btn-action btn-start"
+													disabled={!!pending[container.id]}
+													aria-label="Start {container.name}"
+													on:click={() => containerAction(container.id, 'start')}
+												>
+													{pending[container.id] === 'start' ? '…' : 'Start'}
+												</button>
+											{:else}
+												<div class="action-group">
+													<button
+														class="btn-action btn-restart"
+														disabled={!!pending[container.id]}
+														aria-label="Restart {container.name}"
+														on:click={() => containerAction(container.id, 'restart')}
+													>
+														{pending[container.id] === 'restart' ? '…' : 'Restart'}
+													</button>
+													<div class="overflow-wrap">
+														<button
+															class="btn-overflow"
+															aria-label="More actions for {container.name}"
+															on:click|stopPropagation={() => toggleMenu(container.id)}
+														>⋯</button>
+														{#if openMenu === container.id}
+															<div class="overflow-menu">
+																<button
+																	class="overflow-item overflow-danger"
+																	on:click|stopPropagation={() => { closeMenus(); promptStop(container); }}
+																>Stop</button>
+															</div>
+														{/if}
+													</div>
+												</div>
+											{/if}
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				{/each}
+			{/if}
+		{/if}
+	</div>
+</div>
+
+<!-- ── Stop confirmation modal ──────────────────────────────────────────────── -->
+{#if stopTarget}
+	<div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="stop-modal-title">
+		<div class="modal">
+			<h2 id="stop-modal-title" class="modal-title">Stop container?</h2>
+			<p class="modal-body">
+				<span class="mono">{stopTarget.name}</span> will be stopped.
+				Dependent services may be affected.
+			</p>
+			<div class="modal-actions">
+				<button class="btn-secondary" on:click={() => { stopTarget = null; }}>Cancel</button>
+				<button class="btn-danger-sm" on:click={confirmStop}>Stop</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- ── Delete confirmation modal ─────────────────────────────────────────────── -->
+{#if deleteTarget}
+	<div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="delete-modal-title">
+		<div class="modal">
+			<h2 id="delete-modal-title" class="modal-title modal-title-danger">Delete abandoned container?</h2>
+			<p class="modal-body">
+				<span class="mono">{deleteTarget.name}</span> will be force-removed.
+				This container is no longer tracked by Coolify and cannot be recovered.
+			</p>
+			<div class="modal-actions">
+				<button class="btn-secondary" on:click={() => { deleteTarget = null; }}>Cancel</button>
+				<button class="btn-danger-sm" on:click={confirmDelete}>Delete</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- ── Shutdown modal ────────────────────────────────────────────────────────── -->
+{#if showShutdownModal}
+	<div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="shutdown-modal-title">
+		<div class="modal modal-wide">
+			{#if shutdownDone}
+				<h2 id="shutdown-modal-title" class="modal-title">Stack shutting down</h2>
+				<p class="modal-body">
+					Coolify containers stopped and checkpointed. The HermitHost stack is shutting down.
+					This page will become unreachable momentarily.
+				</p>
+				<div class="modal-actions">
+					<button class="btn-secondary" on:click={() => { showShutdownModal = false; }}>Close</button>
+				</div>
+			{:else}
+				<h2 id="shutdown-modal-title" class="modal-title modal-title-danger">Shutdown Stack</h2>
+				<p class="modal-body">
+					This will stop all <strong>{allSiteContainers.length} deployed site container{allSiteContainers.length !== 1 ? 's' : ''}</strong> across {siteGroups.length} site{siteGroups.length !== 1 ? 's' : ''},
+					checkpoint them for restore, then shut down the HermitHost stack.
+					Your sites will be unreachable until the stack is restarted.
+				</p>
+				<div class="confirm-input-group">
+					<label class="confirm-label" for="shutdown-confirm">
+						Type <span class="mono">shutdown all</span> to confirm
+					</label>
+					<input
+						id="shutdown-confirm"
+						class="confirm-input"
+						type="text"
+						bind:value={shutdownConfirmText}
+						placeholder="shutdown all"
+						autocomplete="off"
+					/>
+				</div>
+				<div class="modal-actions">
+					<button class="btn-secondary" on:click={() => { showShutdownModal = false; }}>Cancel</button>
+					<button
+						class="btn-danger-sm"
+						disabled={!shutdownConfirmValid || shutdownInProgress}
+						on:click={executeShutdown}
+					>
+						{shutdownInProgress ? 'Shutting down…' : 'Shut Down Stack'}
+					</button>
+
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.page {
+		padding: 32px 32px 64px;
+		max-width: 1100px;
+	}
+
+	.page-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 24px;
+		gap: 12px;
+	}
+
+	.page-title {
+		font-size: 20px;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.header-actions {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.updated-label {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--text-muted);
+		margin-right: 4px;
+	}
+
+	/* ── Restore banner ────────────────────────────────────────────────────── */
+	.restore-banner {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		padding: 10px 14px;
+		border-radius: 6px;
+		background: rgba(59, 138, 140, 0.08);
+		border: 1px solid var(--accent-teal-dim);
+		color: var(--accent-teal);
+		font-size: 13px;
+		margin-bottom: 20px;
+	}
+
+	.restore-banner.restore-partial {
+		background: rgba(212, 168, 67, 0.08);
+		border-color: rgba(212, 168, 67, 0.3);
+		color: var(--warning);
+	}
+
+	.banner-dismiss {
+		background: none;
+		border: none;
+		color: inherit;
+		opacity: 0.6;
+		cursor: pointer;
+		font-size: 12px;
+		padding: 2px 4px;
+		flex-shrink: 0;
+	}
+
+	.banner-dismiss:hover { opacity: 1; }
+
+	/* ── Section ───────────────────────────────────────────────────────────── */
+	.section {
+		background: var(--bg-surface);
+		border: 1px solid var(--border);
+		border-radius: 8px;
+		margin-bottom: 16px;
+		overflow: hidden;
+	}
+
+	.section-header {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		width: 100%;
+		padding: 12px 16px;
+		background: none;
+		border: none;
+		color: var(--text-primary);
+		cursor: pointer;
+		text-align: left;
+		border-bottom: 1px solid var(--border);
+		transition: background 0.1s;
+	}
+
+	.section-header:hover { background: var(--bg-hover); }
+
+	.section-title {
+		font-size: 13px;
+		font-weight: 600;
+	}
+
+	.section-meta {
+		font-size: 12px;
+		color: var(--text-muted);
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.chevron {
+		margin-left: auto;
+		color: var(--text-muted);
+		transition: transform 0.15s;
+	}
+
+	.chevron.rotated { transform: rotate(-90deg); }
+
+	.badge-healthy {
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		background: rgba(76, 175, 130, 0.1);
+		color: var(--success);
+		border: 1px solid rgba(76, 175, 130, 0.2);
+		padding: 1px 6px;
+		border-radius: 3px;
+	}
+
+	.badge-degraded {
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		background: rgba(207, 92, 92, 0.1);
+		color: var(--danger);
+		border: 1px solid rgba(207, 92, 92, 0.2);
+		padding: 1px 6px;
+		border-radius: 3px;
+	}
+
+	/* ── Table ─────────────────────────────────────────────────────────────── */
+	.table-wrap { overflow-x: auto; }
+
+	/* ── Site groups ───────────────────────────────────────────────────────── */
+	.empty-sites {
+		padding: 24px;
+		text-align: center;
+		color: var(--text-muted);
+		font-size: 12px;
+	}
+
+	.site-group {
+		border-bottom: 1px solid var(--border);
+	}
+
+	.site-group:last-child { border-bottom: none; }
+
+	.site-group-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 10px 16px;
+		background: var(--bg-elevated);
+		border-bottom: 1px solid var(--border);
+	}
+
+	.site-group-identity {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+	}
+
+	.site-group-name {
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.site-group-domain {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--accent-teal);
+		opacity: 0.8;
+		transition: opacity 0.1s;
+	}
+
+	.site-group-domain:hover { opacity: 1; }
+
+	.site-group-abandoned { opacity: 0.7; }
+
+	.badge-abandoned {
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		background: rgba(212, 168, 67, 0.1);
+		color: var(--warning);
+		border: 1px solid rgba(212, 168, 67, 0.25);
+		padding: 1px 6px;
+		border-radius: 3px;
+	}
+
+	.site-group-meta {
+		font-size: 11px;
+		color: var(--text-muted);
+		font-family: var(--font-mono);
+	}
+
+	.site-table { width: 100%; }
+
+	.th-indent, .td-indent { padding-left: 28px; }
+
+	.cell-dim { color: var(--text-muted); }
+
+	.cell-name {
+		font-family: var(--font-mono);
+		font-size: 12px;
+		color: var(--text-primary);
+	}
+
+	.cell-mono {
+		font-family: var(--font-mono);
+		font-size: 11px;
+	}
+
+	.cell-muted { color: var(--text-muted); }
+
+	.site-slug {
+		display: block;
+		font-size: 10px;
+		font-family: var(--font-mono);
+		color: var(--text-muted);
+		margin-top: 2px;
+	}
+
+	.cell-empty {
+		text-align: center;
+		color: var(--text-muted);
+		font-size: 12px;
+		padding: 24px;
+	}
+
+	.cell-actions {
+		text-align: right;
+		white-space: nowrap;
+	}
+
+	/* ── Status badges ─────────────────────────────────────────────────────── */
+	.status-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 2px 7px;
+		border-radius: 3px;
+		font-size: 10px;
+		font-weight: 500;
+		font-family: var(--font-mono);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		white-space: nowrap;
+	}
+
+	.badge-running {
+		background: rgba(76, 175, 130, 0.1);
+		color: var(--success);
+		border: 1px solid rgba(76, 175, 130, 0.2);
+	}
+
+	.badge-exited {
+		background: rgba(207, 92, 92, 0.1);
+		color: var(--danger);
+		border: 1px solid rgba(207, 92, 92, 0.2);
+	}
+
+	.badge-stopped {
+		background: rgba(212, 168, 67, 0.1);
+		color: var(--warning);
+		border: 1px solid rgba(212, 168, 67, 0.2);
+	}
+
+	/* ── Action buttons ────────────────────────────────────────────────────── */
+	.action-group {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+	}
+
+	.btn-action {
+		padding: 4px 10px;
+		border-radius: 4px;
+		font-size: 11px;
+		font-weight: 500;
+		border: 1px solid var(--border-bright);
+		background: var(--bg-elevated);
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: background 0.1s, color 0.1s;
+		min-width: 54px;
+	}
+
+	.btn-action:hover:not(:disabled) {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.btn-action:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.btn-start:hover:not(:disabled) {
+		border-color: rgba(76, 175, 130, 0.4);
+		color: var(--success);
+	}
+
+	.btn-delete {
+		border-color: rgba(207, 92, 92, 0.3);
+		color: var(--danger);
+	}
+
+	.btn-delete:hover:not(:disabled) {
+		border-color: rgba(207, 92, 92, 0.5);
+		background: rgba(207, 92, 92, 0.08);
+		color: var(--danger);
+	}
+
+	.btn-overflow {
+		padding: 4px 8px;
+		border-radius: 4px;
+		font-size: 14px;
+		border: 1px solid var(--border-bright);
+		background: var(--bg-elevated);
+		color: var(--text-muted);
+		cursor: pointer;
+		line-height: 1;
+	}
+
+	.btn-overflow:hover {
+		background: var(--bg-hover);
+		color: var(--text-secondary);
+	}
+
+	.overflow-wrap {
+		position: relative;
+	}
+
+	.overflow-menu {
+		position: absolute;
+		right: 0;
+		top: calc(100% + 4px);
+		background: var(--bg-elevated);
+		border: 1px solid var(--border-bright);
+		border-radius: 5px;
+		min-width: 100px;
+		z-index: 100;
+		box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+	}
+
+	.overflow-item {
+		display: block;
+		width: 100%;
+		padding: 8px 12px;
+		background: none;
+		border: none;
+		text-align: left;
+		font-size: 12px;
+		color: var(--text-secondary);
+		cursor: pointer;
+	}
+
+	.overflow-item:hover { background: var(--bg-hover); color: var(--text-primary); }
+	.overflow-danger:hover { color: var(--danger); }
+
+	/* ── Buttons (page-level) ──────────────────────────────────────────────── */
+	.btn-secondary {
+		padding: 6px 14px;
+		border-radius: 5px;
+		font-size: 12px;
+		font-weight: 500;
+		border: 1px solid var(--border-bright);
+		background: var(--bg-elevated);
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: background 0.1s, color 0.1s;
+	}
+
+	.btn-secondary:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.btn-danger {
+		padding: 6px 14px;
+		border-radius: 5px;
+		font-size: 12px;
+		font-weight: 500;
+		border: 1px solid rgba(207, 92, 92, 0.3);
+		background: rgba(207, 92, 92, 0.08);
+		color: var(--danger);
+		cursor: pointer;
+		transition: background 0.1s;
+	}
+
+	.btn-danger:hover { background: rgba(207, 92, 92, 0.14); }
+
+	.btn-danger-sm {
+		padding: 7px 16px;
+		border-radius: 5px;
+		font-size: 12px;
+		font-weight: 500;
+		border: 1px solid rgba(207, 92, 92, 0.4);
+		background: rgba(207, 92, 92, 0.12);
+		color: var(--danger);
+		cursor: pointer;
+		transition: background 0.1s;
+	}
+
+	.btn-danger-sm:hover:not(:disabled) { background: rgba(207, 92, 92, 0.2); }
+	.btn-danger-sm:disabled { opacity: 0.4; cursor: not-allowed; }
+
+	/* ── Modals ────────────────────────────────────────────────────────────── */
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 200;
+	}
+
+	.modal {
+		background: var(--bg-surface);
+		border: 1px solid var(--border-bright);
+		border-radius: 8px;
+		padding: 24px;
+		width: 380px;
+		max-width: calc(100vw - 40px);
+	}
+
+	.modal-wide { width: 460px; }
+
+	.modal-title {
+		font-size: 15px;
+		font-weight: 600;
+		margin-bottom: 12px;
+	}
+
+	.modal-title-danger { color: var(--danger); }
+
+	.modal-body {
+		font-size: 13px;
+		color: var(--text-secondary);
+		line-height: 1.6;
+		margin-bottom: 20px;
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+	}
+
+	.mono {
+		font-family: var(--font-mono);
+		font-size: 12px;
+		background: var(--bg-elevated);
+		padding: 1px 5px;
+		border-radius: 3px;
+		color: var(--text-primary);
+	}
+
+	.confirm-input-group {
+		margin-bottom: 20px;
+	}
+
+	.confirm-label {
+		display: block;
+		font-size: 12px;
+		color: var(--text-secondary);
+		margin-bottom: 8px;
+	}
+
+	.confirm-input {
+		width: 100%;
+		padding: 8px 10px;
+		background: var(--bg-elevated);
+		border: 1px solid var(--border-bright);
+		border-radius: 5px;
+		color: var(--text-primary);
+		font-family: var(--font-mono);
+		font-size: 13px;
+	}
+
+	.confirm-input:focus {
+		outline: none;
+		border-color: var(--accent-teal-dim);
+	}
+</style>

--- a/src/routes/services/+page.ts
+++ b/src/routes/services/+page.ts
@@ -1,0 +1,11 @@
+import type { PageLoad } from './$types';
+import type { ServicesResponse } from '$lib/types';
+
+export const ssr = false;
+
+export const load: PageLoad = async ({ fetch }) => {
+	const res = await fetch('/api/services');
+	if (!res.ok) throw new Error(`Failed to load services: ${res.status}`);
+	const services: ServicesResponse = await res.json();
+	return { services };
+};

--- a/src/routes/sites/[slug]/+page.ts
+++ b/src/routes/sites/[slug]/+page.ts
@@ -2,6 +2,8 @@ import type { PageLoad } from './$types';
 import type { Site, DnsRecord, Deploy } from '$lib/types';
 import { error } from '@sveltejs/kit';
 
+export const ssr = false;
+
 export const load: PageLoad = async ({ fetch, params }) => {
 	const siteRes = await fetch(`/api/sites/${params.slug}`);
 	if (siteRes.status === 404) {


### PR DESCRIPTION
## Summary

- Adds Services page with Platform Rail (hermithost stack containers) and Sites Rail (coolify-managed containers), including start/stop/restart and physical delete for abandoned containers
- Implements checkpoint lifecycle: `scripts/stack-down.sh` saves running coolify containers, `sites-restore` one-shot service restores them on next stack start
- Wires up GitHub Actions CI (typecheck + build + docker image build) and CD (build → deploy → health check → rollback) for self-hosted runner on hammer

## Details

- `api/src/routes/services.ts` — new endpoints: GET `/api/services`, POST `/:id/start|stop|restart`, DELETE `/:id`
- `api/src/services/docker.ts` — extracted docker helpers; `dockerDelete` rejects on non-2xx and surfaces Docker error message
- Coolify API cross-reference: detects containers whose app was deleted from Coolify (marked abandoned)
- `coolify-setup.sh` — disables coolify-proxy and coolify-sentinel via DB to prevent conflicts with Traefik
- `src/app.d.ts` — declares `__GIT_COMMIT__` global for type safety
- All page `load` functions set `ssr = false` to prevent hard-refresh 500s
- `.github/workflows/ci.yml` — 3 jobs on self-hosted runner (api, frontend, docker)
- `.github/workflows/deploy.yml` — CD pipeline with rollback

## Test plan

- [ ] Navigate to `/services` — Platform Rail and Sites Rail render with correct containers
- [ ] Stop/start/restart container via UI — status badge updates
- [ ] Delete abandoned container — row removed after next poll
- [ ] Hard refresh any page — no 500
- [ ] Push to `feat/*` branch — CI runs and passes
- [ ] Merge to `main` — deploy workflow fires, health checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)