### PR TITLE
feat(dns): diagnose recursion + trust-this-client

### DIFF
--- a/api/src/routes/config.ts
+++ b/api/src/routes/config.ts
@@ -1,7 +1,8 @@
 import { Router, Request, Response } from 'express';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { createCoolifyClient } from '../services/coolify';
-import { createTechnitiumClient, RecursionMode } from '../services/technitium';
+import { createTechnitiumClient, RecursionMode, isValidBareIp } from '../services/technitium';
+import { isIPv6 } from 'net';
 
 const router = Router();
 
@@ -280,6 +281,62 @@ router.put('/', async (req: Request, res: Response) => {
   } catch (err) {
     console.error('[config] PUT failed:', (err as Error).message);
     res.status(500).json({ error: 'Failed to write config' });
+  }
+});
+
+// GET /api/config/dns-recursion-diagnose
+router.get('/dns-recursion-diagnose', async (_req: Request, res: Response) => {
+  const client = createTechnitiumClient();
+  if (!client) {
+    res.status(503).json({ error: 'Technitium not configured' });
+    return;
+  }
+  try {
+    const result = await client.diagnoseRecursion();
+    res.status(200).json(result);
+  } catch (err) {
+    console.error('[config] dns-recursion-diagnose failed:', (err as Error).message);
+    res.status(500).json({ error: 'Failed to diagnose DNS recursion' });
+  }
+});
+
+// POST /api/config/dns-recursion-trust
+router.post('/dns-recursion-trust', async (req: Request, res: Response) => {
+  const body = req.body as { ip?: unknown };
+  // S5: length cap before any further processing (45 = max IPv6 string length)
+  if (typeof body.ip !== 'string' || body.ip.length === 0 || body.ip.length > 45) {
+    res.status(400).json({ error: 'Invalid IP address — must be a bare IPv4 or IPv6 address with no CIDR suffix' });
+    return;
+  }
+  const ip = body.ip.trim();
+
+  if (!ip || !isValidBareIp(ip)) {
+    res.status(400).json({ error: 'Invalid IP address — must be a bare IPv4 or IPv6 address with no CIDR suffix' });
+    return;
+  }
+
+  const client = createTechnitiumClient();
+  if (!client) {
+    res.status(503).json({ error: 'Technitium not configured' });
+    return;
+  }
+
+  try {
+    // S6: snapshot ACL before mutation for audit log
+    const acl_before = await client.getRecursionAcl();
+    const result = await client.trustClient(ip);
+    console.info(JSON.stringify({
+      event: 'dns_acl_extend',
+      ip,
+      acl_before,
+      acl_after: result.acl,
+      actor: 'admin',
+      ts: new Date().toISOString(),
+    }));
+    res.status(200).json(result);
+  } catch (err) {
+    console.error('[config] dns-recursion-trust failed:', (err as Error).message);
+    res.status(500).json({ error: 'Failed to trust client IP' });
   }
 });
 

--- a/api/src/services/technitium.ts
+++ b/api/src/services/technitium.ts
@@ -1,4 +1,7 @@
 import { readFileSync } from 'fs';
+import { randomBytes } from 'crypto';
+import { Resolver } from 'dns/promises';
+import { isIPv4, isIPv6 } from 'net';
 
 // Technitium DNS Server API client — typed, using Node 18+ native fetch only.
 // Auth is passed as a query parameter on every request per Technitium's API design.
@@ -88,6 +91,24 @@ export interface TechnitiumDeleteResponse {
 }
 
 export type RecursionMode = 'Disabled' | 'LanOnly' | 'Public';
+
+// Single source of truth for the safe recursion ACL baseline.
+// Referenced by setRecursion, setRecursionWithExtraAcl, and trustClient.
+const SAFE_RECURSION_ACL_ENTRIES: readonly string[] = [
+  '127.0.0.0/8', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', '::1/128', 'fd00::/8',
+];
+
+export type DiagnoseResult = {
+  recursion_working: boolean;
+  current_mode: RecursionMode;
+  current_acl: string[];
+  untrusted_clients: Array<{
+    ip: string;
+    rdns: string | null;     // reverse-DNS from Technitium `domain` field, or null if no PTR
+    hits: number;
+    in_acl: boolean;
+  }>;
+};
 
 export interface TechnitiumGetRecordsResult {
   zone: TechnitiumZone;
@@ -247,30 +268,42 @@ export class TechnitiumClient {
     });
   }
 
