### PR TITLE
fix(deploy): route health checks through Traefik on :9080

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,10 +80,11 @@ jobs:
         run: docker compose -p $COMPOSE_PROJECT --env-file .env up -d --no-deps --no-build frontend
 
       # ── Health checks (30s window, 2s interval) ────────────────────────────────
-      - name: Health check — API
+      # Port 3001 is not published to host — API is only reachable via Traefik on :9080
+      - name: Health check — API (via Traefik :9080/api/health)
         run: |
           for i in $(seq 1 15); do
-            if curl -sf http://localhost:3001/api/health > /dev/null; then
+            if curl -sf http://localhost:9080/api/health > /dev/null; then
               echo "✓ API healthy (attempt $i)"
               exit 0
             fi
@@ -93,24 +94,11 @@ jobs:
           echo "✗ API health check failed after 30s"
           exit 1
 
-      - name: Health check — Frontend container
-        run: |
-          for i in $(seq 1 15); do
-            if curl -sf http://localhost:3000 > /dev/null; then
-              echo "✓ Frontend healthy (attempt $i)"
-              exit 0
-            fi
-            echo "  waiting... ($i/15)"
-            sleep 2
-          done
-          echo "✗ Frontend health check failed after 30s"
-          exit 1
-
       - name: Health check — Management UI (via Traefik :9080)
         run: |
           for i in $(seq 1 15); do
             if curl -sf http://localhost:9080 > /dev/null; then
-              echo "✓ Management UI reachable via Traefik (attempt $i)"
+              echo "✓ Management UI healthy (attempt $i)"
               exit 0
             fi
             echo "  waiting... ($i/15)"


### PR DESCRIPTION
## Summary

Port 3001 is not published to the host — the API is only reachable via Traefik on `:9080`.  
Direct `curl localhost:3001` health checks always fail.

Replaces both checks with Traefik-routed equivalents:
- `localhost:9080/api/health` — API health (Traefik `admin` entrypoint, `PathPrefix(/api)` → api:3001)  
- `localhost:9080` — Management UI (Traefik `admin` entrypoint, `PathPrefix(/)` → frontend:3000)

Removes the redundant direct frontend container check (`localhost:3000`).

## Test plan
- [ ] Hammer runner online with `hammer` label
- [ ] Merge → deploy fires on hammer
- [ ] API health check passes via :9080/api/health
- [ ] Management UI health check passes via :9080

🤖 Generated with [Claude Code](https://claude.com/claude-code)