### PR TITLE
feat(security): Docker socket proxy sidecar + CORS fix (S3+S4)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -52,6 +52,13 @@ HERMITHOST_PASSWORD=
 # Generate with: openssl rand -hex 32
 COOKIE_SECRET=
 
+# ── CORS ─────────────────────────────────────────────────────────
+# Allowed origin(s) for the API. Required when cookie-based auth is used —
+# browsers reject Access-Control-Allow-Origin: * with credentials: true.
+# Single origin:   CORS_ORIGIN=https://hermithost.example.com
+# Multiple origins: CORS_ORIGIN=https://hermithost.example.com,https://admin.example.com
+CORS_ORIGIN=http://localhost:3000
+
 # ── Traefik ───────────────────────────────────────────────────────
 TRAEFIK_HTTP_PORT=8080
 TRAEFIK_HTTPS_PORT=8443

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -21,7 +21,11 @@ const app = express();
 const PORT = process.env.PORT ?? 3001;
 
 // Middleware
-app.use(cors({ origin: process.env.CORS_ORIGIN ?? 'http://localhost:3000' }));
+const _corsRaw = process.env.CORS_ORIGIN ?? 'http://localhost:3000';
+const _corsOrigins = _corsRaw.includes(',')
+  ? _corsRaw.split(',').map(s => s.trim())
+  : _corsRaw;
+app.use(cors({ origin: _corsOrigins, credentials: true }));
 app.use(express.json());
 
 // ── Auth routes — mounted BEFORE requireAuth so login/logout/check are public ──

--- a/api/src/services/docker.ts
+++ b/api/src/services/docker.ts
@@ -1,30 +1,54 @@
 import * as http from 'http';
 
+// Route all Docker API calls through the label-gated sidecar proxy.
+// The proxy blocks operations on containers not managed by hermithost.
+const PROXY_BASE = process.env.DOCKER_PROXY_URL ?? 'http://docker-proxy:2375';
+
+function parseBase(base: string): { hostname: string; port: number; basePath: string } {
+  const u = new URL(base);
+  return {
+    hostname: u.hostname,
+    port: parseInt(u.port || '80', 10),
+    basePath: u.pathname.replace(/\/$/, ''),
+  };
+}
+
+// Translate Docker Engine API paths (/containers/json, /containers/:id/start …)
+// to the proxy surface, which mirrors those paths directly.
+// The proxy exposes /containers/* so paths pass through unchanged.
+function proxyPath(dockerPath: string): string {
+  const { basePath } = parseBase(PROXY_BASE);
+  return `${basePath}${dockerPath}`;
+}
+
 export function dockerGet(path: string): Promise<unknown> {
+  const { hostname, port } = parseBase(PROXY_BASE);
   return new Promise((resolve, reject) => {
     const req = http.get(
-      { socketPath: '/var/run/docker.sock', path, headers: { Host: 'localhost' } },
+      { hostname, port, path: proxyPath(path), headers: { Host: hostname } },
       (res) => {
         let body = '';
         res.on('data', (d: Buffer) => { body += d; });
         res.on('end', () => {
           try { resolve(JSON.parse(body)); }
-          catch { reject(new Error(`Docker API parse error: ${body.slice(0, 200)}`)); }
+          catch { reject(new Error(`Docker proxy parse error: ${body.slice(0, 200)}`)); }
         });
       }
     );
     req.on('error', reject);
-    req.setTimeout(3000, () => { req.destroy(); reject(new Error('Docker API timeout')); });
+    req.setTimeout(3000, () => { req.destroy(); reject(new Error('Docker proxy timeout')); });
   });
 }
 
 export function dockerDelete(path: string): Promise<{ statusCode: number }> {
+  const { hostname, port } = parseBase(PROXY_BASE);
   return new Promise((resolve, reject) => {
     const options: http.RequestOptions = {
-      socketPath: '/var/run/docker.sock',
-      path,
+      hostname,
+      port,
+      path: proxyPath(path),
       method: 'DELETE',
-      headers: { Host: 'localhost' },
+      headers: { Host: hostname },
     };
     const req = http.request(options, (res) => {
       let body = '';
@@ -34,27 +58,29 @@ export function dockerDelete(path: string): Promise<{ statusCode: number }> {
         if (code >= 200 && code < 300) {
           resolve({ statusCode: code });
         } else {
-          let message = `Docker API error ${code}`;
-          try { message = (JSON.parse(body) as { message?: string }).message ?? message; } catch {}
+          let message = `Docker proxy error ${code}`;
+          try { message = (JSON.parse(body) as { error?: string; message?: string }).error ?? message; } catch {}
           reject(new Error(message));
         }
       });
     });
     req.on('error', reject);
-    req.setTimeout(10000, () => { req.destroy(); reject(new Error('Docker API timeout')); });
+    req.setTimeout(10000, () => { req.destroy(); reject(new Error('Docker proxy timeout')); });
     req.end();
   });
 }
 
 export function dockerPost(path: string, body?: object): Promise<{ statusCode: number | undefined }> {
+  const { hostname, port } = parseBase(PROXY_BASE);
   return new Promise((resolve, reject) => {
     const payload = body ? JSON.stringify(body) : '';
     const options: http.RequestOptions = {
-      socketPath: '/var/run/docker.sock',
-      path,
+      hostname,
+      port,
+      path: proxyPath(path),
       method: 'POST',
       headers: {
-        Host: 'localhost',
+        Host: hostname,
         'Content-Type': 'application/json',
         'Content-Length': Buffer.byteLength(payload),
       },
@@ -68,7 +94,7 @@ export function dockerPost(path: string, body?: object): Promise<{ statusCode: n
       });
     });
     req.on('error', reject);
-    req.setTimeout(30000, () => { req.destroy(); reject(new Error('Docker API timeout')); });
+    req.setTimeout(30000, () => { req.destroy(); reject(new Error('Docker proxy timeout')); });
     if (payload) req.write(payload);
     req.end();
   });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -261,6 +261,17 @@ services:
       - hermithost-net
     restart: unless-stopped
 
