### PR TITLE
fix(ui): show site name on detail page

### DIFF
--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -687,7 +687,7 @@
 	<div class="breadcrumb">
 		<a href="/" class="breadcrumb-link">Sites</a>
 		<span class="breadcrumb-sep">/</span>
-		<span class="breadcrumb-current mono">{site.domain}</span>
+		<span class="breadcrumb-current">{site.name}</span>
 	</div>
 
 	<!-- Page header -->
@@ -695,10 +695,10 @@
 		<div class="header-left">
 			<div class="site-title-row">
 				<span class="status-dot status-{site.overallStatus}"></span>
-				<h1 class="page-title mono">{site.domain}</h1>
+				<h1 class="page-title">{site.name}</h1>
 			</div>
 			<div class="site-meta">
-				<span>{site.description}</span>
+				<span class="mono">{site.domain}</span>
 				<span class="sep">·</span>
 				<span class="mono">{site.repository}</span>
 				<span class="sep">·</span>


### PR DESCRIPTION
## Summary
- Detail page header now shows `site.name` instead of `site.domain`
- Breadcrumb shows `site.name` instead of `site.domain`
- Domain displayed as monospace secondary label in meta row

## Test plan
- [ ] Detail page shows human-readable site name in header
- [ ] Breadcrumb shows site name

🤖 Generated with [Claude Code](https://claude.com/claude-code)