-  async getRecursion(): Promise<RecursionMode> {
+  private async getRecursionSettings(): Promise<{ mode: RecursionMode; acl: string[] }> {
     return this.withTokenRetry(async () => {
       const body = this.buildParams({});
       const res = await fetch(`${this.baseUrl}/api/settings/get`, { method: 'POST', headers: this.postHeaders, body });
       const data = await res.json() as { status: string; errorMessage?: string; response?: { recursion?: string; recursionNetworkACL?: string } };
       if (data.status !== 'ok') throw new Error(`Technitium /api/settings/get error: ${data.errorMessage ?? data.status}`);
       const recursion = data.response?.recursion ?? '';
-      const acl = data.response?.recursionNetworkACL ?? '';
+      const aclRaw = data.response?.recursionNetworkACL ?? '';
+      const acl = aclRaw.split(',').map(s => s.trim()).filter(Boolean);
+      let mode: RecursionMode;
       switch (recursion) {
-        case 'Deny':  return 'Disabled';
-        case 'Allow': return 'Public';
-        case 'UseSpecifiedNetworkACL': return 'LanOnly';
+        case 'Deny':  mode = 'Disabled'; break;
+        case 'Allow': mode = 'Public'; break;
+        case 'UseSpecifiedNetworkACL': mode = 'LanOnly'; break;
         default:
           // AllowOnlyForPrivateNetworks (broken default) or unrecognized value.
           // Surface drift for observability; UI shows safe default until reconciled.
-          console.warn(`[technitium] getRecursion: unrecognized Technitium recursion="${recursion}" acl="${acl}" — reporting as LanOnly`);
-          return 'LanOnly';
+          console.warn(`[technitium] getRecursion: unrecognized Technitium recursion="${recursion}" acl="${aclRaw}" — reporting as LanOnly`);
+          mode = 'LanOnly';
       }
+      return { mode, acl };
     });
+  }
+
+  async getRecursion(): Promise<RecursionMode> {
+    const { mode } = await this.getRecursionSettings();
+    return mode;
+  }
+
+  async getRecursionAcl(): Promise<string[]> {
+    const { acl } = await this.getRecursionSettings();
+    return acl;
   }
 
   async setRecursion(mode: RecursionMode): Promise<void> {
     return this.withTokenRetry(async () => {
-      const SAFE_RECURSION_ACL = '127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,::1/128,fd00::/8';
       const technitiumRecursion: Record<RecursionMode, string> = {
         Disabled: 'Deny',
         LanOnly:  'UseSpecifiedNetworkACL',
@@ -278,7 +311,7 @@ export class TechnitiumClient {
       };
       const technitiumAcl: Record<RecursionMode, string> = {
         Disabled: '',
-        LanOnly:  SAFE_RECURSION_ACL,
+        LanOnly:  SAFE_RECURSION_ACL_ENTRIES.join(','),
         Public:   '',
       };
       const body = this.buildParams({
@@ -289,6 +322,244 @@ export class TechnitiumClient {
       await handleResponse<TechnitiumDeleteResponse>(res, 'POST /api/settings/set (recursion)');
     });
   }
+
+  // Sets recursion to LanOnly and merges extraCidrs into the safe baseline ACL.
+  // Implementer note: chosen over mutating setRecursion() to keep the baseline-only
+  // path simple and unchanged; this variant is additive-only, never destructive.
+  async setRecursionWithExtraAcl(mode: RecursionMode, extraCidrs: string[]): Promise<void> {
+    return this.withTokenRetry(async () => {
+      const technitiumRecursion: Record<RecursionMode, string> = {
+        Disabled: 'Deny',
+        LanOnly:  'UseSpecifiedNetworkACL',
+        Public:   'Allow',
+      };
+      // Merge: safe baseline + caller-supplied extras, deduplicated.
+      const merged = Array.from(new Set([...SAFE_RECURSION_ACL_ENTRIES, ...extraCidrs]));
+      const technitiumAcl: Record<RecursionMode, string> = {
+        Disabled: '',
+        LanOnly:  merged.join(','),
+        Public:   '',
+      };
+      const body = this.buildParams({
+        recursion:           technitiumRecursion[mode],
+        recursionNetworkACL: technitiumAcl[mode],
+      });
+      const res = await fetch(`${this.baseUrl}/api/settings/set`, { method: 'POST', headers: this.postHeaders, body });
+      await handleResponse<TechnitiumDeleteResponse>(res, 'POST /api/settings/set (recursion+acl)');
+    });
+  }
+
+  async diagnoseRecursion(): Promise<DiagnoseResult> {
+    const { mode, acl } = await this.getRecursionSettings();
+
+    // Active probe: resolve a guaranteed-NXDOMAIN synthetic name through Technitium:53.
+    // We only care whether Technitium refuses the query, not the answer.
+    let recursion_working = true;
+    try {
+      const resolver = new Resolver();
+      resolver.setServers(['technitium']);
+      const probeName = `recursion-probe-${randomBytes(4).toString('hex')}.example.invalid`;
+      await resolver.resolve4(probeName);
+      // Any answer (even NXDOMAIN which throws) means NOT refused — caught below.
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code ?? '';
+      if (code === 'EREFUSED' || code === 'ECONNREFUSED') {
+        recursion_working = false;
+      }
+      // ENOTFOUND / ENODATA = NXDOMAIN → resolver answered → recursion is working.
+    }
+
+    // Pull topClients from LastHour stats.
+    // Technitium returns { name: "<ip>", domain: "<rdns or empty>", hits: N }
+    type StatsResponse = {
+      status: string;
+      errorMessage?: string;
+      response?: {
+        stats?: {
+          topClients?: Array<{ name: string; domain?: string; hits: number }>;
+        };
+      };
+    };
+    const statsBody = this.buildParams({ type: 'LastHour' });
+    const statsRes = await fetch(`${this.baseUrl}/api/dashboard/stats/get?type=LastHour`, {
+      method: 'POST',
+      headers: this.postHeaders,
+      body: statsBody,
+    });
+    const statsData = await statsRes.json() as StatsResponse;
+    const topClients: Array<{ name: string; domain?: string; hits: number }> =
+      statsData.response?.stats?.topClients ?? [];
+
+    // Filter to clients NOT covered by any ACL entry.
+    // ip is in `name`; reverse-DNS (if resolved) is in `domain`.
+    const untrusted_clients = topClients
+      .filter(c => {
+        const ip = c.name.trim();
+        return ip && !acl.some(cidr => cidrContainsIp(cidr, ip));
+      })
+      .map(c => ({
+        ip: c.name.trim(),
+        rdns: c.domain?.trim() || null,
+        hits: c.hits,
+        in_acl: false as const,
+      }));
+
+    return { recursion_working, current_mode: mode, current_acl: acl, untrusted_clients };
+  }
+
+  async trustClient(ip: string): Promise<{ acl: string[] }> {
+    // Validate: must be a bare IPv4 or IPv6 address — no CIDR, no garbage.
+    if (!isValidBareIp(ip)) {
+      throw new Error(`Invalid IP address: "${ip}"`);
+    }
+
+    const { mode, acl } = await this.getRecursionSettings();
+
+    // No-op if already covered.
+    if (acl.some(cidr => cidrContainsIp(cidr, ip))) {
+      return { acl };
+    }
+
+    const hostCidr = isIPv6(ip) ? `${ip}/128` : `${ip}/32`;
+    const newAcl = [...acl, hostCidr];
+
+    await this.setRecursionWithExtraAcl(mode === 'LanOnly' ? 'LanOnly' : mode, newAcl.filter(e => {
+      // Only pass the user-added extras; setRecursionWithExtraAcl merges with safe baseline.
+      return !SAFE_RECURSION_ACL_ENTRIES.includes(e);
+    }));
+
+    return { acl: newAcl };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — no dependencies beyond Node built-ins
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if `ip` falls within the network described by `cidr`.
+ * Handles IPv4 (e.g. "10.0.0.0/8") and IPv6 (e.g. "fd00::/8").
+ * Returns false on any parse error rather than throwing.
+ */
+export function cidrContainsIp(cidr: string, ip: string): boolean {
+  try {
+    const slashIdx = cidr.lastIndexOf('/');
+    if (slashIdx === -1) return cidr === ip;
+    const network = cidr.slice(0, slashIdx);
+    const prefix = parseInt(cidr.slice(slashIdx + 1), 10);
+
+    // Normalize IPv4-mapped IPv6 (::ffff:a.b.c.d) for cross-family matching.
+    const v4MappedIpMatch = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+    const v4MappedNetMatch = network.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+
+    // Case: ip is IPv4-mapped IPv6, cidr is plain IPv4
+    if (v4MappedIpMatch && isIPv4(network)) {
+      return ipv4InCidr(network, v4MappedIpMatch[1], prefix);
+    }
+    // Case: cidr network is IPv4-mapped IPv6, ip is plain IPv4
+    if (v4MappedNetMatch && isIPv4(ip)) {
+      return ipv4InCidr(v4MappedNetMatch[1], ip, prefix);
+    }
+
+    if (isIPv4(network) && isIPv4(ip)) {
+      return ipv4InCidr(network, ip, prefix);
+    }
+    if (isIPv6(network) && isIPv6(ip)) {
+      return ipv6InCidr(network, ip, prefix);
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function ipv4ToUint32(ip: string): number {
+  return ip.split('.').reduce((acc, octet) => (acc << 8) | parseInt(octet, 10), 0) >>> 0;
+}
+
+function ipv4InCidr(network: string, ip: string, prefix: number): boolean {
+  if (prefix < 0 || prefix > 32) return false;
+  const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+  return (ipv4ToUint32(network) & mask) === (ipv4ToUint32(ip) & mask);
+}
+
+/**
+ * Expands an IPv6 address to a 16-byte Uint8Array.
+ * Handles compressed notation (::) and IPv4-mapped (::ffff:a.b.c.d).
+ */
+function ipv6ToBytes(ip: string): Uint8Array {
+  // Handle IPv4-mapped: ::ffff:a.b.c.d
+  const v4mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (v4mapped) {
+    const v4 = ipv4ToUint32(v4mapped[1]);
+    const bytes = new Uint8Array(16);
+    bytes[10] = 0xff; bytes[11] = 0xff;
+    bytes[12] = (v4 >>> 24) & 0xff;
+    bytes[13] = (v4 >>> 16) & 0xff;
+    bytes[14] = (v4 >>> 8) & 0xff;
+    bytes[15] = v4 & 0xff;
+    return bytes;
+  }
+  // Expand ::
+  const halves = ip.split('::');
+  const left  = halves[0] ? halves[0].split(':') : [];
+  const right = halves[1] ? halves[1].split(':') : [];
+  const missing = 8 - left.length - right.length;
+  const groups = [...left, ...Array(missing).fill('0'), ...right];
+  const bytes = new Uint8Array(16);
+  groups.forEach((g, i) => {
+    const v = parseInt(g, 16);
+    bytes[i * 2]     = (v >>> 8) & 0xff;
+    bytes[i * 2 + 1] = v & 0xff;
+  });
+  return bytes;
+}
+
+function ipv6InCidr(network: string, ip: string, prefix: number): boolean {
+  if (prefix < 0 || prefix > 128) return false;
+  const netBytes = ipv6ToBytes(network);
+  const ipBytes  = ipv6ToBytes(ip);
+  let bitsLeft = prefix;
+  for (let i = 0; i < 16; i++) {
+    if (bitsLeft >= 8) {
+      if (netBytes[i] !== ipBytes[i]) return false;
+      bitsLeft -= 8;
+    } else if (bitsLeft > 0) {
+      const mask = ~(0xff >>> bitsLeft) & 0xff;
+      if ((netBytes[i] & mask) !== (ipBytes[i] & mask)) return false;
+      bitsLeft = 0;
+    } else {
+      break;
+    }
+  }
+  return true;
+}
+
+/**
+ * Strict validation: bare IPv4 or IPv6 only — no CIDR, no whitespace, no commas.
+ * Uses net.isIP() plus a sanity-check regex to guard against edge cases.
+ */
+export function isValidBareIp(input: string): boolean {
+  if (typeof input !== 'string') return false;
+  // Reject anything containing CIDR slash, commas, or whitespace.
+  if (/[/,\s]/.test(input)) return false;
+  // Only allow characters valid in IPv4/IPv6 addresses.
+  if (!/^[0-9a-fA-F:.]+$/.test(input)) return false;
+  return isIPv4(input) || isIPv6(input);
+}
+
+// Module-level exports wrapping the client instance for convenience.
+// Callers should prefer using TechnitiumClient directly if they already hold a reference.
+export async function diagnoseRecursion(): Promise<DiagnoseResult> {
+  const client = createTechnitiumClient();
+  if (!client) throw new Error('Technitium client not configured');
+  return client.diagnoseRecursion();
+}
+
+export async function trustClient(ip: string): Promise<{ acl: string[] }> {
+  const client = createTechnitiumClient();
+  if (!client) throw new Error('Technitium client not configured');
+  return client.trustClient(ip);
 }
 
 export function createTechnitiumClient(

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -56,6 +56,88 @@
 	let savingDnsRecursion = false;
 	let dnsRecursionSuccess = false;
 	let dnsRecursionError = '';
+
+	// ── DNS Recursion Diagnose ────────────────────────────────────────────────
+	type UntrustedClient = { ip: string; rdns: string | null; hits: number; in_acl: boolean };
+	type DiagnoseResult = {
+		recursion_working: boolean;
+		current_mode: RecursionMode;
+		current_acl: string[];
+		untrusted_clients: UntrustedClient[];
+	};
+	let diagnosing = false;
+	let diagnoseResult: DiagnoseResult | null = null;
+	let diagnoseError = '';
+	let showDiagnoseModal = false;
+	let trustingIp: string | null = null;
+
+	// Toast state
+	let toastMessage = '';
+	let toastVisible = false;
+	let toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function showToast(msg: string) {
+		toastMessage = msg;
+		toastVisible = true;
+		if (toastTimer !== null) clearTimeout(toastTimer);
+		toastTimer = setTimeout(() => { toastVisible = false; }, 4000);
+	}
+
+	async function onDiagnoseClick() {
+		diagnosing = true;
+		diagnoseError = '';
+		diagnoseResult = null;
+		try {
+			const res = await fetch('/api/config/dns-recursion-diagnose', {
+				credentials: 'include',
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({})) as { error?: string };
+				throw new Error(body.error ?? `HTTP ${res.status}`);
+			}
+			diagnoseResult = (await res.json()) as DiagnoseResult;
+			showDiagnoseModal = true;
+		} catch (err) {
+			diagnoseError = (err as Error).message;
+		} finally {
+			diagnosing = false;
+		}
+	}
+
+	async function onTrustClient(ip: string) {
+		trustingIp = ip;
+		try {
+			const res = await fetch('/api/config/dns-recursion-trust', {
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ ip }),
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({})) as { error?: string };
+				throw new Error(body.error ?? `HTTP ${res.status}`);
+			}
+			showToast(`Added ${ip} to ACL`);
+			if (diagnoseResult) {
+				diagnoseResult = {
+					...diagnoseResult,
+					untrusted_clients: diagnoseResult.untrusted_clients.filter((c) => c.ip !== ip),
+				};
+			}
+		} catch (err) {
+			showToast(`Error: ${(err as Error).message}`);
+		} finally {
+			trustingIp = null;
+		}
+	}
+
+	function closeDiagnoseModal() {
+		showDiagnoseModal = false;
+	}
+
+	function onDiagnoseModalKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') closeDiagnoseModal();
+	}
 	let savingDnsProvider = false;
 	let dnsProviderError = '';
 	let savingCloudflareToken = false;
@@ -876,7 +958,25 @@
 						{#if savingDnsRecursion}
 							<span class="spinner"></span>
 						{/if}
+						{#if dnsRecursion === 'LanOnly'}
+							<button
+								class="btn btn-ghost"
+								aria-label="Diagnose DNS recursion issues"
+								disabled={diagnosing}
+								on:click={onDiagnoseClick}
+							>
+								{#if diagnosing}
+									<span class="spinner"></span>
+									Diagnosing…
+								{:else}
+									Diagnose
+								{/if}
+							</button>
+						{/if}
 					</div>
+					{#if diagnoseError}
+						<p class="error-msg">Diagnose failed: {diagnoseError}</p>
+					{/if}
 					{#if dnsRecursionSuccess}
 						<p class="inline-success">DNS recursion updated to {recursionLabels[dnsRecursion]}.</p>
 					{/if}
@@ -1138,6 +1238,84 @@
 		</div>
 	</section>
 </div>
+
+<!-- ── DNS Recursion Diagnose Modal ──────────────────────────────────────── -->
+{#if showDiagnoseModal && diagnoseResult}
+	<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+	<div
+		class="diag-backdrop"
+		role="dialog"
+		aria-modal="true"
+		aria-label="DNS Recursion Diagnosis"
+		on:keydown={onDiagnoseModalKeydown}
+		tabindex="-1"
+	>
+		<div class="diag-modal">
+			<div class="diag-header">
+				<span class="diag-title">
+					{#if !diagnoseResult.recursion_working && diagnoseResult.untrusted_clients.length > 0}
+						Recursion broken — these clients are being REFUSED
+					{:else if diagnoseResult.untrusted_clients.length > 0}
+						Some clients refused — review below
+					{:else}
+						&#10003; Recursion working
+					{/if}
+				</span>
+				<button class="diag-close btn btn-ghost" aria-label="Close" on:click={closeDiagnoseModal}>✕</button>
+			</div>
+			<div class="diag-body">
+				{#if diagnoseResult.untrusted_clients.length === 0}
+					<p class="diag-ok-msg">&#10003; Recursion working. No refused clients in last hour.</p>
+				{:else}
+					<table class="diag-table">
+						<thead>
+							<tr>
+								<th>IP</th>
+								<th>Hits (last hour)</th>
+								<th></th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each diagnoseResult.untrusted_clients as client (client.ip)}
+								<tr>
+									<td class="diag-ip">
+									{client.ip}
+									{#if client.rdns}
+										<div class="diag-rdns">{client.rdns}</div>
+									{:else}
+										<div class="diag-rdns diag-rdns--none"><em>(no PTR)</em></div>
+									{/if}
+								</td>
+									<td class="diag-hits">{client.hits}</td>
+									<td>
+										<button
+											class="btn btn-primary diag-trust-btn"
+											disabled={trustingIp === client.ip}
+											on:click={() => onTrustClient(client.ip)}
+										>
+											{#if trustingIp === client.ip}
+												<span class="spinner"></span>
+											{/if}
+											Trust this client
+										</button>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				{/if}
+			</div>
+			<div class="diag-footer">
+				<button class="btn btn-ghost" on:click={closeDiagnoseModal}>Dismiss</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- ── Toast ─────────────────────────────────────────────────────────────── -->
+{#if toastVisible}
+	<div class="diag-toast" role="status" aria-live="polite">{toastMessage}</div>
+{/if}
 
 <style>
 	.page {
@@ -1720,5 +1898,126 @@
 	.chip-text {
 		color: var(--text-muted);
 		line-height: 1.5;
+	}
+
+	/* ── DNS Diagnose Modal ── */
+	.diag-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.55);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+	}
+
+	.diag-modal {
+		background: var(--bg-surface);
+		border: 1px solid var(--border);
+		border-radius: 8px;
+		width: min(560px, 92vw);
+		display: flex;
+		flex-direction: column;
+		max-height: 80vh;
+		overflow: hidden;
+	}
+
+	.diag-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 14px 16px;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.diag-title {
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.diag-close {
+		padding: 4px 8px;
+		font-size: 13px;
+	}
+
+	.diag-body {
+		padding: 16px;
+		overflow-y: auto;
+		flex: 1;
+	}
+
+	.diag-ok-msg {
+		font-size: 13px;
+		color: var(--success, #4caf82);
+		margin: 0;
+	}
+
+	.diag-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 12px;
+	}
+
+	.diag-table th {
+		text-align: left;
+		color: var(--text-muted);
+		font-weight: 500;
+		padding: 6px 8px;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.diag-table td {
+		padding: 8px;
+		border-bottom: 1px solid var(--border);
+		vertical-align: middle;
+	}
+
+	.diag-ip {
+		font-family: var(--font-mono);
+		color: var(--text-primary);
+	}
+
+	.diag-rdns {
+		font-family: var(--font-mono);
+		font-size: 0.78em;
+		color: var(--text-secondary);
+		margin-top: 2px;
+	}
+
+	.diag-rdns--none {
+		color: var(--text-tertiary, var(--text-secondary));
+	}
+
+	.diag-hits {
+		color: var(--text-secondary);
+	}
+
+	.diag-trust-btn {
+		padding: 5px 10px;
+		font-size: 11px;
+	}
+
+	.diag-footer {
+		padding: 12px 16px;
+		border-top: 1px solid var(--border);
+		display: flex;
+		justify-content: flex-end;
+	}
+
+	/* ── Toast ── */
+	.diag-toast {
+		position: fixed;
+		bottom: 24px;
+		right: 24px;
+		background: var(--bg-elevated);
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		padding: 10px 16px;
+		font-size: 12px;
+		color: var(--text-primary);
+		z-index: 1100;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+		pointer-events: none;
 	}
 </style>


### PR DESCRIPTION
## Summary

Adds Settings → DNS Recursion → **Diagnose** button (LanOnly mode only). Click runs an active recursion probe + lists every refused client IP with its reverse-DNS and hit count. Per-row **Trust this client** appends the IP to the ACL as `/32` (or `/128`).

Solves the Mac Docker Desktop case where host-originated `dig @127.0.0.1` arrives at Technitium with src = the host's WAN IP (Docker Desktop NAT quirk) — not loopback, not bridge gateway. The safe LanOnly ACL refuses those, with no observable signal in the dashboard. This PR makes that signal observable + actionable.

Same surface unblocks any out-of-LAN client on production deployments.

## Backend

- `diagnoseRecursion()` — active probe via `dns/promises` Resolver against `technitium:53`, EREFUSED detection, topClients filter via `cidrContainsIp`
- `trustClient(ip)` — strict bare-IP validation (no CIDR, no zone-id, length-capped), idempotent, audit-logged with `acl_before`/`acl_after`
- `cidrContainsIp()` — pure fn, IPv4/IPv6, handles `::ffff:` cross-family normalization both directions
- Single `SAFE_RECURSION_ACL_ENTRIES` const — no duplication across set paths
- Two new auth-gated endpoints under `/api/config/dns-recursion-{diagnose,trust}`

## Frontend

- Diagnose button next to dropdown, gated to LanOnly
- Modal: IP + rDNS (or "(no PTR)") + hits + per-row Trust button. **rDNS render is the human-in-the-loop signal** against topClients-poisoning (security review S1, BLOCKING — addressed)
- Toast on success/error, idempotent re-Diagnose

## Sign-Offs

| Council | Agent | Verdict |
|---|---|---|
| Technical | backend-developer | tsc clean, round 2 hardening applied |
| Technical | frontend-developer | svelte-check 0 new warnings |
| Delivery | qa-specialist | 10/10 spec test cases PASS (code review) |
| Delivery | security-reviewer | APPROVED w/ conditions: S1 (BLOCKING), S2, S3, S5, S6 — all fixed in this commit |

## Test plan

- [x] Backend tsc clean
- [x] Frontend svelte-check 0 new warnings
- [x] QA: 10 cases per spec §4
- [x] Security: 6 findings addressed (S7 race condition documented as INFO/acceptable for single-user)
- [ ] Post-merge: hit Diagnose on dev stack → expect `172.124.143.76` to appear → click Trust → verify `dig @127.0.0.1 google.com` recurses

## Spec

`clients/self/projects/hermithost/specs/plan-dns-recursion-diagnose-2026-04-29.md`