### PR TITLE
fix(ssh-bridge): enable root SSH to bypass Coolify sudo-wrapper bug

### DIFF
--- a/docker/ssh-bridge/entrypoint.sh
+++ b/docker/ssh-bridge/entrypoint.sh
@@ -9,10 +9,17 @@ while [ ! -f "$KEY_FILE" ]; do
   if [ $WAIT -gt 60 ]; then echo "ERROR: key never appeared"; exit 1; fi
 done
 
+# Install key for root (Coolify connects as root to avoid sudo-wrapper bugs)
+mkdir -p /root/.ssh && chmod 700 /root/.ssh
+cat "$KEY_FILE" > /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys
+echo "[ssh-bridge] Public key installed for root."
+
+# Keep deploy user key for backwards compatibility
 cat "$KEY_FILE" > /home/deploy/.ssh/authorized_keys
 chmod 600 /home/deploy/.ssh/authorized_keys
 chown deploy:deploy /home/deploy/.ssh/authorized_keys
-echo "[ssh-bridge] Public key installed."
+echo "[ssh-bridge] Public key installed for deploy."
 
 # Align Docker GID to host socket (critical on macOS Docker Desktop)
 SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- Coolify's `parseCommandsByLineForSudo()` corrupts `loadComposeFile` clone commands by inserting `sudo` before shell keywords (`if`/`then`/`fi`) inside `&&` chains, causing bash syntax errors (EXIT:2) on non-root servers
- This was the root cause of all cantaconmigo deploy failures ("Failed to read the Docker Compose file from the repository")
- Adds root `authorized_keys` setup in ssh-bridge entrypoint so Coolify can connect as `root`, bypassing the sudo wrapper entirely
- Retains `deploy` user setup for backwards compatibility

## Post-merge steps
After rebuilding ssh-bridge with this change:
```sql
UPDATE servers SET "user" = 'root' WHERE ip = 'ssh-bridge';
```
Or via Coolify UI: Server Settings → User → change to `root`

## Test plan
- [ ] Merge and rebuild ssh-bridge (`docker compose up -d --build ssh-bridge`)
- [ ] Verify root SSH works: `ssh root@ssh-bridge whoami` from Coolify container
- [ ] Update Coolify server user to `root`
- [ ] Re-deploy cantaconmigo — should succeed
- [ ] Verify deploy user SSH still works (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)