### PR TITLE
fix(infra): minimal start script for external network bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Pull Request opened
             ↓ (all must pass before merge)
 ```
 
-Deployment is left to the operator — run `docker compose up -d --build` on the host after pulling the latest code.
+Deployment is left to the operator — run `bash scripts/start.sh -d --build` on the host after pulling latest code.
 
 ### Setup
 
@@ -102,7 +102,7 @@ cp .env.template .env
 bash scripts/setup.sh
 
 # 3. Start the stack
-docker compose up -d
+bash scripts/start.sh -d
 ```
 
 ---
@@ -135,10 +135,10 @@ bash scripts/setup.sh
 ### 2. Start the stack
 
 ```bash
-docker compose up -d
+bash scripts/start.sh -d
 ```
 
-The `network-init` container automatically creates the `coolify` Docker network if it doesn't exist (required for inter-container communication).
+`start.sh` ensures the external `coolify` Docker network exists before starting the stack (required for inter-container communication).
 
 ### 3. Open the dashboard
 
@@ -273,7 +273,7 @@ Traefik + Let's Encrypt automatically issues and renews SSL certificates for all
 | Script | Purpose |
 |--------|---------|
 | `bash scripts/setup.sh` | First-time config — generates secrets, prompts for email + hostname |
-| `docker compose up -d` | Start the full stack (network-init auto-creates `coolify` network) |
+| `bash scripts/start.sh -d` | Start the full stack (auto-creates `coolify` network if needed) |
 | `bash scripts/stop.sh` | Stop all containers |
 | `bash scripts/restart.sh` | Restart the stack |
 | `bash scripts/status.sh` | Show container status |
@@ -441,10 +441,10 @@ Run `bash scripts/setup.sh` — it will prompt for anything missing and generate
 
 ### Stack won't start — Docker network missing
 
-The `network-init` container automatically creates the `coolify` network on startup. If you still see this error, check that the `network-init` service ran successfully:
+`scripts/start.sh` automatically creates the `coolify` network before starting the stack. If you ran `docker compose up` directly instead, create the network manually:
 
 ```bash
-docker compose logs network-init
+docker network create coolify
 ```
 
 ### Coolify login fails

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,4 @@
 services:
-  # ── Network Init (one-shot) ────────────────────────────────────
-  # Creates the external 'coolify' network if it doesn't exist yet.
-  # Makes docker compose up self-sufficient on fresh machines.
-  network-init:
-    image: docker:cli
-    restart: "no"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    entrypoint: ["sh", "-c", "docker network inspect coolify >/dev/null 2>&1 || docker network create coolify"]
-
   # ── Coolify — Deployment Engine ────────────────────────────────
   coolify:
     image: "ghcr.io/coollabsio/coolify:latest"
@@ -257,9 +247,6 @@ services:
     networks:
       - hermithost-net
       - coolify
-    depends_on:
-      network-init:
-        condition: service_completed_successfully
 
   # ── SvelteKit Dashboard ────────────────────────────────────────
   frontend:
@@ -314,8 +301,6 @@ services:
       - coolify
     restart: unless-stopped
     depends_on:
-      network-init:
-        condition: service_completed_successfully
       coolify:
         condition: service_healthy
       coolify-server-setup:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -92,4 +92,4 @@ fi
 
 echo ""
 echo "[setup] Configuration complete. Ready to start:"
-echo "        docker compose up -d"
+echo "        bash scripts/start.sh -d"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Ensure the external coolify network exists, then start the stack.
+# The coolify network is external so docker compose down doesn't destroy it
+# and take deployed site containers offline.
+docker network inspect coolify >/dev/null 2>&1 || docker network create coolify
+exec docker compose up "$@"


### PR DESCRIPTION
## Summary
- Removes network-init container (can't work — compose validates external networks before starting any containers)
- Adds minimal `scripts/start.sh` that creates the `coolify` network pre-compose
- Keeps `external: true` so `docker compose down` doesn't destroy the network and take deployed sites offline

## Test plan
- [ ] `bash scripts/start.sh -d` on fresh machine with no pre-existing `coolify` network
- [ ] `bash scripts/start.sh -d` on existing machine where `coolify` network already exists
- [ ] `docker compose down && bash scripts/start.sh -d` — verify deployed site containers stay online

🤖 Generated with [Claude Code](https://claude.com/claude-code)