### PR TITLE
fix(settings): always persist docker_compose_location for dockercompose build pack

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -422,7 +422,7 @@
 							placeholder="/docker-compose.yml"
 							disabled={addState === 'loading'}
 						/>
-						<span class="field-hint">Path to compose file relative to repo root</span>
+						<span class="field-hint">Path within the repo, appended to Base Directory. Use <code>/docker-compose.yml</code> or <code>/docker-compose.yaml</code> for files at repo root.</span>
 					</div>
 					<div class="form-field">
 						<label for="add-base-dir">Base Directory</label>
@@ -433,7 +433,7 @@
 							placeholder="/"
 							disabled={addState === 'loading'}
 						/>
-						<span class="field-hint">Subdirectory for monorepos (usually /)</span>
+						<span class="field-hint">Repo subdirectory used as working directory. <code>/</code> = repo root. Monorepos: e.g. <code>/services/web</code>.</span>
 					</div>
 				{/if}
 				<div class="form-field">

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -78,8 +78,11 @@
 		if (settingsServer !== site.server) payload.server = settingsServer;
 		if (settingsDesc !== site.description) payload.description = settingsDesc;
 		if (settingsBuildPack !== (site.build_pack ?? 'nixpacks')) payload.build_pack = settingsBuildPack;
-		if (settingsDockerComposeLoc !== (site.docker_compose_location ?? '/docker-compose.yml')) payload.docker_compose_location = settingsDockerComposeLoc;
-		if (settingsBaseDir !== (site.base_directory ?? '/')) payload.base_directory = settingsBaseDir;
+		// Always include path fields when build_pack is dockercompose — change-detection is unreliable
+		// because the mapper applies defaults (?? '/docker-compose.yml', ?? '/') that mask NULL values
+		// in Coolify's DB, making the comparison always appear equal and the fields never get persisted.
+		if (settingsBuildPack === 'dockercompose' || settingsDockerComposeLoc !== (site.docker_compose_location ?? '/docker-compose.yml')) payload.docker_compose_location = settingsDockerComposeLoc;
+		if (settingsBuildPack === 'dockercompose' || settingsBaseDir !== (site.base_directory ?? '/')) payload.base_directory = settingsBaseDir;
 
 		try {
 			const res = await fetch(`/api/sites/${site.slug}`, {

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -1397,12 +1397,12 @@
 							<div class="form-field">
 								<label for="cfg-compose-loc">Docker Compose File</label>
 								<input id="cfg-compose-loc" bind:value={settingsDockerComposeLoc} class="input mono" placeholder="/docker-compose.yml" />
-								<span class="field-hint">Path to compose file relative to repo root</span>
+								<span class="field-hint">Path within the repo, appended to Base Directory. Use <code>/docker-compose.yml</code> or <code>/docker-compose.yaml</code> for files at repo root.</span>
 							</div>
 							<div class="form-field">
 								<label for="cfg-base-dir">Base Directory</label>
 								<input id="cfg-base-dir" bind:value={settingsBaseDir} class="input mono" placeholder="/" />
-								<span class="field-hint">Subdirectory to use as build context (for monorepos)</span>
+								<span class="field-hint">Repo subdirectory to use as working directory. <code>/</code> = repo root. For monorepos use e.g. <code>/services/web</code>.</span>
 							</div>
 						{/if}
 						<div class="form-field">


### PR DESCRIPTION
## Summary
- Change-detection guard on `docker_compose_location` and `base_directory` was broken: our mapper applies `?? '/docker-compose.yml'` and `?? '/'` defaults that mask `NULL` values in Coolify's DB
- Both sides of the comparison resolved to the default, so fields were never included in the PATCH — Coolify DB stayed `NULL`
- Coolify's `loadComposeFile()` then ran `cat .` (null path) → generic `RuntimeException` at `Application.php:1836` on every dockercompose deploy
- Fix: when `build_pack === 'dockercompose'`, always include both path fields in the PATCH regardless of apparent change

## Test plan
- [ ] On hammer: open cantaconmigo site settings → build pack = `dockercompose`, compose file = `/docker-compose.yml`, base dir = `/` → Save Settings
- [ ] Verify PATCH now sends `docker_compose_location` and `base_directory` (browser devtools network tab)
- [ ] Trigger deploy — should get past `loadComposeFile()` and proceed to build stage
- [ ] Verify fix is idempotent: saving settings again doesn't break anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)