### PR TITLE
fix(dockercompose): add docker_compose_location and base_directory support

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -451,6 +451,8 @@ router.post('/', async (req: Request, res: Response) => {
     domain?: string;       // alias for fqdn
     deploy_auth?: 'ssh_key' | 'pat';
     deploy_token?: string; // PAT value — only used when deploy_auth === 'pat'
+    docker_compose_location?: string;
+    base_directory?: string;
   };
   if (!body.name || !body.git_repository || !body.git_branch) {
     res.status(400).json({
@@ -515,6 +517,8 @@ router.post('/', async (req: Request, res: Response) => {
       environment_name: 'production',
       instant_deploy: false,
       ...(body.description !== undefined ? { description: body.description } : {}),
+      ...(body.docker_compose_location !== undefined ? { docker_compose_location: body.docker_compose_location } : (body.build_pack === 'dockercompose' ? { docker_compose_location: '/docker-compose.yml' } : {})),
+      ...(body.base_directory !== undefined ? { base_directory: body.base_directory } : {}),
     };
     let app = await client.createApplication(payload);
 
@@ -604,6 +608,8 @@ router.patch('/:slug', async (req: Request, res: Response) => {
     server?: string;
     deploy_auth?: 'ssh_key' | 'pat';
     deploy_token?: string;  // required when deploy_auth === 'pat'
+    docker_compose_location?: string;
+    base_directory?: string;
   }>;
   if (Object.keys(body).length === 0) {
     res.status(400).json({ error: 'Request body must include at least one field to update' });
@@ -626,6 +632,8 @@ router.patch('/:slug', async (req: Request, res: Response) => {
     }
     if (body.git_branch !== undefined) payload.git_branch = body.git_branch;
     if (body.build_pack !== undefined) payload.build_pack = body.build_pack;
+    if (body.docker_compose_location !== undefined) payload.docker_compose_location = body.docker_compose_location;
+    if (body.base_directory !== undefined) payload.base_directory = body.base_directory;
 
     // Auth-aware repository URL handling:
     // - Always stores clean base URL in the frontend-facing Site response

--- a/api/src/services/coolify.ts
+++ b/api/src/services/coolify.ts
@@ -10,6 +10,8 @@ export interface CoolifyApplication {
   git_branch: string;
   git_commit_sha: string;
   build_pack: string;
+  docker_compose_location?: string;
+  base_directory?: string;
   created_at: string;
   updated_at: string;
   private_key_uuid?: string;
@@ -55,6 +57,8 @@ export interface CoolifyCreateApplicationPayload {
   git_repository: string;
   git_branch: string;
   build_pack: string;
+  docker_compose_location?: string;
+  base_directory?: string;
   ports_exposes: string;
   server_uuid: string;
   destination_uuid: string;
@@ -86,6 +90,8 @@ export interface CoolifyUpdateApplicationPayload {
   git_repository?: string;
   git_branch?: string;
   build_pack?: string;
+  docker_compose_location?: string;
+  base_directory?: string;
 }
 
 export interface CoolifyEnv {

--- a/api/src/services/mapper.ts
+++ b/api/src/services/mapper.ts
@@ -187,6 +187,8 @@ export function mapSite(
     deploy_auth: deployAuth,
     branch: app.git_branch,
     build_pack: app.build_pack,
+    docker_compose_location: app.docker_compose_location ?? '/docker-compose.yml',
+    base_directory: app.base_directory ?? '/',
     server: serverName,
     overallStatus: mapAppStatus(app.status),
     http,

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -93,6 +93,8 @@ export interface Site {
   deploy_auth: 'ssh_key' | 'pat';
   branch: string;
   build_pack: string;
+  docker_compose_location: string;
+  base_directory: string;
   http: HttpStatus;
   ssl: SslStatus;
   dns: DnsStatus;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -99,6 +99,8 @@ export interface Site {
 	deploy_auth: 'ssh_key' | 'pat';
 	branch: string;
 	build_pack: string;
+	docker_compose_location: string;
+	base_directory: string;
 	http: HttpStatus;
 	ssl: SslStatus;
 	dns: DnsStatus;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,8 @@
 	let addGitRepo = '';
 	let addGitBranch = 'main';
 	let addBuildPack = 'nixpacks';
+	let addDockerComposeLoc = '/docker-compose.yml';
+	let addBaseDir = '/';
 	let addDeployAuth: 'ssh_key' | 'pat' = 'ssh_key';
 	let addDeployToken = '';
 	type AddState = 'idle' | 'loading' | 'error';
@@ -30,6 +32,8 @@
 		addGitRepo = '';
 		addGitBranch = 'main';
 		addBuildPack = 'nixpacks';
+		addDockerComposeLoc = '/docker-compose.yml';
+		addBaseDir = '/';
 		addDeployAuth = 'ssh_key';
 		addDeployToken = '';
 		addState = 'idle';
@@ -72,6 +76,7 @@
 				git_branch: addGitBranch.trim() || 'main',
 				build_pack: addBuildPack,
 				deploy_auth: addDeployAuth,
+				...(addBuildPack === 'dockercompose' ? { docker_compose_location: addDockerComposeLoc, base_directory: addBaseDir } : {}),
 			};
 			if (addDeployAuth === 'pat') {
 				payload.deploy_token = addDeployToken.trim();
@@ -407,6 +412,30 @@
 						<option value="static">static</option>
 					</select>
 				</div>
+				{#if addBuildPack === 'dockercompose'}
+					<div class="form-field">
+						<label for="add-compose-loc">Docker Compose File</label>
+						<input
+							id="add-compose-loc"
+							bind:value={addDockerComposeLoc}
+							class="input mono"
+							placeholder="/docker-compose.yml"
+							disabled={addState === 'loading'}
+						/>
+						<span class="field-hint">Path to compose file relative to repo root</span>
+					</div>
+					<div class="form-field">
+						<label for="add-base-dir">Base Directory</label>
+						<input
+							id="add-base-dir"
+							bind:value={addBaseDir}
+							class="input mono"
+							placeholder="/"
+							disabled={addState === 'loading'}
+						/>
+						<span class="field-hint">Subdirectory for monorepos (usually /)</span>
+					</div>
+				{/if}
 				<div class="form-field">
 					<label>Deploy Auth</label>
 					<div class="auth-toggle">

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -49,6 +49,8 @@
 	let settingsServer = data.site.server;
 	let settingsDesc = data.site.description;
 	let settingsBuildPack = data.site.build_pack ?? 'nixpacks';
+	let settingsDockerComposeLoc = data.site.docker_compose_location ?? '/docker-compose.yml';
+	let settingsBaseDir = data.site.base_directory ?? '/';
 	let settingsDeployAuth: 'ssh_key' | 'pat' = data.site.deploy_auth;
 	let settingsDeployToken = '';
 	type AuthSaveState = 'idle' | 'saving' | 'saved' | 'error';
@@ -76,6 +78,8 @@
 		if (settingsServer !== site.server) payload.server = settingsServer;
 		if (settingsDesc !== site.description) payload.description = settingsDesc;
 		if (settingsBuildPack !== (site.build_pack ?? 'nixpacks')) payload.build_pack = settingsBuildPack;
+		if (settingsDockerComposeLoc !== (site.docker_compose_location ?? '/docker-compose.yml')) payload.docker_compose_location = settingsDockerComposeLoc;
+		if (settingsBaseDir !== (site.base_directory ?? '/')) payload.base_directory = settingsBaseDir;
 
 		try {
 			const res = await fetch(`/api/sites/${site.slug}`, {
@@ -1389,6 +1393,18 @@
 								<option value="static">static</option>
 							</select>
 						</div>
+						{#if settingsBuildPack === 'dockercompose'}
+							<div class="form-field">
+								<label for="cfg-compose-loc">Docker Compose File</label>
+								<input id="cfg-compose-loc" bind:value={settingsDockerComposeLoc} class="input mono" placeholder="/docker-compose.yml" />
+								<span class="field-hint">Path to compose file relative to repo root</span>
+							</div>
+							<div class="form-field">
+								<label for="cfg-base-dir">Base Directory</label>
+								<input id="cfg-base-dir" bind:value={settingsBaseDir} class="input mono" placeholder="/" />
+								<span class="field-hint">Subdirectory to use as build context (for monorepos)</span>
+							</div>
+						{/if}
 						<div class="form-field">
 							<label for="cfg-server">Server</label>
 							<input id="cfg-server" bind:value={settingsServer} class="input mono" />
@@ -2054,6 +2070,12 @@
 	.form-field-wide {
 		flex: 1;
 		min-width: 200px;
+	}
+
+	.field-hint {
+		font-size: 11px;
+		color: var(--text-secondary);
+		margin-top: 2px;
 	}
 
 	.form-field-narrow {


### PR DESCRIPTION
## Problem
`"Deployment failed: Failed to read the Docker Compose file from the repository"` when using the `dockercompose` build pack.

**Root cause:** `docker_compose_location` was never sent to Coolify on create or update. Without it, Coolify's internal default can be empty/wrong — it can't locate the compose file even when it exists at repo root.

## Fix
- Added `docker_compose_location` and `base_directory` to all Coolify API type interfaces
- POST `/api/sites` now defaults `docker_compose_location` to `/docker-compose.yml` when `build_pack === 'dockercompose'`
- PATCH `/api/sites/:slug` passes both fields through when provided
- Mapper surfaces both fields on the `Site` response (with `/docker-compose.yml` + `/` defaults)
- Frontend: conditional form inputs shown in **Add Site modal** and **Site Settings tab** only when `dockercompose` build pack is selected — users can override path for non-standard layouts or monorepos

## Test plan
- [x] Build clean (frontend + API)
- [x] Deployed to localhost
- [ ] Create a site with `dockercompose` build pack — verify Coolify receives `docker_compose_location: /docker-compose.yml`
- [ ] Verify compose file fields appear in Settings only when `dockercompose` is selected
- [ ] Verify other build packs show no compose file fields