### PR TITLE
fix(services): remove false-positive abandoned detection on missing resourceName

### DIFF
--- a/api/src/routes/services.ts
+++ b/api/src/routes/services.ts
@@ -119,10 +119,13 @@ function groupBySite(containers: DockerContainer[], liveAppIds: Set<string> | nu
 
     const slug = c.Labels['coolify.name'] ?? c.Id.slice(0, 12);
     const resourceName = c.Labels['coolify.resourceName'];
-    const appId = c.Labels['coolify.applicationId'];
+    // appId is guaranteed non-null — Docker sitesFilter requires coolify.applicationId
+    const appId = c.Labels['coolify.applicationId']!;
     const siteName = resourceName ?? slug;
-    // Abandoned: missing labels, OR (if Coolify is reachable) app not in live app list
-    const abandoned = !resourceName || !appId || (liveAppIds !== null && !liveAppIds.has(appId));
+    // Abandoned: app no longer exists in live Coolify app list.
+    // coolify.resourceName is a display hint only — its absence does not mean abandoned.
+    // When Coolify is unreachable (liveAppIds=null), skip cross-check to avoid false positives.
+    const abandoned = liveAppIds !== null && !liveAppIds.has(appId);
     if (!groups.has(slug)) {
       groups.set(slug, { id: slug, name: siteName, domain: extractDomain(c.Labels), abandoned, containers: [] });
     }


### PR DESCRIPTION
## Problem

Legitimate deployed containers (e.g. `nz2y4d1kim2gbg6pmhy0po0y`) were showing as abandoned even though the site still exists in Coolify.

Root cause: the abandoned condition included `!resourceName` — if Coolify omits the `coolify.resourceName` label (which is inconsistent across Coolify versions/deployments), the container is flagged abandoned regardless of whether the app exists in Coolify.

## Fix

```typescript
// Before
const abandoned = !resourceName || !appId || (liveAppIds !== null && !liveAppIds.has(appId));

// After — appId guaranteed non-null by Docker filter; resourceName is display-only
const abandoned = liveAppIds !== null && !liveAppIds.has(appId);
```

`coolify.resourceName` is a display hint only. The only meaningful abandoned signal is whether the app UUID is absent from the live Coolify application list. When Coolify is unreachable (`liveAppIds=null`), we skip the check entirely to avoid false positives.

## Test plan
- [ ] Container `nz2y4d1kim2gbg6pmhy0po0y-*` no longer shows as abandoned
- [ ] Genuinely abandoned containers (app deleted in Coolify) still show as abandoned
- [ ] Coolify unreachable → no containers marked abandoned

🤖 Generated with [Claude Code](https://claude.com/claude-code)