### PR TITLE
fix(coolify): remove force_domain_override and verify domain patch

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -573,12 +573,17 @@ router.post('/', async (req: Request, res: Response) => {
     if (resolvedFqdn) {
       // Coolify requires full URL format — add https:// if no protocol present
       const coolifyDomain = /^https?:\/\//i.test(resolvedFqdn) ? resolvedFqdn : `https://${resolvedFqdn}`;
-      await client.updateApplication(app.uuid, { domains: coolifyDomain, force_domain_override: true }).catch((e: Error) => {
+      await client.updateApplication(app.uuid, { domains: coolifyDomain }).catch((e: Error) => {
         console.warn(`[coolify] domains patch failed for ${app.uuid}:`, e.message);
       });
-      // Re-fetch to get full app with updated fqdn
+      // Verify domain was actually set — Coolify may silently ignore the patch
       const refreshed = await client.getApplication(app.uuid).catch(() => null);
-      if (refreshed) app = refreshed;
+      if (refreshed) {
+        app = refreshed;
+        if (!refreshed.fqdn?.includes(resolvedFqdn)) {
+          console.warn(`[coolify] domain verification failed for ${app.uuid}: expected ${resolvedFqdn}, got ${refreshed.fqdn}`);
+        }
+      }
       await provisionDns(resolvedFqdn);
       // Route file written after first deploy (container doesn't exist yet at creation time)
     }

--- a/api/src/services/backup.ts
+++ b/api/src/services/backup.ts
@@ -402,7 +402,7 @@ export async function importBackup(data: BackupFile): Promise<ImportResult> {
         }
         if (site.domain) {
           const coolifyDomain = /^https?:\/\//i.test(site.domain) ? site.domain : `https://${site.domain}`;
-          await coolify.updateApplication(app.uuid, { domains: coolifyDomain, force_domain_override: true }).catch((e: Error) => {
+          await coolify.updateApplication(app.uuid, { domains: coolifyDomain }).catch((e: Error) => {
             console.warn(`[backup-restore] domains patch failed for ${app.uuid} (${site.name}): ${e.message}`);
           });
           // Verify domain was actually set — Coolify may silently ignore the patch

--- a/api/src/services/coolify.ts
+++ b/api/src/services/coolify.ts
@@ -86,7 +86,6 @@ export interface CoolifyUpdateApplicationPayload {
   name?: string;
   description?: string;
   domains?: string;  // sets fqdn — Coolify PATCH uses 'domains', not 'fqdn'
-  force_domain_override?: boolean;
   git_repository?: string;
   git_branch?: string;
   build_pack?: string;


### PR DESCRIPTION
## Summary
- Remove `force_domain_override` from Coolify PATCH payload — not a real API field, caused domain updates to be silently ignored
- Add post-patch verification on site creation — logs warning if domain didn't stick
- Remove same field from backup restore path (verification already existed from PR #67)

## Test plan
- [ ] Create a new site with a custom domain — verify domain is set correctly (not sslip.io fallback)
- [ ] Run backup restore with domains — verify domains are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)