### PR TITLE
fix(start): auto-activate internal CA profile when PORT_MODE=lan

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,5 +2,32 @@
 # Ensure the external coolify network exists, then start the stack.
 # The coolify network is external so docker compose down doesn't destroy it
 # and take deployed site containers offline.
+#
+# Profile selection:
+#   HERMITHOST_PORT_MODE=lan      → passes --profile internal (activates step-ca + step-ca-init)
+#   HERMITHOST_PORT_MODE=internet → no profile (uses Let's Encrypt)
+#   unset                         → no profile (safe default)
+#
+# Idempotent: docker compose up is a no-op for already-running services.
+
 docker network inspect coolify >/dev/null 2>&1 || docker network create coolify
-exec docker compose up "$@"
+
+# Load .env from project root so PORT_MODE is available even when start.sh is
+# invoked directly (outside of a shell that already sourced .env).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+if [ -f "$ROOT/.env" ]; then
+  # shellcheck disable=SC1091
+  set -a
+  . "$ROOT/.env"
+  set +a
+fi
+
+PROFILE_ARG=""
+if [ "${HERMITHOST_PORT_MODE:-}" = "lan" ]; then
+  PROFILE_ARG="--profile internal"
+  echo "[start] LAN mode detected — activating internal CA profile (step-ca)"
+fi
+
+# shellcheck disable=SC2086
+exec docker compose $PROFILE_ARG up "$@"


### PR DESCRIPTION
## Summary
- `scripts/start.sh` now sources `.env` and passes `--profile internal` to `docker compose up` when `HERMITHOST_PORT_MODE=lan`, so step-ca + step-ca-init actually launch in LAN mode.
- Fixes silent drift where `network_mode=internal` was reported by API but step-ca was absent — ACME issuance for `.hh` would have silently failed.
- Idempotent: rerunning the script in the same mode is a no-op.

## Why
Per ADR-006 + PR #85, `HERMITHOST_PORT_MODE` is the single source of truth and `lan` mode is meant to auto-activate the internal CA. The env coupling was in place; the stack-launch coupling was missing.

## Test plan
- [x] LAN mode cold start: step-ca + step-ca-init come up; init exits 0; step-ca healthy
- [x] Internet mode: step-ca / step-ca-init NOT created
- [x] Idempotent rerun: zero errors, zero duplicates
- [x] `GET /api/config` reports `network_mode: internal` (lan) and `external` (internet)
- [x] Traefik resolver `internal-ca` reaches `https://step-ca:9000/acme/acme/directory` (200 + valid ACME metadata)
- [x] No regression — api, frontend, traefik, technitium, coolify, ssh-bridge, all DBs healthy in both modes
- [ ] Post-merge smoke: `curl -kI https://cantaconmigo.hh` (Phase E)

QA: 6/6 acceptance criteria PASS (qa-specialist, 2026-05-01).