### PR TITLE
feat(ui): add Preview badge to environment variables

### DIFF
--- a/api/src/services/coolify.ts
+++ b/api/src/services/coolify.ts
@@ -101,6 +101,7 @@ export interface CoolifyEnv {
   is_shown_once: boolean;
   is_runtime: boolean;
   is_buildtime: boolean;
+  is_preview: boolean;
 }
 
 export interface CreateEnvPayload {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,6 +87,7 @@ export interface EnvVar {
 	is_shown_once: boolean;
 	is_runtime: boolean;
 	is_buildtime: boolean;
+	is_preview: boolean;
 }
 
 export interface Site {

--- a/src/routes/sites/[slug]/+page.svelte
+++ b/src/routes/sites/[slug]/+page.svelte
@@ -1393,6 +1393,9 @@
 										{#if env.is_buildtime}
 											<span class="env-badge env-badge-build">Build</span>
 										{/if}
+										{#if env.is_preview}
+											<span class="env-badge env-badge-preview">Preview</span>
+										{/if}
 									</td>
 									<td class="cell-actions">
 										{#if deletingEnvUuid === env.uuid}
@@ -1961,6 +1964,12 @@
 		color: #e8c87a;
 		border-color: rgba(232,200,122,0.3);
 		background: rgba(232,200,122,0.08);
+	}
+
+	.env-badge-preview {
+		color: #a8c8e6;
+		border-color: rgba(168,200,230,0.3);
+		background: rgba(168,200,230,0.08);
 	}
 
 	.env-toggles {


### PR DESCRIPTION
## Summary
- Add `is_preview` to `CoolifyEnv` and `EnvVar` types
- Show blue "Preview" badge in env tab to distinguish production vs preview env entries
- Coolify auto-creates duplicate env vars (one production, one preview) — badge makes this visible

## Test plan
- [ ] View environment tab for a site with env vars — verify Preview badge appears on preview entries
- [ ] Verify non-preview entries show no Preview badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)