### PR TITLE
feat(sites): add build pack selector

### DIFF
--- a/api/src/services/mapper.ts
+++ b/api/src/services/mapper.ts
@@ -185,6 +185,7 @@ export function mapSite(
     description: app.description ?? '',
     repository: cleanUrl,
     deploy_auth: deployAuth,
+    build_pack: app.build_pack,
     server: serverName,
     overallStatus: mapAppStatus(app.status),
     http,

--- a/api/src/services/mapper.ts
+++ b/api/src/services/mapper.ts
@@ -185,6 +185,7 @@ export function mapSite(
     description: app.description ?? '',
     repository: cleanUrl,
     deploy_auth: deployAuth,
+    branch: app.git_branch,
     build_pack: app.build_pack,
     server: serverName,
     overallStatus: mapAppStatus(app.status),

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -91,6 +91,7 @@ export interface Site {
   repository: string;
   server: string;
   deploy_auth: 'ssh_key' | 'pat';
+  build_pack: string;
   http: HttpStatus;
   ssl: SslStatus;
   dns: DnsStatus;

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -91,6 +91,7 @@ export interface Site {
   repository: string;
   server: string;
   deploy_auth: 'ssh_key' | 'pat';
+  branch: string;
   build_pack: string;
   http: HttpStatus;
   ssl: SslStatus;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,6 +97,7 @@ export interface Site {
 	repository: string;
 	server: string;
 	deploy_auth: 'ssh_key' | 'pat';
+	build_pack: string;
 	http: HttpStatus;
 	ssl: SslStatus;
 	dns: DnsStatus;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,6 +97,7 @@ export interface Site {
 	repository: string;
 	server: string;
 	deploy_auth: 'ssh_key' | 'pat';
+	branch: string;
 	build_pack: string;
 	http: HttpStatus;
 	ssl: SslStatus;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,6 +14,7 @@
 	let addDomain = '';
 	let addGitRepo = '';
 	let addGitBranch = 'main';
+	let addBuildPack = 'nixpacks';
 	let addDeployAuth: 'ssh_key' | 'pat' = 'ssh_key';
 	let addDeployToken = '';
 	type AddState = 'idle' | 'loading' | 'error';
@@ -28,6 +29,7 @@
 		addDomain = '';
 		addGitRepo = '';
 		addGitBranch = 'main';
+		addBuildPack = 'nixpacks';
 		addDeployAuth = 'ssh_key';
 		addDeployToken = '';
 		addState = 'idle';
@@ -68,6 +70,7 @@
 				domain: addDomain.trim(),
 				git_repository: addGitRepo.trim(),
 				git_branch: addGitBranch.trim() || 'main',
+				build_pack: addBuildPack,
 				deploy_auth: addDeployAuth,
 			};
 			if (addDeployAuth === 'pat') {
@@ -389,6 +392,20 @@
 						placeholder="main"
 						disabled={addState === 'loading'}
 					/>
+				</div>
+				<div class="form-field">
+					<label for="add-build-pack">Build Pack</label>
+					<select
+						id="add-build-pack"
+						bind:value={addBuildPack}
+						class="input"
+						disabled={addState === 'loading'}
+					>
+						<option value="nixpacks">nixpacks</option>
+						<option value="dockerfile">dockerfile</option>
+						<option value="dockercompose">dockercompose</option>
+						<option value="static">static</option>
+					</select>
 				</div>
 				<div class="form-field">
 					<label>Deploy Auth</label>

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -48,6 +48,7 @@
 	let settingsBranch = data.site.branch ?? 'main';
 	let settingsServer = data.site.server;
 	let settingsDesc = data.site.description;
+	let settingsBuildPack = data.site.build_pack ?? 'nixpacks';
 	let settingsDeployAuth: 'ssh_key' | 'pat' = data.site.deploy_auth;
 	let settingsDeployToken = '';
 	type AuthSaveState = 'idle' | 'saving' | 'saved' | 'error';
@@ -74,6 +75,7 @@
 		if (settingsBranch !== (site.branch ?? 'main')) payload.git_branch = settingsBranch;
 		if (settingsServer !== site.server) payload.server = settingsServer;
 		if (settingsDesc !== site.description) payload.description = settingsDesc;
+		if (settingsBuildPack !== (site.build_pack ?? 'nixpacks')) payload.build_pack = settingsBuildPack;
 
 		try {
 			const res = await fetch(`/api/sites/${site.slug}`, {
@@ -1377,6 +1379,15 @@
 						<div class="form-field">
 							<label for="cfg-branch">Branch</label>
 							<input id="cfg-branch" bind:value={settingsBranch} class="input mono" placeholder="main" />
+						</div>
+						<div class="form-field">
+							<label for="cfg-build-pack">Build Pack</label>
+							<select id="cfg-build-pack" bind:value={settingsBuildPack} class="input">
+								<option value="nixpacks">nixpacks</option>
+								<option value="dockerfile">dockerfile</option>
+								<option value="dockercompose">dockercompose</option>
+								<option value="static">static</option>
+							</select>
 						</div>
 						<div class="form-field">
 							<label for="cfg-server">Server</label>


### PR DESCRIPTION
## Summary
- Adds Build Pack `<select>` to the **Add Site** modal (options: nixpacks, dockerfile, dockercompose, static; default: nixpacks)
- Adds Build Pack `<select>` to the **Site Settings** tab — reads current value, sends PATCH only when changed
- Extends `Site` type in both API (`api/src/types.ts`) and frontend (`src/lib/types.ts`) with `build_pack: string`
- `mapSite()` in `mapper.ts` now maps `app.build_pack` into the Site response

## Test plan
- [x] TypeScript check passes (0 errors)
- [x] Build Pack select appears in Add Site modal with all 4 options
- [x] Default value is `nixpacks`
- [x] Build Pack select appears in Site Settings tab
- [x] POST payload includes `build_pack`
- [x] PATCH payload includes `build_pack` when changed