### PR TITLE
fix(setup): register ssh-bridge as root user

### DIFF
--- a/scripts/coolify-setup.sh
+++ b/scripts/coolify-setup.sh
@@ -156,7 +156,7 @@ fi
 echo "[setup] Updating server IP to ssh-bridge..."
 curl -sf -X PATCH "$COOLIFY_URL/servers/$SERVER_UUID" \
   -H "$(auth_header)" -H "Content-Type: application/json" \
-  -d '{"ip":"ssh-bridge","port":22,"user":"deploy"}' > /dev/null || true
+  -d '{"ip":"ssh-bridge","port":22,"user":"root"}' > /dev/null || true
 echo "[setup] Server IP updated."
 
 # ── 4. Register private key with Coolify ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- `coolify-setup.sh` line 159 hardcoded `"user":"deploy"` when registering the ssh-bridge server with Coolify
- This causes Coolify's `parseCommandsByLineForSudo()` to corrupt shell commands (inserting `sudo` before `if`/`then` keywords), breaking all docker-compose deployments
- Changes `deploy` → `root` to match the entrypoint.sh change from PR #54
- Ensures fresh stack bootstraps on new devices automatically use root

## Test plan
- [ ] Spin up fresh hermithost stack — verify server registers with `user=root`
- [ ] Deploy any docker-compose app — should succeed without sudo wrapper corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)