### PR TITLE
fix(ui+infra): site name display + SSL for public mode

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -51,3 +51,6 @@ TRAEFIK_HTTPS_PORT=8443
 # Email for Let's Encrypt certificate notifications.
 # Prompted by setup.sh if not set.
 ACME_EMAIL=
+# Only set when using --profile internal (step-ca local CA).
+# Leave empty for public Let's Encrypt mode.
+# LEGO_CA_CERTIFICATES=/home/step/certs/root_ca.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,8 +232,10 @@ services:
       timeout: 5s
       retries: 3
     environment:
-      # Trust step-ca root CA so Lego can negotiate with it
-      LEGO_CA_CERTIFICATES: "/home/step/certs/root_ca.crt"
+      # Trust step-ca root CA so Lego can negotiate with it.
+      # Only set when running with --profile internal; empty value is
+      # ignored by Traefik so the letsencrypt resolver works unimpaired.
+      LEGO_CA_CERTIFICATES: "${LEGO_CA_CERTIFICATES:-}"
     ports:
       - "${TRAEFIK_HTTP_PORT:-8080}:80"
       - "${TRAEFIK_HTTPS_PORT:-8443}:443"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -290,8 +290,8 @@
 									<span class="status-dot status-{site.overallStatus}"></span>
 								{/if}
 								<div>
-									<a href="/sites/{site.slug}" class="site-domain">{site.domain}</a>
-									<div class="site-desc">{site.description}</div>
+									<a href="/sites/{site.slug}" class="site-name">{site.name}</a>
+									<div class="site-domain-sub mono">{site.domain}</div>
 								</div>
 							</div>
 						</td>
@@ -661,8 +661,7 @@
 		50% { opacity: 0.4; }
 	}
 
-	.site-domain {
-		font-family: var(--font-mono);
+	.site-name {
 		font-size: 13px;
 		color: var(--accent-teal);
 		font-weight: 500;
@@ -670,12 +669,12 @@
 		transition: color 0.1s;
 	}
 
-	.site-domain:hover {
+	.site-name:hover {
 		color: #5ab5b7;
 	}
 
-	.site-desc {
-		font-size: 12px;
+	.site-domain-sub {
+		font-size: 11px;
 		color: var(--text-secondary);
 		margin-top: 1px;
 	}


### PR DESCRIPTION
## Summary
- Sites list now shows `site.name` as primary label with domain as monospace sub-label
- `LEGO_CA_CERTIFICATES` is env-driven with empty default — Traefik no longer errors when step-ca isn't running in public mode
- Added `LEGO_CA_CERTIFICATES` docs to `.env.template`

## Test plan
- [ ] Sites list shows human-readable names, not just domains
- [ ] Traefik starts without step-ca errors in public mode
- [ ] Let's Encrypt cert provisioning works with port forwarding in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)