### PR TITLE
fix(probe): add 5s timeout to DNS probe

### DIFF
--- a/api/src/services/healthProbe.ts
+++ b/api/src/services/healthProbe.ts
@@ -95,7 +95,12 @@ function probeSsl(domain: string): Promise<SslStatus> {
 async function probeDns(domain: string): Promise<DnsStatus> {
   const checkedAt = new Date().toISOString();
   try {
-    await dns.promises.resolve4(domain);
+    await Promise.race([
+      dns.promises.resolve4(domain),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('DNS timeout')), 5000)
+      ),
+    ]);
     return { resolving: true, propagated: true, checkedAt };
   } catch {
     return { resolving: false, propagated: false, checkedAt };


### PR DESCRIPTION
## Summary
- `dns.promises.resolve4` had no timeout — a stale/unresolvable domain could hang the probe forever
- `Promise.allSettled` waits for all three probes; a hanging DNS probe meant `runProbes()` never settled
- Added `Promise.race` with a 5s `setTimeout` rejection, matching the existing HTTP and SSL probe timeouts

## Test plan
- [ ] Deploy to hammer and confirm sites list responds quickly even when DNS is slow/unreachable
- [ ] Confirm probe still reports `resolving: true` for working domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)