### PR TITLE
feat(dns): Phase 1 — Technitium TSIG bootstrap for RFC2136 DNS-01

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -29,10 +29,10 @@ COOLIFY_API_TOKEN=
 COOLIFY_PORT=8000
 
 # ── Technitium DNS (auto-provisioned at startup) ──────────────────
-# Permanent token written to /coolify-api-token/technitium_token by startup.
-# Leave empty — the API reads from the shared volume at runtime.
+# TECHNITIUM_TOKEN is auto-provisioned by coolify-setup.sh at first boot.
+# It is written to /coolify-api-token/technitium_token (Docker volume) and read
+# from there by the API and TSIG init script. Do NOT set this manually.
 TECHNITIUM_URL=http://technitium:5380
-TECHNITIUM_TOKEN=
 # Host port for DNS queries (TCP + UDP — both bound by docker-compose).
 # Set by setup.sh: LAN mode → 53; Internet mode → 5353 (avoids system DNS conflict).
 # Default 5353 is safe on macOS/Linux where mDNSResponder/systemd-resolved owns 53.
@@ -66,6 +66,7 @@ COOKIE_SECRET=
 # RFC2136_TSIG_ALGORITHM — HMAC algorithm. Default: hmac-sha256
 # RFC2136_TSIG_SECRET_FILE — path inside the Docker volume where the secret is persisted.
 #                            Mode 0600. Do not commit the value of this file.
+#                            Auto-managed: leave empty (default path is used internally).
 # RFC2136_TSIG_SECRET    — exported at start.sh runtime from RFC2136_TSIG_SECRET_FILE.
 #                          Never written to .env. Phase 2 reads it from the env at compose-up.
 # RFC2136_ZONE           — Internal TLD zone accepting DNS-01 updates. Default: hh
@@ -73,6 +74,7 @@ COOKIE_SECRET=
 # Manifest at /coolify-api-token/rfc2136_tsig.json captures keyName, algorithm, zone, subnet.
 RFC2136_TSIG_KEYNAME=
 RFC2136_TSIG_ALGORITHM=
+# RFC2136_TSIG_SECRET_FILE — leave empty; path is controlled internally (SEC-N3).
 RFC2136_TSIG_SECRET_FILE=
 RFC2136_ZONE=
 

--- a/.env.template
+++ b/.env.template
@@ -57,6 +57,25 @@ HERMITHOST_PASSWORD=
 # Changing HERMITHOST_PASSWORD rotates the secret and invalidates all sessions.
 COOKIE_SECRET=
 
+# ── RFC2136 TSIG (auto-managed by scripts/setup.sh + conf.d/technitium-tsig-init.sh) ──
+# These vars are managed automatically in LAN mode. Do NOT set them by hand.
+#
+# RFC2136_TSIG_KEYNAME   — TSIG key name used in Technitium and in Lego (Phase 2).
+#                          Default: hermithost-acme  (Technitium stores without trailing dot;
+#                          Phase 2 passes as "hermithost-acme." with dot to Traefik/Lego)
+# RFC2136_TSIG_ALGORITHM — HMAC algorithm. Default: hmac-sha256
+# RFC2136_TSIG_SECRET_FILE — path inside the Docker volume where the secret is persisted.
+#                            Mode 0600. Do not commit the value of this file.
+# RFC2136_TSIG_SECRET    — exported at start.sh runtime from RFC2136_TSIG_SECRET_FILE.
+#                          Never written to .env. Phase 2 reads it from the env at compose-up.
+# RFC2136_ZONE           — Internal TLD zone accepting DNS-01 updates. Default: hh
+#
+# Manifest at /coolify-api-token/rfc2136_tsig.json captures keyName, algorithm, zone, subnet.
+RFC2136_TSIG_KEYNAME=
+RFC2136_TSIG_ALGORITHM=
+RFC2136_TSIG_SECRET_FILE=
+RFC2136_ZONE=
+
 # ── CORS ─────────────────────────────────────────────────────────
 # Allowed origin(s) for the API. Required when cookie-based auth is used —
 # browsers reject Access-Control-Allow-Origin: * with credentials: true.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,7 @@ services:
       - ./scripts/coolify-setup.sh:/setup.sh:ro
     environment:
       COOLIFY_API_TOKEN: "${COOLIFY_API_TOKEN}"
+      TECHNITIUM_URL: "${TECHNITIUM_URL:-http://technitium:5380}"
       PGHOST: "coolify-db"
       PGPORT: "5432"
       PGDATABASE: "coolify"

--- a/scripts/conf.d/technitium-tsig-init.sh
+++ b/scripts/conf.d/technitium-tsig-init.sh
@@ -21,6 +21,13 @@
 
 set -euo pipefail
 
+# ── Temp-file cleanup trap (SEC-N2) ──────────────────────────────────────────
+# Declared early so it covers every exit path including SIGINT/SIGTERM.
+# Variables are set to empty here and replaced once the real paths are known.
+TSIG_BODY_FILE=""
+ZONE_BODY_FILE=""
+trap 'rm -f "$TSIG_BODY_FILE" "$ZONE_BODY_FILE" 2>/dev/null || true' EXIT INT TERM
+
 # ── Inputs ────────────────────────────────────────────────────────────────────
 TECHNITIUM_URL="${TECHNITIUM_URL:-http://localhost:5380}"
 TECHNITIUM_TOKEN="${TECHNITIUM_TOKEN:-}"
@@ -32,9 +39,16 @@ TSIG_MANIFEST_FILE="$(dirname "$TSIG_SECRET_FILE")/rfc2136_tsig.json"
 ZONE="${RFC2136_ZONE:-hh}"
 
 # ── Guards ────────────────────────────────────────────────────────────────────
+# If TECHNITIUM_TOKEN was not passed explicitly, read it from the shared volume
+# (written there by coolify-setup.sh at startup). This removes the requirement
+# for operators to supply the token via .env. QA blocker fix.
 if [ -z "$TECHNITIUM_TOKEN" ]; then
-  echo "[tsig-init] TECHNITIUM_TOKEN is empty — skipping TSIG bootstrap (LAN mode only)."
-  exit 0
+  TECHNITIUM_TOKEN="$(cat /coolify-api-token/technitium_token 2>/dev/null | tr -d '[:space:]' || true)"
+fi
+if [ -z "$TECHNITIUM_TOKEN" ]; then
+  echo "[tsig-init] TECHNITIUM_TOKEN not found in env or volume (/coolify-api-token/technitium_token)."
+  echo "[tsig-init] Bring the stack up first (bash scripts/start.sh -d) then re-run setup.sh."
+  exit 1
 fi
 
 # Only run in LAN mode

