### PR TITLE
ci: target hammer runner for CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   # ── API: typecheck + build in one job (avoids double npm ci) ──────────────
   api:
     name: API — Typecheck & Build
-    runs-on: self-hosted
+    runs-on: [self-hosted, hammer]
     defaults:
       run:
         working-directory: api
@@ -28,7 +28,7 @@ jobs:
   # ── Frontend: typecheck + svelte-check + build ───────────────────────────
   frontend:
     name: Frontend — Typecheck & Build
-    runs-on: self-hosted
+    runs-on: [self-hosted, hammer]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -50,7 +50,7 @@ jobs:
   # ── Docker: validate both images build cleanly ───────────────────────────
   docker:
     name: Docker — Image Build
-    runs-on: self-hosted
+    runs-on: [self-hosted, hammer]
     needs: [api, frontend]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Changes all CI jobs from `runs-on: self-hosted` to `runs-on: [self-hosted, hammer]`

## Test plan
- [ ] CI runs on hammer runner for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)