+  # ── Docker Socket Proxy (label-gated sidecar) ─────────────────
+  docker-proxy:
+    build:
+      context: ./sidecar/docker-proxy
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - hermithost-net
+
   # ── Node.js API ────────────────────────────────────────────────
   api:
     build:
@@ -268,7 +279,7 @@ services:
       dockerfile: Dockerfile
     environment:
       PORT: "3001"
-      CORS_ORIGIN: "*"
+      CORS_ORIGIN: "${CORS_ORIGIN:-http://localhost:3000}"
       SITES_DIR: "/app/sites"
       COOLIFY_API_URL: "http://coolify:8080/api/v1"
       COOLIFY_API_TOKEN: "${COOLIFY_API_TOKEN}"
@@ -290,12 +301,12 @@ services:
       PGDATABASE: "coolify"
       PGUSER: "coolify"
       PGPASSWORD: "${COOLIFY_DB_PASSWORD}"
+      DOCKER_PROXY_URL: "http://docker-proxy:2375"
     volumes:
       - hermithost-sites:/app/sites
       - coolify-api-token:/coolify-api-token
       - coolify-keys:/coolify-keys:ro
       - ./traefik/conf.d:/app/traefik-conf.d
-      - /var/run/docker.sock:/var/run/docker.sock
       - step-ca-data:/home/step:ro
       - traefik-logs:/traefik-logs:ro
       - hermithost-stats:/app/data
@@ -309,6 +320,8 @@ services:
         condition: service_healthy
       coolify-server-setup:
         condition: service_completed_successfully
+      docker-proxy:
+        condition: service_started
 
   # ── Sites Restore (one-shot) ───────────────────────────────────
   # Restores coolify-managed containers checkpointed by stack-down.sh.

--- a/sidecar/docker-proxy/Dockerfile
+++ b/sidecar/docker-proxy/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+# ── Runtime image ─────────────────────────────────────────────────────────────
+FROM node:20-alpine
+
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 2375
+CMD ["node", "dist/index.js"]

