### PR TITLE
fix(ssh-bridge): add git-lfs to alpine package install

### DIFF
--- a/docker/ssh-bridge/Dockerfile
+++ b/docker/ssh-bridge/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.20
-RUN apk add --no-cache openssh docker-cli docker-cli-compose bash curl sudo git jq
+RUN apk add --no-cache openssh docker-cli docker-cli-compose bash curl sudo git git-lfs jq
 RUN adduser -D -s /bin/bash deploy && \
     passwd -d deploy && \
     mkdir -p /home/deploy/.ssh && chmod 700 /home/deploy/.ssh && \


### PR DESCRIPTION
## Summary

- Adds `git-lfs` to the ssh-bridge Alpine image
- Coolify defaults `is_git_lfs_enabled=true` on all apps; without git-lfs on ssh-bridge, `loadComposeFile()` appends `git lfs pull` which fails silently (stderr suppressed by `>/dev/null 2>&1`), producing a generic `RuntimeException: 'Failed to read the Docker Compose file from the repository.'`
- Root cause of persistent cantaconmigo dockercompose deploy failure

## Test plan

- [ ] Rebuild ssh-bridge on hammer: `docker compose build ssh-bridge && docker compose up -d ssh-bridge`
- [ ] Verify `git lfs version` inside ssh-bridge container
- [ ] Trigger cantaconmigo deploy — should pass `loadComposeFile()` and proceed to build

🤖 Generated with [Claude Code](https://claude.com/claude-code)