### PR TITLE
feat(dns): recursion mode dropdown with safe LAN default

### DIFF
--- a/api/src/routes/config.ts
+++ b/api/src/routes/config.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { createCoolifyClient } from '../services/coolify';
-import { createTechnitiumClient } from '../services/technitium';
+import { createTechnitiumClient, RecursionMode } from '../services/technitium';
 
 const router = Router();
 
@@ -108,14 +108,28 @@ async function getTechnitiumStatus(): Promise<IntegrationStatus> {
   }
 }
 
+async function getDnsRecursion(): Promise<RecursionMode> {
+  const client = createTechnitiumClient();
+  if (!client) return 'LanOnly';
+  try {
+    return await client.getRecursion();
+  } catch (err) {
+    console.warn('[config] getRecursion failed — defaulting to LanOnly:', (err as Error).message);
+    return 'LanOnly';
+  }
+}
+
+const VALID_RECURSION_MODES: RecursionMode[] = ['Disabled', 'LanOnly', 'Public'];
+
 // GET /api/config
 router.get('/', async (_req: Request, res: Response) => {
   try {
     const cfToken = readSetting('cloudflare_token') ?? process.env.CLOUDFLARE_TOKEN ?? null;
-    const [coolify_status, technitium_status, cloudflare_status] = await Promise.all([
+    const [coolify_status, technitium_status, cloudflare_status, dns_recursion] = await Promise.all([
       getCoolifyStatus(),
       getTechnitiumStatus(),
       getCloudflareStatus(cfToken),
+      getDnsRecursion(),
     ]);
 
     const dns_provider = readSetting('dns_provider') ?? process.env.DNS_PROVIDER ?? 'technitium';
@@ -133,6 +147,7 @@ router.get('/', async (_req: Request, res: Response) => {
       cloudflare_status,
       cloudflare_token_set: !!cfToken,
       network_mode: readNetworkMode(),
+      dns_recursion,
     });
   } catch (err) {
     console.error('[config] GET failed:', (err as Error).message);
@@ -149,6 +164,7 @@ router.put('/', async (req: Request, res: Response) => {
     cloudflare_token?: unknown;
     network_mode?: unknown;
     dns_forwarders?: unknown;
+    dns_recursion?: unknown;
   };
 
   // Validate at least one known key is present
@@ -158,9 +174,10 @@ router.put('/', async (req: Request, res: Response) => {
   const hasCfToken = typeof body.cloudflare_token === 'string';
   const hasNetworkMode = typeof body.network_mode === 'string' && body.network_mode.trim();
   const hasDnsForwarders = Array.isArray(body.dns_forwarders);
+  const hasDnsRecursion = typeof body.dns_recursion === 'string' && (body.dns_recursion as string).trim();
 
-  if (!hasNsHostname && !hasNsServerIp && !hasDnsProvider && !hasCfToken && !hasNetworkMode && !hasDnsForwarders) {
-    res.status(400).json({ error: 'At least one field required: ns_hostname, ns_server_ip, dns_provider, cloudflare_token, network_mode, dns_forwarders' });
+  if (!hasNsHostname && !hasNsServerIp && !hasDnsProvider && !hasCfToken && !hasNetworkMode && !hasDnsForwarders && !hasDnsRecursion) {
+    res.status(400).json({ error: 'At least one field required: ns_hostname, ns_server_ip, dns_provider, cloudflare_token, network_mode, dns_forwarders, dns_recursion' });
     return;
   }
 
@@ -173,6 +190,12 @@ router.put('/', async (req: Request, res: Response) => {
   // Validate network_mode enum if provided
   if (hasNetworkMode && !['external', 'internal', 'mixed'].includes((body.network_mode as string).trim())) {
     res.status(400).json({ error: 'network_mode must be "external" or "internal"' });
+    return;
+  }
+
+  // Validate dns_recursion enum if provided
+  if (hasDnsRecursion && !VALID_RECURSION_MODES.includes((body.dns_recursion as string).trim() as RecursionMode)) {
+    res.status(400).json({ error: 'dns_recursion must be "Disabled", "LanOnly", or "Public"' });
     return;
   }
 
@@ -232,6 +255,25 @@ router.put('/', async (req: Request, res: Response) => {
       const value = (body.network_mode as string).trim() as 'external' | 'internal' | 'mixed';
       writeFileSync(NETWORK_MODE_FILE, value, 'utf8');
       result.network_mode = value;
+    }
+
+    if (hasDnsRecursion) {
+      const mode = (body.dns_recursion as string).trim() as RecursionMode;
+      const technitium = createTechnitiumClient();
+      if (technitium) {
+        // Audit: read current state before mutating so we log from→to (spec §7).
+        let from: RecursionMode | 'unknown' = 'unknown';
+        try { from = await technitium.getRecursion(); } catch { /* fall through with 'unknown' */ }
+        await technitium.setRecursion(mode);
+        console.info(JSON.stringify({
+          event: 'dns_recursion_change',
+          from,
+          to: mode,
+          actor: 'admin',
+          ts: new Date().toISOString(),
+        }));
+      }
+      result.dns_recursion = mode;
     }
 
     res.status(200).json(result);

--- a/api/src/services/technitium.ts
+++ b/api/src/services/technitium.ts
@@ -87,6 +87,8 @@ export interface TechnitiumDeleteResponse {
   errorMessage?: string;
 }
 
+export type RecursionMode = 'Disabled' | 'LanOnly' | 'Public';
+
 export interface TechnitiumGetRecordsResult {
   zone: TechnitiumZone;
   records: TechnitiumRecord[];
@@ -242,6 +244,49 @@ export class TechnitiumClient {
       });
       const res = await fetch(`${this.baseUrl}/api/settings/set`, { method: 'POST', headers: this.postHeaders, body });
       await handleResponse<TechnitiumDeleteResponse>(res, 'POST /api/settings/set');
+    });
+  }
+
+  async getRecursion(): Promise<RecursionMode> {
+    return this.withTokenRetry(async () => {
+      const body = this.buildParams({});
+      const res = await fetch(`${this.baseUrl}/api/settings/get`, { method: 'POST', headers: this.postHeaders, body });
+      const data = await res.json() as { status: string; errorMessage?: string; response?: { recursion?: string; recursionNetworkACL?: string } };
+      if (data.status !== 'ok') throw new Error(`Technitium /api/settings/get error: ${data.errorMessage ?? data.status}`);
+      const recursion = data.response?.recursion ?? '';
+      const acl = data.response?.recursionNetworkACL ?? '';
+      switch (recursion) {
+        case 'Deny':  return 'Disabled';
+        case 'Allow': return 'Public';
+        case 'UseSpecifiedNetworkACL': return 'LanOnly';
+        default:
+          // AllowOnlyForPrivateNetworks (broken default) or unrecognized value.
+          // Surface drift for observability; UI shows safe default until reconciled.
+          console.warn(`[technitium] getRecursion: unrecognized Technitium recursion="${recursion}" acl="${acl}" — reporting as LanOnly`);
+          return 'LanOnly';
+      }
+    });
+  }
+
+  async setRecursion(mode: RecursionMode): Promise<void> {
+    return this.withTokenRetry(async () => {
+      const SAFE_RECURSION_ACL = '127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,::1/128,fd00::/8';
+      const technitiumRecursion: Record<RecursionMode, string> = {
+        Disabled: 'Deny',
+        LanOnly:  'UseSpecifiedNetworkACL',
+        Public:   'Allow',
+      };
+      const technitiumAcl: Record<RecursionMode, string> = {
+        Disabled: '',
+        LanOnly:  SAFE_RECURSION_ACL,
+        Public:   '',
+      };
+      const body = this.buildParams({
+        recursion:           technitiumRecursion[mode],
+        recursionNetworkACL: technitiumAcl[mode],
+      });
+      const res = await fetch(`${this.baseUrl}/api/settings/set`, { method: 'POST', headers: this.postHeaders, body });
+      await handleResponse<TechnitiumDeleteResponse>(res, 'POST /api/settings/set (recursion)');
     });
   }
 }

--- a/scripts/coolify-setup.sh
+++ b/scripts/coolify-setup.sh
@@ -95,6 +95,24 @@ else
   echo "[setup] WARNING: Could not obtain Technitium token — DNS integration will be limited."
 fi
 
+# ── Technitium recursion init (idempotent — only fixes broken default) ────────
+if [ -n "$TECH_SESSION" ]; then
+  echo "[setup] Checking Technitium recursion mode..."
+  TECH_PERM_TOKEN=$(cat /coolify-api-token/technitium_token 2>/dev/null || echo "$TECH_SESSION")
+  SETTINGS_RESP=$(curl -sf -X POST "$TECH_URL/api/settings/get?token=$TECH_PERM_TOKEN" 2>/dev/null || echo "")
+  CURRENT_RECURSION=$(echo "$SETTINGS_RESP" | jq -r '.response.recursion // empty' 2>/dev/null)
+  CURRENT_ACL=$(echo "$SETTINGS_RESP" | jq -r '.response.recursionNetworkACL // empty' 2>/dev/null)
+  SAFE_ACL="127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,::1/128,fd00::/8"
+  if [ "$CURRENT_RECURSION" = "AllowOnlyForPrivateNetworks" ] && [ -z "$CURRENT_ACL" ]; then
+    echo "[setup] Broken recursion default detected — applying safe LanOnly ACL..."
+    curl -sf -X POST "$TECH_URL/api/settings/set?token=$TECH_PERM_TOKEN&recursion=UseSpecifiedNetworkACL&recursionNetworkACL=$SAFE_ACL" > /dev/null 2>&1 \
+      && echo "[setup] Recursion mode set to UseSpecifiedNetworkACL with safe ACL." \
+      || echo "[setup] WARNING: Failed to apply recursion fix — check Technitium manually."
+  else
+    echo "[setup] Recursion mode is '${CURRENT_RECURSION:-unknown}' — no change needed."
+  fi
+fi
+
 # ── NS_SERVER_IP — public IP for DNS glue records ────────────────────────────
 echo "[setup] Detecting public IP for DNS glue records..."
 PUBLIC_IP=$(curl -sf --max-time 5 https://ifconfig.me 2>/dev/null || \

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -44,6 +44,18 @@
 	let savingForwarders = false;
 	let forwarderSaveSuccess = false;
 	let forwarderSaveError = '';
+
+	// ── DNS Recursion ──────────────────────────────────────────────────────────
+	type RecursionMode = 'Disabled' | 'LanOnly' | 'Public';
+	const recursionLabels: Record<RecursionMode, string> = {
+		Disabled: 'Disabled (authoritative-only)',
+		LanOnly: 'LAN clients only',
+		Public: 'Public (open resolver — caution)',
+	};
+	let dnsRecursion: RecursionMode = 'LanOnly';
+	let savingDnsRecursion = false;
+	let dnsRecursionSuccess = false;
+	let dnsRecursionError = '';
 	let savingDnsProvider = false;
 	let dnsProviderError = '';
 	let savingCloudflareToken = false;
@@ -148,6 +160,7 @@
 					cloudflare_status?: 'connected' | 'disconnected' | 'unconfigured';
 					cloudflare_token_set?: boolean;
 					network_mode?: 'external' | 'internal';
+					dns_recursion?: RecursionMode;
 				};
 				nsHostname = cfg.ns_hostname ?? '';
 				nsServerIp = cfg.ns_server_ip ?? '';
@@ -161,6 +174,7 @@
 				dnsProvider = cfg.dns_provider ?? 'technitium';
 				cloudflareStatus = cfg.cloudflare_status ?? 'unconfigured';
 				networkMode = cfg.network_mode ?? 'external';
+				dnsRecursion = cfg.dns_recursion ?? 'LanOnly';
 			}
 		} catch {
 			// non-fatal; page still renders
@@ -315,6 +329,47 @@
 			forwarderSaveError = (err as Error).message;
 		} finally {
 			savingForwarders = false;
+		}
+	}
+
+	// ── DNS Recursion handler ──────────────────────────────────────────────────
+	async function onDnsRecursionChange(event: Event) {
+		const select = event.currentTarget as HTMLSelectElement;
+		const newMode = select.value as RecursionMode;
+		const prevMode = dnsRecursion;
+		if (newMode === prevMode) return;
+
+		if (newMode === 'Public') {
+			const confirmed = confirm(
+				'Open resolvers can be abused for DNS amplification attacks. Only enable on trusted networks. Continue?'
+			);
+			if (!confirmed) {
+				select.value = prevMode;
+				return;
+			}
+		}
+
+		savingDnsRecursion = true;
+		dnsRecursionError = '';
+		dnsRecursionSuccess = false;
+		try {
+			const res = await fetch('/api/config', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ dns_recursion: newMode }),
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({})) as { error?: string };
+				throw new Error(body.error ?? `HTTP ${res.status}`);
+			}
+			dnsRecursion = newMode;
+			dnsRecursionSuccess = true;
+			setTimeout(() => { dnsRecursionSuccess = false; }, 3000);
+		} catch (err) {
+			dnsRecursionError = (err as Error).message;
+			select.value = prevMode;
+		} finally {
+			savingDnsRecursion = false;
 		}
 	}
 
@@ -799,6 +854,34 @@
 					{/if}
 					{#if forwarderSaveError}
 						<p class="error-msg">{forwarderSaveError}</p>
+					{/if}
+				</div>
+
+				<!-- DNS Recursion -->
+				<div class="field-group" style="margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--border);">
+					<label class="field-label" for="dns-recursion">DNS Recursion</label>
+					<p class="field-hint">LAN clients only is the safe default. Public exposes this server as an open resolver — only enable on trusted networks.</p>
+					<div class="input-row" style="margin-top: 8px;">
+						<select
+							id="dns-recursion"
+							class="text-input select-input"
+							on:change={onDnsRecursionChange}
+							disabled={savingDnsRecursion}
+							value={dnsRecursion}
+						>
+							<option value="Disabled">Disabled (authoritative-only)</option>
+							<option value="LanOnly">LAN clients only</option>
+							<option value="Public">Public (open resolver — caution)</option>
+						</select>
+						{#if savingDnsRecursion}
+							<span class="spinner"></span>
+						{/if}
+					</div>
+					{#if dnsRecursionSuccess}
+						<p class="inline-success">DNS recursion updated to {recursionLabels[dnsRecursion]}.</p>
+					{/if}
+					{#if dnsRecursionError}
+						<p class="error-msg">Failed to update DNS recursion: {dnsRecursionError}</p>
 					{/if}
 				</div>
 			{/if}


### PR DESCRIPTION
## Summary

Adds Settings → Integrations → **DNS Recursion** dropdown to fix the broken-out-of-the-box state where pointing a local resolver at the localhost HermitHost stack returned `;; Got recursion not available from 127.0.0.1`.

Root cause: Technitium ships in `AllowOnlyForPrivateNetworks` mode with an empty `recursionNetworkACL`. Docker bridge NAT presents the source IP as the bridge gateway (e.g. `172.x.x.x`), which fails Technitium's implicit ACL check → recursion denied → `REFUSED`.

## Three modes (HermitHost owns the ACL)

| Mode | Technitium `recursion` | ACL |
|---|---|---|
| **Disabled** | `Deny` | `[]` |
| **LanOnly** ★ default | `UseSpecifiedNetworkACL` | `127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, ::1/128, fd00::/8` |
| **Public** | `Allow` | `[]` (UI requires confirm) |

## Locked decisions

1. Default at install = LanOnly with safe ACL.
2. `coolify-setup.sh` auto-fix applies **only when broken-default state** (mode = `AllowOnlyForPrivateNetworks` AND ACL empty). Preserves user customizations from Technitium's own admin UI.

## Security

- Enum-only at API boundary; no raw ACL strings accepted.
- Audit log per spec §7: structured JSON `{event, from, to, actor, ts}` on every change.
- Public mode requires UI confirmation before commit.
- Unrecognized Technitium values surfaced as `console.warn` for observable drift.

## Test plan

- [x] Backend tsc clean
- [x] Frontend svelte-check clean
- [x] QA review — all 8 spec test cases PASS (qa-specialist)
- [x] Security review — APPROVED with conditions; S1 (audit log) addressed in this commit; S3 (warn + dead ternary) addressed
- [ ] Post-merge: pull on macbeth, verify `dig @<host> google.com` succeeds without manual Technitium UI fiddling

## Spec

`clients/self/projects/hermithost/specs/plan-dns-recursion-mode-2026-04-29.md`