--- a/sidecar/docker-proxy/package.json
+++ b/sidecar/docker-proxy/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "docker-proxy",
+  "version": "1.0.0",
+  "description": "Label-gated Docker socket sidecar for hermithost",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/sidecar/docker-proxy/src/index.ts
+++ b/sidecar/docker-proxy/src/index.ts
@@ -1,0 +1,156 @@
+import express, { Request, Response, NextFunction } from 'express';
+import * as http from 'http';
+
+const app = express();
+app.use(express.json());
+
+const DOCKER_SOCKET = '/var/run/docker.sock';
+const PORT = 2375;
+
+// A container is "managed" if it belongs to the hermithost compose stack
+// OR is a Coolify-deployed application (carries coolify.applicationId or coolify.managed=true).
+function isManagedContainer(labels: Record<string, string>): boolean {
+  if (labels['com.docker.compose.project'] === 'hermithost') return true;
+  if (labels['coolify.applicationId']) return true;
+  if (labels['coolify.managed'] === 'true') return true;
+  return false;
+}
+
+// ── Docker socket helpers ─────────────────────────────────────────────────────
+
+function dockerRequest(options: http.RequestOptions, body?: string): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ socketPath: DOCKER_SOCKET, ...options }, (res) => {
+      let data = '';
+      res.on('data', (chunk: Buffer) => { data += chunk; });
+      res.on('end', () => resolve({ statusCode: res.statusCode ?? 0, body: data }));
+    });
+    req.on('error', reject);
+    req.setTimeout(15000, () => { req.destroy(); reject(new Error('Docker socket timeout')); });
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+async function getContainerLabels(id: string): Promise<Record<string, string> | null> {
+  try {
+    const result = await dockerRequest({ path: `/containers/${id}/json`, method: 'GET', headers: { Host: 'localhost' } });
+    if (result.statusCode === 404) return null;
+    const data = JSON.parse(result.body) as { Config?: { Labels?: Record<string, string> } };
+    return data.Config?.Labels ?? {};
+  } catch {
+    return null;
+  }
+}
+
+// ── Guard middleware for mutating container operations ───────────────────────
+
+async function assertManaged(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const { id } = req.params;
+  const labels = await getContainerLabels(id);
+  if (labels === null) {
+    res.status(404).json({ error: 'Container not found' });
+    return;
+  }
+  if (!isManagedContainer(labels)) {
+    console.warn(`[docker-proxy] BLOCKED: operation on unmanaged container ${id}`);
+    res.status(403).json({ error: 'Container is not managed by hermithost' });
+    return;
+  }
+  next();
+}
+
+// ── GET /containers — list containers, pass through filters from query ────────
+
+app.get('/containers', async (req: Request, res: Response): Promise<void> => {
+  try {
+    const qs = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
+    const result = await dockerRequest({
+      path: `/containers/json${qs}`,
+      method: 'GET',
+      headers: { Host: 'localhost' },
+    });
+    res.status(result.statusCode).set('Content-Type', 'application/json').send(result.body);
+  } catch (err) {
+    console.error('[docker-proxy] GET /containers failed:', (err as Error).message);
+    res.status(502).json({ error: 'Docker socket error' });
+  }
+});
+
+// ── POST /containers/:id/start ────────────────────────────────────────────────
+
+app.post('/containers/:id/start', assertManaged, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const result = await dockerRequest({
+      path: `/containers/${req.params.id}/start`,
+      method: 'POST',
+      headers: { Host: 'localhost', 'Content-Length': '0' },
+    });
+    res.status(result.statusCode).send();
+  } catch (err) {
+    console.error(`[docker-proxy] start ${req.params.id} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Docker socket error' });
+  }
+});
+
+// ── POST /containers/:id/stop ─────────────────────────────────────────────────
+
+app.post('/containers/:id/stop', assertManaged, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const qs = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
+    const result = await dockerRequest({
+      path: `/containers/${req.params.id}/stop${qs}`,
+      method: 'POST',
+      headers: { Host: 'localhost', 'Content-Length': '0' },
+    });
+    res.status(result.statusCode).send();
+  } catch (err) {
+    console.error(`[docker-proxy] stop ${req.params.id} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Docker socket error' });
+  }
+});
+
+// ── POST /containers/:id/restart ──────────────────────────────────────────────
+
+app.post('/containers/:id/restart', assertManaged, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const qs = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
+    const result = await dockerRequest({
+      path: `/containers/${req.params.id}/restart${qs}`,
+      method: 'POST',
+      headers: { Host: 'localhost', 'Content-Length': '0' },
+    });
+    res.status(result.statusCode).send();
+  } catch (err) {
+    console.error(`[docker-proxy] restart ${req.params.id} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Docker socket error' });
+  }
+});
+
+// ── DELETE /containers/:id ────────────────────────────────────────────────────
+
+app.delete('/containers/:id', assertManaged, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const qs = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
+    const result = await dockerRequest({
+      path: `/containers/${req.params.id}${qs}`,
+      method: 'DELETE',
+      headers: { Host: 'localhost' },
+    });
+    res.status(result.statusCode).send();
+  } catch (err) {
+    console.error(`[docker-proxy] delete ${req.params.id} failed:`, (err as Error).message);
+    res.status(502).json({ error: 'Docker socket error' });
+  }
+});
+
+// ── Catch-all — deny anything not explicitly routed ──────────────────────────
+
+app.use((_req: Request, res: Response) => {
+  res.status(404).json({ error: 'Not found' });
+});
+
+app.listen(PORT, () => {
+  console.log(`[docker-proxy] Listening on :${PORT}`);
+  console.log(`[docker-proxy] Socket: ${DOCKER_SOCKET}`);
+});

--- a/sidecar/docker-proxy/tsconfig.json
+++ b/sidecar/docker-proxy/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- **S3:** Adds a label-gated Docker socket proxy sidecar — API container no longer mounts the Docker socket directly. Only hermithost and Coolify-managed containers can be started/stopped/deleted.
- **S4:** Replaces CORS `"*"` with configurable origin(s) + `credentials: true` for cookie auth.

## New files
- `sidecar/docker-proxy/` — Express proxy (156 lines) with Dockerfile

## New env vars
- `DOCKER_PROXY_URL` — defaults to `http://docker-proxy:2375`
- `CORS_ORIGIN` — comma-separated allowed origins (defaults to `http://localhost:3000`)

## Test plan
- [ ] Verify API can list containers through proxy
- [ ] Verify start/stop/restart work on hermithost containers
- [ ] Verify operations on non-hermithost containers return 403
- [ ] Verify CORS headers include `credentials: true`
- [ ] Verify cross-origin requests from non-allowed origins are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)