### PR TITLE
fix(api): use 'domains' field for Coolify create payload

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -560,7 +560,7 @@ router.post('/', async (req: Request, res: Response) => {
       ...(body.description !== undefined ? { description: body.description } : {}),
       ...(body.docker_compose_location !== undefined ? { docker_compose_location: body.docker_compose_location } : (body.build_pack === 'dockercompose' ? { docker_compose_location: '/docker-compose.yml' } : {})),
       ...(body.base_directory !== undefined ? { base_directory: body.base_directory } : {}),
-      ...(coolifyFqdn ? { fqdn: coolifyFqdn } : {}),
+      ...(coolifyFqdn ? { domains: coolifyFqdn } : {}),
     };
     let app = await client.createApplication(payload);
 

--- a/api/src/services/backup.ts
+++ b/api/src/services/backup.ts
@@ -383,8 +383,7 @@ export async function importBackup(data: BackupFile): Promise<ImportResult> {
         const resolvedRepo = site.deploy_auth === 'pat' && site.deploy_token
           ? embedPatInRepoUrl(site.git_repository, site.deploy_token)
           : site.git_repository;
-        // Resolve fqdn before creation — Coolify v4.3.5 PATCH silently ignores 'domains',
-        // but POST /applications/public accepts fqdn at creation time.
+        // Resolve domain before creation — Coolify POST /applications/public uses 'domains' field.
         const coolifyFqdn = site.domain
           ? (/^https?:\/\//i.test(site.domain) ? site.domain : `https://${site.domain}`)
           : undefined;
@@ -401,7 +400,7 @@ export async function importBackup(data: BackupFile): Promise<ImportResult> {
           environment_name: 'production',
           instant_deploy: false,
           ...(site.description ? { description: site.description } : {}),
-          ...(coolifyFqdn ? { fqdn: coolifyFqdn } : {}),
+          ...(coolifyFqdn ? { domains: coolifyFqdn } : {}),
         });
         if (site.deploy_auth !== 'pat') {
           await linkGithubKey(app.uuid);

--- a/api/src/services/coolify.ts
+++ b/api/src/services/coolify.ts
@@ -53,7 +53,7 @@ export interface CoolifyCreateApplicationPayload {
   type: 'public' | 'private';
   name: string;
   description?: string;
-  fqdn?: string;
+  domains?: string;
   git_repository: string;
   git_branch: string;
   build_pack: string;


### PR DESCRIPTION
## Summary
- Coolify v4.3.5 API rejects `fqdn` with 422 ("This field is not allowed") — the correct field name is `domains`
- Renamed `fqdn` → `domains` in `CoolifyCreateApplicationPayload` interface and both create paths (sites.ts + backup.ts)
- Fixes site creation failing after PR #71

## Test plan
- [ ] Create a new site on localhost stack — verify Coolify accepts the payload (no 422)
- [ ] Verify the created app has the correct domain (not sslip.io fallback)
- [ ] Verify backup restore path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)