### PR TITLE
debug(services): add DEBUG_SERVICES logging for abandoned detection

### DIFF
--- a/api/src/routes/services.ts
+++ b/api/src/routes/services.ts
@@ -126,6 +126,9 @@ function groupBySite(containers: DockerContainer[], liveAppIds: Set<string> | nu
     // coolify.resourceName is a display hint only — its absence does not mean abandoned.
     // When Coolify is unreachable (liveAppIds=null), skip cross-check to avoid false positives.
     const abandoned = liveAppIds !== null && !liveAppIds.has(appId);
+    if (abandoned && process.env.DEBUG_SERVICES === 'true') {
+      console.log(`[services:debug] marking abandoned: ${name} (appId=${appId}, inLiveList=${liveAppIds?.has(appId) ?? 'n/a'})`);
+    }
     if (!groups.has(slug)) {
       groups.set(slug, { id: slug, name: siteName, domain: extractDomain(c.Labels), abandoned, containers: [] });
     }
@@ -166,6 +169,16 @@ router.get('/', async (_req: Request, res: Response) => {
 
     // null = Coolify unreachable; skip UUID cross-check to avoid false positives
     const liveAppIds: Set<string> | null = coolifyApps ? new Set(coolifyApps.map(a => a.uuid)) : null;
+
+    if (process.env.DEBUG_SERVICES === 'true') {
+      console.log('[services:debug] liveAppIds:', liveAppIds ? [...liveAppIds] : null);
+      console.log('[services:debug] sites containers:', sitesRaw.map(c => ({
+        name: (c.Names[0] ?? '').replace(/^\//, ''),
+        appId: c.Labels['coolify.applicationId'] ?? '(none)',
+        resourceName: c.Labels['coolify.resourceName'] ?? '(none)',
+        project: c.Labels['com.docker.compose.project'] ?? '(none)',
+      })));
+    }
 
     const response: ServicesResponse = {
       stackGroups: groupStackContainers(stackRaw),


### PR DESCRIPTION
## Purpose

Temporary diagnostic PR to understand why container `nz2y4d1kim2gbg6pmhy0po0y-153841513440` is marked abandoned despite the site existing in Coolify.

## What it logs (gated behind `DEBUG_SERVICES=true`)

- All UUIDs returned by `listApplications()` from Coolify API
- `coolify.applicationId` + `coolify.resourceName` on each sites container
- Which containers are flagged abandoned and the exact match result

## How to use after deploy

On hammer, temporarily add to the API's environment:
```
DEBUG_SERVICES=true
```
Then hit `GET /api/services` (or just load the Services page), and check:
```bash
docker logs hermithost-api-1 2>&1 | grep "services:debug"
```

The logs will show exactly what UUID is on the container vs what Coolify returned.

**Remove this PR once the root cause is identified and fixed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)