--- a/scripts/conf.d/technitium-tsig-init.sh
+++ b/scripts/conf.d/technitium-tsig-init.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# One-shot: generate or reuse a TSIG key for RFC2136 dynamic updates and register it
+# in Technitium. Called by setup.sh after the Technitium post-bootstrap section.
+#
+# Produces:
+#   /coolify-api-token/rfc2136_tsig.secret   (0600) — raw base64 HMAC-SHA256 secret
+#   /coolify-api-token/rfc2136_tsig.json             — manifest consumed by Phase 2
+#
+# Idempotent: if the secret file already exists the key is reused (not regenerated).
+# If Technitium already has the key registered with the same name it is re-set to the
+# same value (settings/set is idempotent for identical inputs).
+#
+# Spike findings (2026-05-01):
+#   Q1: Technitium v15.0.1 accepts RFC2136 + HMAC-SHA256 TSIG natively.
+#   Q2: settings/set uses tsigKeys=keyName|secret|algo (pipe-delimited, from web UI JS).
+#       zones/options/set uses updateSecurityPolicies=keyName|domain|allowedTypes.
+#       Correct update mode value for subnet ACL is "UseSpecifiedNetworkACL".
+#   Q5: hermithost_hermithost-net CIDR = 172.18.0.0/16 (runtime-read, not hardcoded).
+#
+# ADR reference: adr-007-dns-01-internal-ca-2026-05-01.md
+
+set -euo pipefail
+
+# ── Inputs ────────────────────────────────────────────────────────────────────
+TECHNITIUM_URL="${TECHNITIUM_URL:-http://localhost:5380}"
+TECHNITIUM_TOKEN="${TECHNITIUM_TOKEN:-}"
+TSIG_KEY_NAME="${RFC2136_TSIG_KEYNAME:-hermithost-acme}"
+TSIG_ALGORITHM="${RFC2136_TSIG_ALGORITHM:-hmac-sha256}"
+TSIG_SECRET_FILE="${RFC2136_TSIG_SECRET_FILE:-/coolify-api-token/rfc2136_tsig.secret}"
+# Manifest lives alongside the secret file (same directory, Docker volume)
+TSIG_MANIFEST_FILE="$(dirname "$TSIG_SECRET_FILE")/rfc2136_tsig.json"
+ZONE="${RFC2136_ZONE:-hh}"
+
+# ── Guards ────────────────────────────────────────────────────────────────────
+if [ -z "$TECHNITIUM_TOKEN" ]; then
+  echo "[tsig-init] TECHNITIUM_TOKEN is empty — skipping TSIG bootstrap (LAN mode only)."
+  exit 0
+fi
+
+# Only run in LAN mode
+if [ "${HERMITHOST_PORT_MODE:-}" != "lan" ]; then
+  echo "[tsig-init] Not in LAN mode (HERMITHOST_PORT_MODE=${HERMITHOST_PORT_MODE:-unset}) — skipping TSIG bootstrap."
+  exit 0
+fi
+
+echo "[tsig-init] Starting Technitium TSIG bootstrap..."
+echo "[tsig-init]   Key name  : ${TSIG_KEY_NAME}"
+echo "[tsig-init]   Algorithm : ${TSIG_ALGORITHM}"
+echo "[tsig-init]   Zone      : ${ZONE}"
+echo "[tsig-init]   Secret file: ${TSIG_SECRET_FILE}"
+
+# ── Step 1: Generate or reuse the TSIG secret ─────────────────────────────────
+if [ -f "$TSIG_SECRET_FILE" ]; then
+  echo "[tsig-init] Secret file already exists — reusing."
+  TSIG_SECRET="$(cat "$TSIG_SECRET_FILE")"
+else
+  echo "[tsig-init] Generating new 32-byte HMAC-SHA256 secret..."
+  TSIG_SECRET="$(openssl rand -base64 32 | tr -d '\n')"
+  # Ensure parent directory exists (shared volume must be mounted by now)
+  mkdir -p "$(dirname "$TSIG_SECRET_FILE")"
+  printf '%s' "$TSIG_SECRET" > "$TSIG_SECRET_FILE"
+  chmod 0600 "$TSIG_SECRET_FILE"
+  echo "[tsig-init] Secret written to ${TSIG_SECRET_FILE}."
+fi
+
+# ── Step 2: Determine the hermithost-net subnet at runtime ───────────────────
+# The network name in docker compose is hermithost_hermithost-net.
+# We use docker network inspect to get the actual CIDR rather than hardcoding.
+HERMITHOST_NET_SUBNET=""
+for NET_NAME in hermithost_hermithost-net hermithost-net; do
+  if docker network inspect "$NET_NAME" --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}' >/dev/null 2>&1; then
+    HERMITHOST_NET_SUBNET="$(docker network inspect "$NET_NAME" --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || true)"
+    if [ -n "$HERMITHOST_NET_SUBNET" ]; then
+      echo "[tsig-init] Detected hermithost-net subnet: ${HERMITHOST_NET_SUBNET}"
+      break
+    fi
+  fi
+done
+
+if [ -z "$HERMITHOST_NET_SUBNET" ]; then
+  # Fallback: use the broad Docker bridge range but warn loudly
+  HERMITHOST_NET_SUBNET="172.16.0.0/12"
+  echo "[tsig-init] WARNING: Could not detect hermithost-net subnet. Falling back to ${HERMITHOST_NET_SUBNET}."
+  echo "[tsig-init] To narrow the ACL, ensure the 'docker' command is available and the stack is running."
+fi
+
+# Loopback is included so Traefik (running inside the container stack) can update via 127.0.0.1
+# when the compose network routes through the host stack.
+UPDATE_ACL="${HERMITHOST_NET_SUBNET},127.0.0.0/8"
+
+# ── Step 3: Register the TSIG key in Technitium ───────────────────────────────
+# Format: tsigKeys=keyName|sharedSecret|algorithmName (pipe-delimited, from Technitium web UI).
+# Key name is stored WITHOUT trailing dot; Technitium normalizes it internally.
+echo "[tsig-init] Registering TSIG key '${TSIG_KEY_NAME}' in Technitium..."
+TSIG_REGISTER_RESULT="$(
+  curl -sf -X POST "${TECHNITIUM_URL}/api/settings/set" \
+    --data-urlencode "token=${TECHNITIUM_TOKEN}" \
+    --data-urlencode "tsigKeys=${TSIG_KEY_NAME}|${TSIG_SECRET}|${TSIG_ALGORITHM}" \
+    2>/dev/null
+)"
+TSIG_STATUS="$(echo "$TSIG_REGISTER_RESULT" | grep -o '"status":"[^"]*"' | cut -d'"' -f4 || echo "unknown")"
+if [ "$TSIG_STATUS" != "ok" ]; then
+  echo "[tsig-init] ERROR: Failed to register TSIG key. Response: ${TSIG_REGISTER_RESULT}"
+  exit 1
+fi
+echo "[tsig-init] TSIG key registered successfully."
+
+# ── Step 4: Configure zone update permissions ─────────────────────────────────
+# - update mode: UseSpecifiedNetworkACL (v15 name for subnet-restricted updates)
+# - updateNetworkACL: hermithost-net subnet + loopback
+# - updateSecurityPolicies: require TSIG signature matching the registered key,
+#   allow TXT record type only (DNS-01 only needs TXT), domain=*.${ZONE}.
+#   The wildcard domain *.${ZONE}. covers _acme-challenge.<host>.<zone> records.
+echo "[tsig-init] Configuring zone '${ZONE}' update permissions..."
+ZONE_SET_RESULT="$(
+  curl -sf -X POST "${TECHNITIUM_URL}/api/zones/options/set" \
+    --data-urlencode "token=${TECHNITIUM_TOKEN}" \
+    --data-urlencode "zone=${ZONE}" \
+    --data-urlencode "update=UseSpecifiedNetworkACL" \
+    --data-urlencode "updateNetworkACL=${UPDATE_ACL}" \
+    --data-urlencode "updateSecurityPolicies=${TSIG_KEY_NAME}|*.${ZONE}.|TXT" \
+    2>/dev/null
+)"
+ZONE_STATUS="$(echo "$ZONE_SET_RESULT" | grep -o '"status":"[^"]*"' | cut -d'"' -f4 || echo "unknown")"
+if [ "$ZONE_STATUS" != "ok" ]; then
+  echo "[tsig-init] ERROR: Failed to configure zone permissions. Response: ${ZONE_SET_RESULT}"
+  exit 1
+fi
+echo "[tsig-init] Zone '${ZONE}' configured: UseSpecifiedNetworkACL, ACL=${UPDATE_ACL}, TSIG policy=TXT."
+
+# ── Step 5: Write the manifest ────────────────────────────────────────────────
+cat > "$TSIG_MANIFEST_FILE" << MANIFEST_EOF
+{
+  "keyName": "${TSIG_KEY_NAME}",
+  "algorithm": "${TSIG_ALGORITHM}",
+  "zone": "${ZONE}",
+  "subnet": "${HERMITHOST_NET_SUBNET}",
+  "updateMode": "UseSpecifiedNetworkACL"
+}
+MANIFEST_EOF
+echo "[tsig-init] Manifest written to ${TSIG_MANIFEST_FILE}."
+
+echo "[tsig-init] TSIG bootstrap complete."
+echo "[tsig-init]   Key name  : ${TSIG_KEY_NAME}"
+echo "[tsig-init]   Algorithm : ${TSIG_ALGORITHM}"
+echo "[tsig-init]   Zone      : ${ZONE}."
+echo "[tsig-init]   Update ACL: ${UPDATE_ACL}"
+echo "[tsig-init]   Policy    : TXT records on *.${ZONE}."

--- a/scripts/conf.d/technitium-tsig-init.sh
+++ b/scripts/conf.d/technitium-tsig-init.sh
@@ -78,26 +78,33 @@ for NET_NAME in hermithost_hermithost-net hermithost-net; do
 done
 
 if [ -z "$HERMITHOST_NET_SUBNET" ]; then
-  # Fallback: use the broad Docker bridge range but warn loudly
-  HERMITHOST_NET_SUBNET="172.16.0.0/12"
-  echo "[tsig-init] WARNING: Could not detect hermithost-net subnet. Falling back to ${HERMITHOST_NET_SUBNET}."
-  echo "[tsig-init] To narrow the ACL, ensure the 'docker' command is available and the stack is running."
+  echo "[tsig-init] ERROR: hermithost-net subnet detection failed. Bring stack up first, then re-run setup." >&2
+  exit 1
 fi
 
-# Loopback is included so Traefik (running inside the container stack) can update via 127.0.0.1
-# when the compose network routes through the host stack.
-UPDATE_ACL="${HERMITHOST_NET_SUBNET},127.0.0.0/8"
+# Trust model: TSIG secret is the primary security boundary; the network ACL is a coarse
+# second factor (defense-in-depth, not the sole gate). Ref: ADR-007 Risk R1 + Security review S-finding.
+UPDATE_ACL="${HERMITHOST_NET_SUBNET}"
 
 # ── Step 3: Register the TSIG key in Technitium ───────────────────────────────
 # Format: tsigKeys=keyName|sharedSecret|algorithmName (pipe-delimited, from Technitium web UI).
 # Key name is stored WITHOUT trailing dot; Technitium normalizes it internally.
+#
+# SEC: secret is written to a mode-0600 temp file and passed via curl stdin to
+# avoid leaking it on the process argv (visible to `ps`).
 echo "[tsig-init] Registering TSIG key '${TSIG_KEY_NAME}' in Technitium..."
+TSIG_BODY_FILE="$(dirname "$TSIG_SECRET_FILE")/.tsig_req_body.tmp"
+# Build the body without exposing to argv; printf avoids newline injection.
+printf 'token=%s&tsigKeys=%s|%s|%s' \
+  "${TECHNITIUM_TOKEN}" "${TSIG_KEY_NAME}" "${TSIG_SECRET}" "${TSIG_ALGORITHM}" \
+  > "$TSIG_BODY_FILE"
+chmod 0600 "$TSIG_BODY_FILE"
 TSIG_REGISTER_RESULT="$(
   curl -sf -X POST "${TECHNITIUM_URL}/api/settings/set" \
-    --data-urlencode "token=${TECHNITIUM_TOKEN}" \
-    --data-urlencode "tsigKeys=${TSIG_KEY_NAME}|${TSIG_SECRET}|${TSIG_ALGORITHM}" \
+    --data @"$TSIG_BODY_FILE" \
     2>/dev/null
-)"
+)" || true
+rm -f "$TSIG_BODY_FILE"
 TSIG_STATUS="$(echo "$TSIG_REGISTER_RESULT" | grep -o '"status":"[^"]*"' | cut -d'"' -f4 || echo "unknown")"
 if [ "$TSIG_STATUS" != "ok" ]; then
   echo "[tsig-init] ERROR: Failed to register TSIG key. Response: ${TSIG_REGISTER_RESULT}"
@@ -107,20 +114,22 @@ echo "[tsig-init] TSIG key registered successfully."
 
 # ── Step 4: Configure zone update permissions ─────────────────────────────────
 # - update mode: UseSpecifiedNetworkACL (v15 name for subnet-restricted updates)
-# - updateNetworkACL: hermithost-net subnet + loopback
+# - updateNetworkACL: hermithost-net subnet (no loopback — SA-1)
 # - updateSecurityPolicies: require TSIG signature matching the registered key,
 #   allow TXT record type only (DNS-01 only needs TXT), domain=*.${ZONE}.
 #   The wildcard domain *.${ZONE}. covers _acme-challenge.<host>.<zone> records.
 echo "[tsig-init] Configuring zone '${ZONE}' update permissions..."
+ZONE_BODY_FILE="$(dirname "$TSIG_SECRET_FILE")/.zone_req_body.tmp"
+printf 'token=%s&zone=%s&update=UseSpecifiedNetworkACL&updateNetworkACL=%s&updateSecurityPolicies=%s|*.%s.|TXT' \
+  "${TECHNITIUM_TOKEN}" "${ZONE}" "${UPDATE_ACL}" "${TSIG_KEY_NAME}" "${ZONE}" \
+  > "$ZONE_BODY_FILE"
+chmod 0600 "$ZONE_BODY_FILE"
 ZONE_SET_RESULT="$(
   curl -sf -X POST "${TECHNITIUM_URL}/api/zones/options/set" \
-    --data-urlencode "token=${TECHNITIUM_TOKEN}" \
-    --data-urlencode "zone=${ZONE}" \
-    --data-urlencode "update=UseSpecifiedNetworkACL" \
-    --data-urlencode "updateNetworkACL=${UPDATE_ACL}" \
-    --data-urlencode "updateSecurityPolicies=${TSIG_KEY_NAME}|*.${ZONE}.|TXT" \
+    --data @"$ZONE_BODY_FILE" \
     2>/dev/null
-)"
+)" || true
+rm -f "$ZONE_BODY_FILE"
 ZONE_STATUS="$(echo "$ZONE_SET_RESULT" | grep -o '"status":"[^"]*"' | cut -d'"' -f4 || echo "unknown")"
 if [ "$ZONE_STATUS" != "ok" ]; then
   echo "[tsig-init] ERROR: Failed to configure zone permissions. Response: ${ZONE_SET_RESULT}"
@@ -129,13 +138,15 @@ fi
 echo "[tsig-init] Zone '${ZONE}' configured: UseSpecifiedNetworkACL, ACL=${UPDATE_ACL}, TSIG policy=TXT."
 
 # ── Step 5: Write the manifest ────────────────────────────────────────────────
+CREATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 cat > "$TSIG_MANIFEST_FILE" << MANIFEST_EOF
 {
   "keyName": "${TSIG_KEY_NAME}",
   "algorithm": "${TSIG_ALGORITHM}",
   "zone": "${ZONE}",
   "subnet": "${HERMITHOST_NET_SUBNET}",
-  "updateMode": "UseSpecifiedNetworkACL"
+  "updateMode": "UseSpecifiedNetworkACL",
+  "createdAt": "${CREATED_AT}"
 }
 MANIFEST_EOF
 echo "[tsig-init] Manifest written to ${TSIG_MANIFEST_FILE}."

--- a/scripts/conf.d/technitium-tsig-init.sh
+++ b/scripts/conf.d/technitium-tsig-init.sh
@@ -126,6 +126,39 @@ if [ "$TSIG_STATUS" != "ok" ]; then
 fi
 echo "[tsig-init] TSIG key registered successfully."
 
+# ── Step 3.5: Ensure root zone exists ────────────────────────────────────────
+# On a clean-volume bring-up, zone 'hh' does not exist until the first site is
+# provisioned via the API.  zones/options/set fails with "No such zone was found"
+# if we call it before the zone exists.  Proactively create it here so this
+# script is self-sufficient regardless of bring-up order.
+#
+# Detection: POST /api/zones/list, grep for the zone name in the JSON response.
+# Creation:  POST /api/zones/create with zone=hh&type=Primary.
+# Both calls are idempotent — create silently succeeds if the zone already exists.
+echo "[tsig-init] Ensuring zone '${ZONE}' exists in Technitium..."
+ZONE_LIST_RESULT="$(
+  curl -sf -X POST "${TECHNITIUM_URL}/api/zones/list" \
+    -d "token=${TECHNITIUM_TOKEN}" \
+    2>/dev/null
+)" || true
+ZONE_EXISTS="$(echo "$ZONE_LIST_RESULT" | grep -o "\"name\":\"${ZONE}\"" || true)"
+if [ -n "$ZONE_EXISTS" ]; then
+  echo "[tsig-init] Zone '${ZONE}' already exists — skipping creation."
+else
+  echo "[tsig-init] Zone '${ZONE}' not found — creating Primary zone..."
+  ZONE_CREATE_RESULT="$(
+    curl -sf -X POST "${TECHNITIUM_URL}/api/zones/create" \
+      -d "token=${TECHNITIUM_TOKEN}&zone=${ZONE}&type=Primary" \
+      2>/dev/null
+  )" || true
+  ZONE_CREATE_STATUS="$(echo "$ZONE_CREATE_RESULT" | grep -o '"status":"[^"]*"' | cut -d'"' -f4 || echo "unknown")"
+  if [ "$ZONE_CREATE_STATUS" != "ok" ]; then
+    echo "[tsig-init] ERROR: Failed to create zone '${ZONE}'. Response: ${ZONE_CREATE_RESULT}"
+    exit 1
+  fi
+  echo "[tsig-init] Zone '${ZONE}' created successfully."
+fi
+
 # ── Step 4: Configure zone update permissions ─────────────────────────────────
 # - update mode: UseSpecifiedNetworkACL (v15 name for subnet-restricted updates)
 # - updateNetworkACL: hermithost-net subnet (no loopback — SA-1)

--- a/scripts/coolify-setup.sh
+++ b/scripts/coolify-setup.sh
@@ -75,21 +75,32 @@ TECH_URL="${TECHNITIUM_URL:-http://technitium:5380}"
 # Step 1: get a session token to bootstrap
 TECH_RESP=$(curl -sf -X POST "$TECH_URL/api/user/login" \
   -d "user=admin&pass=admin&includeInfo=false" 2>/dev/null || echo "")
-TECH_SESSION=$(echo "$TECH_RESP" | jq -r '.token // empty' 2>/dev/null)
+# Technitium v13+ wraps all responses: {"status":"ok","response":{"token":"..."}}
+TECH_SESSION=$(echo "$TECH_RESP" | jq -r '.response.token // .token // empty' 2>/dev/null)
 
 if [ -n "$TECH_SESSION" ]; then
   # Step 2: delete old permanent token (ignore errors if it doesn't exist)
   curl -sf -X POST "$TECH_URL/api/user/deleteToken?token=$TECH_SESSION&tokenName=hermithost-api" > /dev/null 2>&1 || true
   # Step 3: create new permanent token
   PERM_RESP=$(curl -sf -X POST "$TECH_URL/api/user/createToken?token=$TECH_SESSION&tokenName=hermithost-api" 2>/dev/null || echo "")
-  PERM_TOKEN=$(echo "$PERM_RESP" | jq -r '.token // empty' 2>/dev/null)
+  # Technitium v13+ wraps all responses: {"status":"ok","response":{"token":"..."}}
+  PERM_TOKEN=$(echo "$PERM_RESP" | jq -r '.response.token // .token // empty' 2>/dev/null)
   if [ -n "$PERM_TOKEN" ]; then
     printf '%s' "$PERM_TOKEN" > /coolify-api-token/technitium_token
-    echo "[setup] Technitium permanent token written."
+    # Verify the write landed in the volume before declaring success
+    if [ ! -s /coolify-api-token/technitium_token ]; then
+      echo "[setup] ERROR: technitium_token write succeeded but file is missing or empty — volume not mounted?" >&2
+      exit 1
+    fi
+    echo "[setup] Technitium permanent token written ($(wc -c < /coolify-api-token/technitium_token) bytes)."
   else
     # Fallback: write session token — withTokenRetry in API handles expiry
     printf '%s' "$TECH_SESSION" > /coolify-api-token/technitium_token
-    echo "[setup] WARNING: Could not create permanent Technitium token — wrote session token as fallback."
+    if [ ! -s /coolify-api-token/technitium_token ]; then
+      echo "[setup] ERROR: technitium_token fallback write failed — volume not mounted?" >&2
+      exit 1
+    fi
+    echo "[setup] WARNING: Could not create permanent Technitium token — wrote session token as fallback ($(wc -c < /coolify-api-token/technitium_token) bytes)."
   fi
 else
   echo "[setup] WARNING: Could not obtain Technitium token — DNS integration will be limited."
@@ -99,7 +110,7 @@ fi
 if [ -n "$TECH_SESSION" ]; then
   echo "[setup] Checking Technitium recursion mode..."
   TECH_PERM_TOKEN=$(cat /coolify-api-token/technitium_token 2>/dev/null || echo "$TECH_SESSION")
-  SETTINGS_RESP=$(curl -sf -X POST "$TECH_URL/api/settings/get?token=$TECH_PERM_TOKEN" 2>/dev/null || echo "")
+  SETTINGS_RESP=$(curl -sf "$TECH_URL/api/settings/get?token=$TECH_PERM_TOKEN" 2>/dev/null || echo "")
   CURRENT_RECURSION=$(echo "$SETTINGS_RESP" | jq -r '.response.recursion // empty' 2>/dev/null)
   CURRENT_ACL=$(echo "$SETTINGS_RESP" | jq -r '.response.recursionNetworkACL // empty' 2>/dev/null)
   SAFE_ACL="127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,::1/128,fd00::/8"

--- a/scripts/rotate-tsig.sh
+++ b/scripts/rotate-tsig.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Rotate the RFC2136 TSIG secret.
+#
+# Generates a fresh HMAC-SHA256 secret, re-registers it in Technitium, writes
+# the new secret to the coolify-api-token Docker volume, and reminds the
+# operator to restart Traefik (Phase 2 dependency).
+#
+# Usage:
+#   TECHNITIUM_URL=http://localhost:5380 \
+#   TECHNITIUM_TOKEN=<token> \
+#   bash scripts/rotate-tsig.sh
+#
+# Or source .env selectively first:
+#   export TECHNITIUM_URL TECHNITIUM_TOKEN
+#   bash scripts/rotate-tsig.sh
+#
+# The script runs inside docker (coolify-api-token volume mounted) so the
+# secret is never written to the host filesystem. SEC-S1.
+#
+# ADR reference: adr-007-dns-01-internal-ca-2026-05-01.md §Rotation
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+ENV_FILE="$ROOT/.env"
+
+# ── Resolve required vars ─────────────────────────────────────────────────────
+TECHNITIUM_URL="${TECHNITIUM_URL:-}"
+TECHNITIUM_TOKEN="${TECHNITIUM_TOKEN:-}"
+
+if [ -z "$TECHNITIUM_URL" ] || [ -z "$TECHNITIUM_TOKEN" ]; then
+  if [ -f "$ENV_FILE" ]; then
+    _URL="$(grep -E '^TECHNITIUM_URL=' "$ENV_FILE" | cut -d'=' -f2- || true)"
+    _TOKEN="$(grep -E '^TECHNITIUM_TOKEN=' "$ENV_FILE" | cut -d'=' -f2- || true)"
+    TECHNITIUM_URL="${TECHNITIUM_URL:-$_URL}"
+    TECHNITIUM_TOKEN="${TECHNITIUM_TOKEN:-$_TOKEN}"
+  fi
+fi
+
+if [ -z "$TECHNITIUM_URL" ]; then
+  echo "[rotate-tsig] ERROR: TECHNITIUM_URL is not set." >&2
+  exit 1
+fi
+if [ -z "$TECHNITIUM_TOKEN" ]; then
+  echo "[rotate-tsig] ERROR: TECHNITIUM_TOKEN is not set." >&2
+  exit 1
+fi
+
+TSIG_KEY_NAME="${RFC2136_TSIG_KEYNAME:-hermithost-acme}"
+TSIG_ALGORITHM="${RFC2136_TSIG_ALGORITHM:-hmac-sha256}"
+TSIG_SECRET_FILE="${RFC2136_TSIG_SECRET_FILE:-/coolify-api-token/rfc2136_tsig.secret}"
+TSIG_MANIFEST_FILE="$(dirname "$TSIG_SECRET_FILE")/rfc2136_tsig.json"
+ZONE="${RFC2136_ZONE:-hh}"
+
+echo "[rotate-tsig] Rotating TSIG key '${TSIG_KEY_NAME}'..."
+
+# ── Generate new secret ───────────────────────────────────────────────────────
+NEW_SECRET="$(openssl rand -base64 32 | tr -d '\n')"
+
+# ── Detect hermithost-net subnet ──────────────────────────────────────────────
+HERMITHOST_NET_SUBNET=""
+for NET_NAME in hermithost_hermithost-net hermithost-net; do
+  HERMITHOST_NET_SUBNET="$(docker network inspect "$NET_NAME" --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || true)"
+  if [ -n "$HERMITHOST_NET_SUBNET" ]; then
+    break
+  fi
+done
+
+if [ -z "$HERMITHOST_NET_SUBNET" ]; then
+  echo "[rotate-tsig] ERROR: hermithost-net subnet detection failed. Bring stack up first." >&2
+  exit 1
+fi
+
+UPDATE_ACL="${HERMITHOST_NET_SUBNET}"
+
+# ── Register new secret in Technitium ────────────────────────────────────────
+# Write to temp file (mode 0600) to avoid argv leakage. SEC-S2.
+TSIG_BODY_FILE="$(dirname "$TSIG_SECRET_FILE")/.tsig_rotate_req.tmp"
+printf 'token=%s&tsigKeys=%s|%s|%s' \
+  "${TECHNITIUM_TOKEN}" "${TSIG_KEY_NAME}" "${NEW_SECRET}" "${TSIG_ALGORITHM}" \
+  > "$TSIG_BODY_FILE"
+chmod 0600 "$TSIG_BODY_FILE"
+REGISTER_RESULT="$(
+  curl -sf -X POST "${TECHNITIUM_URL}/api/settings/set" \
+    --data @"$TSIG_BODY_FILE" \
+    2>/dev/null
+)" || true
+rm -f "$TSIG_BODY_FILE"
+
+STATUS="$(echo "$REGISTER_RESULT" | grep -o '"status":"[^"]*"' | cut -d'"' -f4 || echo "unknown")"
+if [ "$STATUS" != "ok" ]; then
+  echo "[rotate-tsig] ERROR: Failed to register rotated TSIG key. Response: ${REGISTER_RESULT}" >&2
+  exit 1
+fi
+
+# ── Re-apply zone permissions with new ACL ────────────────────────────────────
+ZONE_BODY_FILE="$(dirname "$TSIG_SECRET_FILE")/.zone_rotate_req.tmp"
+printf 'token=%s&zone=%s&update=UseSpecifiedNetworkACL&updateNetworkACL=%s&updateSecurityPolicies=%s|*.%s.|TXT' \
+  "${TECHNITIUM_TOKEN}" "${ZONE}" "${UPDATE_ACL}" "${TSIG_KEY_NAME}" "${ZONE}" \
+  > "$ZONE_BODY_FILE"
+chmod 0600 "$ZONE_BODY_FILE"
+ZONE_RESULT="$(
+  curl -sf -X POST "${TECHNITIUM_URL}/api/zones/options/set" \
+    --data @"$ZONE_BODY_FILE" \
+    2>/dev/null
+)" || true
+rm -f "$ZONE_BODY_FILE"
+
+ZONE_STATUS="$(echo "$ZONE_RESULT" | grep -o '"status":"[^"]*"' | cut -d'"' -f4 || echo "unknown")"
+if [ "$ZONE_STATUS" != "ok" ]; then
+  echo "[rotate-tsig] ERROR: Failed to re-apply zone permissions. Response: ${ZONE_RESULT}" >&2
+  exit 1
+fi
+
+# ── Persist new secret to volume ──────────────────────────────────────────────
+printf '%s' "$NEW_SECRET" > "$TSIG_SECRET_FILE"
+chmod 0600 "$TSIG_SECRET_FILE"
+
+# ── Update manifest ───────────────────────────────────────────────────────────
+CREATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+cat > "$TSIG_MANIFEST_FILE" << MANIFEST_EOF
+{
+  "keyName": "${TSIG_KEY_NAME}",
+  "algorithm": "${TSIG_ALGORITHM}",
+  "zone": "${ZONE}",
+  "subnet": "${HERMITHOST_NET_SUBNET}",
+  "updateMode": "UseSpecifiedNetworkACL",
+  "createdAt": "${CREATED_AT}"
+}
+MANIFEST_EOF
+
+echo "[rotate-tsig] TSIG key rotated successfully."
+echo ""
+echo "[rotate-tsig] *** ACTION REQUIRED ***"
+echo "[rotate-tsig] Restart Traefik to pick up the new secret (Phase 2 dependency):"
+echo "[rotate-tsig]   docker compose restart traefik"
+echo "[rotate-tsig] Ad-hoc deletion of the secret file is discouraged — always use this"
+echo "[rotate-tsig] script to rotate so Technitium and the volume stay in sync."

--- a/scripts/rotate-tsig.sh
+++ b/scripts/rotate-tsig.sh
@@ -21,6 +21,11 @@
 
 set -euo pipefail
 
+# ── Temp-file cleanup trap (SEC-N2) ──────────────────────────────────────────
+TSIG_BODY_FILE=""
+ZONE_BODY_FILE=""
+trap 'rm -f "$TSIG_BODY_FILE" "$ZONE_BODY_FILE" 2>/dev/null || true' EXIT INT TERM
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$SCRIPT_DIR/.."
 ENV_FILE="$ROOT/.env"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -292,6 +292,7 @@ if [ "$PORT_MODE_CURRENT" = "lan" ]; then
   # from the coolify-api-token volume (/coolify-api-token/technitium_token),
   # which coolify-setup.sh writes at startup. Operators never supply this token.
   docker run --rm \
+    --network hermithost_hermithost-net \
     -v coolify-api-token:/coolify-api-token \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "${SCRIPT_DIR}/conf.d:/scripts/conf.d:ro" \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -267,6 +267,29 @@ else
   echo "[setup] COOLIFY_ADMIN_PASSWORD already set — skipping."
 fi
 
+# ── Technitium TSIG bootstrap (LAN mode only) ────────────────────────────────
+# Generates or reuses the RFC2136 TSIG key and registers it in Technitium.
+# Only runs when HERMITHOST_PORT_MODE=lan and Technitium is reachable.
+# Idempotent: re-running setup.sh reuses the existing key without re-registering.
+echo ""
+echo "[setup] Checking RFC2136 TSIG bootstrap (LAN mode only)..."
+PORT_MODE_CURRENT="$(grep -E '^HERMITHOST_PORT_MODE=' "$ENV_FILE" | cut -d'=' -f2- || true)"
+if [ "$PORT_MODE_CURRENT" = "lan" ]; then
+  # Source the .env so TECHNITIUM_URL and TECHNITIUM_TOKEN are available.
+  # At setup time the stack may not be running yet, so we skip gracefully if
+  # TECHNITIUM_TOKEN is empty (the init script self-guards on empty token).
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+  bash "$SCRIPT_DIR/conf.d/technitium-tsig-init.sh" || {
+    echo "[setup] WARNING: TSIG bootstrap failed or was skipped."
+    echo "[setup] Re-run 'bash scripts/setup.sh' after starting the stack to complete TSIG setup."
+  }
+else
+  echo "[setup] Not in LAN mode — skipping TSIG bootstrap."
+fi
+
 echo ""
 echo "[setup] Configuration complete. Ready to start:"
 echo "        bash scripts/start.sh -d"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -275,14 +275,29 @@ echo ""
 echo "[setup] Checking RFC2136 TSIG bootstrap (LAN mode only)..."
 PORT_MODE_CURRENT="$(grep -E '^HERMITHOST_PORT_MODE=' "$ENV_FILE" | cut -d'=' -f2- || true)"
 if [ "$PORT_MODE_CURRENT" = "lan" ]; then
-  # Source the .env so TECHNITIUM_URL and TECHNITIUM_TOKEN are available.
-  # At setup time the stack may not be running yet, so we skip gracefully if
-  # TECHNITIUM_TOKEN is empty (the init script self-guards on empty token).
-  set -a
-  # shellcheck disable=SC1090
-  . "$ENV_FILE"
-  set +a
-  bash "$SCRIPT_DIR/conf.d/technitium-tsig-init.sh" || {
+  # Extract only the two variables the TSIG init script needs from .env.
+  # Using explicit variable assignment avoids exporting the entire .env
+  # (COOKIE_SECRET, passwords, etc.) into the child environment. SEC-S4.
+  #
+  # The init script writes the TSIG secret to /coolify-api-token/ which is a
+  # Docker named volume (coolify-api-token). To ensure the secret is NEVER
+  # written to the host filesystem, invoke the script inside a container with
+  # that volume mounted (SEC-S1). The host Docker socket is bind-mounted so the
+  # container can run `docker network inspect` for subnet detection.
+  _TECH_URL="$(grep -E '^TECHNITIUM_URL=' "$ENV_FILE" | cut -d'=' -f2- || true)"
+  _TECH_TOKEN="$(grep -E '^TECHNITIUM_TOKEN=' "$ENV_FILE" | cut -d'=' -f2- || true)"
+  # Resolve env vars that the init script consumes
+  _RFC2136_ZONE="$(grep -E '^RFC2136_ZONE=' "$ENV_FILE" | cut -d'=' -f2- || true)"
+  _PORT_MODE="$(grep -E '^HERMITHOST_PORT_MODE=' "$ENV_FILE" | cut -d'=' -f2- || true)"
+  docker run --rm \
+    -v coolify-api-token:/coolify-api-token \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "${SCRIPT_DIR}/conf.d:/scripts/conf.d:ro" \
+    -e TECHNITIUM_URL="${_TECH_URL}" \
+    -e TECHNITIUM_TOKEN="${_TECH_TOKEN}" \
+    -e HERMITHOST_PORT_MODE="${_PORT_MODE}" \
+    -e RFC2136_ZONE="${_RFC2136_ZONE}" \
+    docker:cli sh -c "apk add --no-cache bash openssl curl >/dev/null 2>&1 && bash /scripts/conf.d/technitium-tsig-init.sh" || {
     echo "[setup] WARNING: TSIG bootstrap failed or was skipped."
     echo "[setup] Re-run 'bash scripts/setup.sh' after starting the stack to complete TSIG setup."
   }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -285,16 +285,17 @@ if [ "$PORT_MODE_CURRENT" = "lan" ]; then
   # that volume mounted (SEC-S1). The host Docker socket is bind-mounted so the
   # container can run `docker network inspect` for subnet detection.
   _TECH_URL="$(grep -E '^TECHNITIUM_URL=' "$ENV_FILE" | cut -d'=' -f2- || true)"
-  _TECH_TOKEN="$(grep -E '^TECHNITIUM_TOKEN=' "$ENV_FILE" | cut -d'=' -f2- || true)"
   # Resolve env vars that the init script consumes
   _RFC2136_ZONE="$(grep -E '^RFC2136_ZONE=' "$ENV_FILE" | cut -d'=' -f2- || true)"
   _PORT_MODE="$(grep -E '^HERMITHOST_PORT_MODE=' "$ENV_FILE" | cut -d'=' -f2- || true)"
+  # TECHNITIUM_TOKEN is NOT read from .env — the init script reads it directly
+  # from the coolify-api-token volume (/coolify-api-token/technitium_token),
+  # which coolify-setup.sh writes at startup. Operators never supply this token.
   docker run --rm \
     -v coolify-api-token:/coolify-api-token \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "${SCRIPT_DIR}/conf.d:/scripts/conf.d:ro" \
     -e TECHNITIUM_URL="${_TECH_URL}" \
-    -e TECHNITIUM_TOKEN="${_TECH_TOKEN}" \
     -e HERMITHOST_PORT_MODE="${_PORT_MODE}" \
     -e RFC2136_ZONE="${_RFC2136_ZONE}" \
     docker:cli sh -c "apk add --no-cache bash openssl curl >/dev/null 2>&1 && bash /scripts/conf.d/technitium-tsig-init.sh" || {

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,15 +12,14 @@
 
 docker network inspect coolify >/dev/null 2>&1 || docker network create coolify
 
-# Load .env from project root so PORT_MODE is available even when start.sh is
-# invoked directly (outside of a shell that already sourced .env).
+# Load only the specific vars needed from .env — do NOT export the entire file.
+# Broad export (set -a / source) would leak COOKIE_SECRET, HERMITHOST_PASSWORD,
+# COOLIFY_DB_PASSWORD, etc. into docker compose up env. SEC-S4.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$SCRIPT_DIR/.."
 if [ -f "$ROOT/.env" ]; then
-  # shellcheck disable=SC1091
-  set -a
-  . "$ROOT/.env"
-  set +a
+  HERMITHOST_PORT_MODE="$(grep -E '^HERMITHOST_PORT_MODE=' "$ROOT/.env" | cut -d'=' -f2- | tr -d '[:space:]' || true)"
+  RFC2136_TSIG_SECRET_FILE="$(grep -E '^RFC2136_TSIG_SECRET_FILE=' "$ROOT/.env" | cut -d'=' -f2- | tr -d '[:space:]' || true)"
 fi
 
 PROFILE_ARG=""

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -27,6 +27,21 @@ PROFILE_ARG=""
 if [ "${HERMITHOST_PORT_MODE:-}" = "lan" ]; then
   PROFILE_ARG="--profile internal"
   echo "[start] LAN mode detected — activating internal CA profile (step-ca)"
+
+  # ── RFC2136 TSIG secret (Phase 1: read and export; Phase 2: Traefik consumes) ──
+  # The secret is generated once by setup.sh / conf.d/technitium-tsig-init.sh and
+  # persisted in the coolify-api-token volume. We read it here so that Phase 2 can
+  # reference RFC2136_TSIG_SECRET in docker-compose.yml without storing it in .env.
+  TSIG_SECRET_FILE="${RFC2136_TSIG_SECRET_FILE:-/coolify-api-token/rfc2136_tsig.secret}"
+  if [ -f "$TSIG_SECRET_FILE" ]; then
+    RFC2136_TSIG_SECRET="$(cat "$TSIG_SECRET_FILE")"
+    export RFC2136_TSIG_SECRET
+    echo "[start] RFC2136_TSIG_SECRET loaded from ${TSIG_SECRET_FILE}."
+  else
+    echo "[start] WARNING: RFC2136 TSIG secret file not found at ${TSIG_SECRET_FILE}."
+    echo "[start]   Run 'bash scripts/setup.sh' with the stack running to bootstrap the TSIG key."
+    echo "[start]   DNS-01 certificate issuance will not work until the key is provisioned."
+  fi
 fi
 
 # shellcheck disable=SC2086

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -29,18 +29,30 @@ if [ "${HERMITHOST_PORT_MODE:-}" = "lan" ]; then
   echo "[start] LAN mode detected — activating internal CA profile (step-ca)"
 
   # ── RFC2136 TSIG secret (Phase 1: read and export; Phase 2: Traefik consumes) ──
-  # The secret is generated once by setup.sh / conf.d/technitium-tsig-init.sh and
-  # persisted in the coolify-api-token volume. We read it here so that Phase 2 can
-  # reference RFC2136_TSIG_SECRET in docker-compose.yml without storing it in .env.
-  TSIG_SECRET_FILE="${RFC2136_TSIG_SECRET_FILE:-/coolify-api-token/rfc2136_tsig.secret}"
-  if [ -f "$TSIG_SECRET_FILE" ]; then
-    RFC2136_TSIG_SECRET="$(cat "$TSIG_SECRET_FILE")"
-    export RFC2136_TSIG_SECRET
-    echo "[start] RFC2136_TSIG_SECRET loaded from ${TSIG_SECRET_FILE}."
+  # The secret lives exclusively inside the coolify-api-token Docker volume.
+  # It is never written to or read from the host filesystem (SEC-S1).
+  # We use `docker run --rm` with the volume mounted to read it at start time.
+  TSIG_VOLUME_PATH="${RFC2136_TSIG_SECRET_FILE:-/coolify-api-token/rfc2136_tsig.secret}"
+  TSIG_VOLUME_NAME="coolify-api-token"
+  TSIG_FILE_IN_VOLUME="$(basename "$TSIG_VOLUME_PATH")"
+  TSIG_VOLUME_DIR="$(dirname "$TSIG_VOLUME_PATH")"
+  if docker volume inspect "$TSIG_VOLUME_NAME" >/dev/null 2>&1; then
+    RFC2136_TSIG_SECRET="$(
+      docker run --rm \
+        -v "${TSIG_VOLUME_NAME}:${TSIG_VOLUME_DIR}:ro" \
+        alpine sh -c "cat '${TSIG_VOLUME_PATH}' 2>/dev/null" 2>/dev/null || true
+    )"
+    if [ -n "$RFC2136_TSIG_SECRET" ]; then
+      export RFC2136_TSIG_SECRET
+      echo "[start] RFC2136_TSIG_SECRET loaded from volume ${TSIG_VOLUME_NAME}."
+    else
+      echo "[start] WARNING: RFC2136 TSIG secret not found in volume ${TSIG_VOLUME_NAME} at ${TSIG_VOLUME_PATH}."
+      echo "[start]   Run 'bash scripts/setup.sh' with the stack running to bootstrap the TSIG key."
+      echo "[start]   DNS-01 certificate issuance will not work until the key is provisioned."
+    fi
   else
-    echo "[start] WARNING: RFC2136 TSIG secret file not found at ${TSIG_SECRET_FILE}."
-    echo "[start]   Run 'bash scripts/setup.sh' with the stack running to bootstrap the TSIG key."
-    echo "[start]   DNS-01 certificate issuance will not work until the key is provisioned."
+    echo "[start] WARNING: Docker volume '${TSIG_VOLUME_NAME}' not found. TSIG secret unavailable."
+    echo "[start]   Run 'bash scripts/setup.sh' to initialise the stack and provision the TSIG key."
   fi
 fi
 


### PR DESCRIPTION
## Spike Findings (resolved before code)

**Q1 — Does Technitium accept RFC2136 with HMAC-SHA256?**
CONFIRMED YES. Technitium v15.0.1 (running on this stack) accepts RFC2136 dynamic updates natively. `nsupdate` tested successfully. Wrong-key updates return `NOTAUTH(BADKEY)`. Out-of-subnet updates return `REFUSED`. No DNS App or plugin required.

**Q2 — Exact Technitium HTTP API for TSIG key creation + zone-update permission**

The Technitium v15 API changed parameter names from prior docs. Discovered by reading the web UI JavaScript source (`/opt/technitium/dns/www/js/main.js`, `zone.js`):

| Operation | Endpoint | Key param format |
|---|---|---|
| Register TSIG key | `POST /api/settings/set` | `tsigKeys=keyName\|secret\|algorithm` (pipe-delimited) |
| Set zone update ACL + policy | `POST /api/zones/options/set` | `update=UseSpecifiedNetworkACL`, `updateNetworkACL=<CIDR>`, `updateSecurityPolicies=keyName\|domain\|allowedTypes` |
| List registered keys | `GET /api/settings/getTsigKeyNames` | — |
| Read zone options | `GET /api/zones/options/get` | — |

**Note:** The update mode in v15 is `UseSpecifiedNetworkACL` (renamed from `AllowOnlySpecifiedNetworks` in prior versions). Using the old name silently stores as a different internal mode.

**Q5 — Actual subnet of hermithost-net**
`hermithost_hermithost-net` CIDR = `172.18.0.0/16`. The init script reads this at runtime via `docker network inspect` — not hardcoded.

---

## Files Changed

- `scripts/conf.d/technitium-tsig-init.sh` — new one-shot bootstrap script (idempotent)
- `scripts/setup.sh` — extended to call tsig-init in LAN mode
- `scripts/start.sh` — reads `/coolify-api-token/rfc2136_tsig.secret` and exports `RFC2136_TSIG_SECRET` at compose-up (Phase 2 consumer)
- `.env.template` — documents `RFC2136_TSIG_KEYNAME`, `RFC2136_TSIG_ALGORITHM`, `RFC2136_TSIG_SECRET_FILE`, `RFC2136_ZONE` as auto-managed

## Verification (localhost stack, never hammer)

```
=== 1: TSIG-signed nsupdate from hermithost-net (172.18.x.x) ===
exit: 0
"phase1-verify"    <- TXT record added

=== 2: nsupdate from outside subnet (172.17.x.x bridge) ===
update failed: REFUSED
exit: 2            <- ACL enforced

=== 3: Wrong TSIG key ===
update failed: NOTAUTH(BADKEY)
exit: 2            <- key validation working

=== 4: SOA regression check ===
b2f8aeb7d101. hostadmin.hh. 20 900 300 604800 900   <- no regression

=== 5: Idempotency ===
Secret before: RYXNjloczaEzGPTbZ1Gn2ig2Ruo23Tiet4rU3kCr0Yk=
[tsig-init] Secret file already exists — reusing.
Secret after:  RYXNjloczaEzGPTbZ1Gn2ig2Ruo23Tiet4rU3kCr0Yk=  <- same key
```

## Gates Required Before Merge

Per `dns-01-implementation-plan-2026-05-01.md`:

- [ ] Security Reviewer — TSIG storage + rotation model (BLOCKING)
- [ ] Solution Architect — design + ACL scoping review
- [ ] QA Specialist — verification PASS on localhost stack

**Do NOT merge until all three gates are signed off.**