### PR TITLE
fix(dns): handle ACL array shape + correct topClients stats path

### DIFF
--- a/api/src/services/technitium.ts
+++ b/api/src/services/technitium.ts
@@ -373,14 +373,13 @@ export class TechnitiumClient {
     }
 
     // Pull topClients from LastHour stats.
-    // Technitium returns { name: "<ip>", domain: "<rdns or empty>", hits: N }
+    // Technitium returns topClients at response.topClients (sibling of stats, not nested under it).
+    // Each entry: { name: "<ip>", domain: "<rdns or empty>", hits: N }
     type StatsResponse = {
       status: string;
       errorMessage?: string;
       response?: {
-        stats?: {
-          topClients?: Array<{ name: string; domain?: string; hits: number }>;
-        };
+        topClients?: Array<{ name: string; domain?: string; hits: number }>;
       };
     };
     const statsBody = this.buildParams({ type: 'LastHour' });
@@ -391,7 +390,7 @@ export class TechnitiumClient {
     });
     const statsData = await statsRes.json() as StatsResponse;
     const topClients: Array<{ name: string; domain?: string; hits: number }> =
-      statsData.response?.stats?.topClients ?? [];
+      statsData.response?.topClients ?? [];
 
     // Filter to clients NOT covered by any ACL entry.
     // ip is in `name`; reverse-DNS (if resolved) is in `domain`.

--- a/api/src/services/technitium.ts
+++ b/api/src/services/technitium.ts
@@ -272,11 +272,14 @@ export class TechnitiumClient {
     return this.withTokenRetry(async () => {
       const body = this.buildParams({});
       const res = await fetch(`${this.baseUrl}/api/settings/get`, { method: 'POST', headers: this.postHeaders, body });
-      const data = await res.json() as { status: string; errorMessage?: string; response?: { recursion?: string; recursionNetworkACL?: string } };
+      const data = await res.json() as { status: string; errorMessage?: string; response?: { recursion?: string; recursionNetworkACL?: string | string[] } };
       if (data.status !== 'ok') throw new Error(`Technitium /api/settings/get error: ${data.errorMessage ?? data.status}`);
       const recursion = data.response?.recursion ?? '';
       const aclRaw = data.response?.recursionNetworkACL ?? '';
-      const acl = aclRaw.split(',').map(s => s.trim()).filter(Boolean);
+      // Technitium returns recursionNetworkACL as an array; older builds returned a comma-string. Handle both.
+      const acl = (Array.isArray(aclRaw) ? aclRaw : String(aclRaw).split(','))
+        .map(s => String(s).trim())
+        .filter(Boolean);
       let mode: RecursionMode;
       switch (recursion) {
         case 'Deny':  mode = 'Disabled'; break;


### PR DESCRIPTION
## Summary
Two hotfixes for PR #80 Diagnose feature:

1. **`recursionNetworkACL` array shape** — Technitium returns ACL as JSON array, code called `.split(',')` → `aclRaw.split is not a function` → "Diagnose failed".
2. **`topClients` stats path** — code read `response.stats.topClients` but Technitium puts it at `response.topClients` (sibling of `stats`). Empty list → UI falsely reported "No refused clients" while live response had Mac WAN IP `172.124.143.76` with 194 hits.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Live: `wget` against `/api/dashboard/stats/get` confirmed `topClients` at correct path
- [ ] Localhost: Diagnose lists Mac WAN IP after `dig @127.0.0.1 google.com`
- [ ] Localhost: Trust appends `/32`, re-Diagnose empty, dig recurses