### PR TITLE
fix(dns): use @ for root A record in site provisioning

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -181,7 +181,7 @@ export async function provisionDns(fqdn: string): Promise<void> {
   }
 
   try {
-    await provider.addRecord(domain, { type: 'A', name: domain, value: serverIp, ttl: 3600 });
+    await provider.addRecord(domain, { type: 'A', name: '@', value: serverIp, ttl: 3600 });
     console.log(`[dns-provision] A record created: ${domain} @ → ${serverIp}`);
   } catch (err) {
     console.warn(`[dns-provision] A record create warning for ${domain}:`, (err as Error).message);


### PR DESCRIPTION
## Summary
- Fix doubled FQDN bug in `provisionDns()` — was passing full domain as record name, causing e.g. `probablyfine.570n3r.com.probablyfine.570n3r.com`
- Use `'@'` to correctly target the zone root

## Test plan
- [ ] Add a new site on macbeth — verify DNS A record is created correctly (no doubled domain)
- [ ] Verify existing sites unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)