### PR TITLE
fix(dockercompose): clarify compose file path hint text

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -422,7 +422,7 @@
 							placeholder="/docker-compose.yml"
 							disabled={addState === 'loading'}
 						/>
-						<span class="field-hint">Path to compose file relative to repo root</span>
+						<span class="field-hint">Path within the repo, appended to Base Directory. Use <code>/docker-compose.yml</code> or <code>/docker-compose.yaml</code> for files at repo root.</span>
 					</div>
 					<div class="form-field">
 						<label for="add-base-dir">Base Directory</label>
@@ -433,7 +433,7 @@
 							placeholder="/"
 							disabled={addState === 'loading'}
 						/>
-						<span class="field-hint">Subdirectory for monorepos (usually /)</span>
+						<span class="field-hint">Repo subdirectory used as working directory. <code>/</code> = repo root. Monorepos: e.g. <code>/services/web</code>.</span>
 					</div>
 				{/if}
 				<div class="form-field">

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -1397,12 +1397,12 @@
 							<div class="form-field">
 								<label for="cfg-compose-loc">Docker Compose File</label>
 								<input id="cfg-compose-loc" bind:value={settingsDockerComposeLoc} class="input mono" placeholder="/docker-compose.yml" />
-								<span class="field-hint">Path to compose file relative to repo root</span>
+								<span class="field-hint">Path within the repo, appended to Base Directory. Use <code>/docker-compose.yml</code> or <code>/docker-compose.yaml</code> for files at repo root.</span>
 							</div>
 							<div class="form-field">
 								<label for="cfg-base-dir">Base Directory</label>
 								<input id="cfg-base-dir" bind:value={settingsBaseDir} class="input mono" placeholder="/" />
-								<span class="field-hint">Subdirectory to use as build context (for monorepos)</span>
+								<span class="field-hint">Repo subdirectory to use as working directory. <code>/</code> = repo root. For monorepos use e.g. <code>/services/web</code>.</span>
 							</div>
 						{/if}
 						<div class="form-field">


### PR DESCRIPTION
## Problem
Hint text for `docker_compose_location` and `base_directory` was vague. Users didn't know what the path was relative to or that both `.yml` and `.yaml` are valid.

## Sourced from Coolify internals
From `ApplicationDeploymentJob.php`, Coolify resolves the full path as:
```
{base_directory (trailing / stripped)}{docker_compose_location}
```
e.g. `base_directory=/` + `docker_compose_location=/docker-compose.yml` → file at repo root named `docker-compose.yml`

## Fix
Updated hint text in both Add Site modal and Site Settings tab to explain:
- `docker_compose_location` is appended to `base_directory`; both `.yml` and `.yaml` are valid
- `base_directory` is the repo subdirectory used as working directory; `/` = repo root; monorepos use e.g. `/services/web`