### PR TITLE
fix(envs): upsert env vars to prevent duplicates

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -886,14 +886,22 @@ router.post('/:slug/envs', async (req: Request, res: Response) => {
   try {
     const client = createCoolifyClient()!;
     const app = await client.getApplication(req.params.slug);
-    await client.createEnv(app.uuid, {
+    const existing = await client.listEnvs(app.uuid);
+    const match = existing.find((e) => e.key === body.key);
+    const payload = {
       key: body.key,
       value: body.value,
       ...(body.is_runtime !== undefined ? { is_runtime: body.is_runtime } : {}),
       ...(body.is_buildtime !== undefined ? { is_buildtime: body.is_buildtime } : {}),
       ...(body.is_shown_once !== undefined ? { is_shown_once: body.is_shown_once } : {}),
-    });
-    res.status(201).json({ message: 'Environment variable created' });
+    };
+    if (match) {
+      await client.updateEnv(app.uuid, { uuid: match.uuid, ...payload });
+      res.status(200).json({ message: 'Environment variable updated (key already existed)' });
+    } else {
+      await client.createEnv(app.uuid, payload);
+      res.status(201).json({ message: 'Environment variable created' });
+    }
   } catch (err) {
     console.error(`[coolify] POST /applications/${req.params.slug}/envs failed:`, (err as Error).message);
     res.status(502).json({ error: 'Failed to create environment variable via Coolify' });


### PR DESCRIPTION
## Summary
- `POST /api/sites/:slug/envs` now checks if the key already exists before creating
- If key exists, updates the existing row instead of creating a duplicate
- Coolify DB has no unique constraint on `(resourceable_id, key)` so the API must enforce idempotency
- Cleaned up 8 existing duplicate rows on hammer via SQL

## Test plan
- [ ] POST an env var that already exists — should return 200 with "updated" message
- [ ] POST a new env var — should return 201 with "created" message
- [ ] Verify no duplicate rows appear after rapid double-click

🤖 Generated with [Claude Code](https://claude.com/claude-code)