### PR TITLE
fix(api): narrow tls cert CN type and annotate issuerCertificate in dns01 integration test

### DIFF
--- a/api/src/integration/dns01-issuance.integration.test.ts
+++ b/api/src/integration/dns01-issuance.integration.test.ts
@@ -45,11 +45,13 @@ function tlsHandshake(host: string, port: number, servername: string) {
         let cur: tls.DetailedPeerCertificate | undefined = peer as tls.DetailedPeerCertificate;
         let depth = 0;
         while (cur && depth < 5) {
+          const sCN = cur.subject?.CN;
+          const iCN = cur.issuer?.CN;
           chain.push({
-            subjectCN: cur.subject?.CN ?? '',
-            issuerCN: cur.issuer?.CN ?? '',
+            subjectCN: Array.isArray(sCN) ? (sCN[0] ?? '') : (sCN ?? ''),
+            issuerCN: Array.isArray(iCN) ? (iCN[0] ?? '') : (iCN ?? ''),
           });
-          const next = (cur as tls.DetailedPeerCertificate).issuerCertificate;
+          const next: tls.DetailedPeerCertificate = (cur as tls.DetailedPeerCertificate).issuerCertificate;
           if (!next || next === cur) break;
           cur = next;
           depth++;


### PR DESCRIPTION
## Summary

- Fixes TypeScript build regression introduced in PR #88
- Narrows `subject.CN` and `issuer.CN` (`string | string[]`) to `string` using `Array.isArray` guard before assigning to `subjectCN`/`issuerCN` fields
- Explicitly annotates `next` as `tls.DetailedPeerCertificate` to resolve implicit `any` from the recursive type

No runtime behavior changes — type fixes only.

## Test plan

- [x] `cd api && npm run build` exits 0 (tsc clean)
- [x] `npm run test` — 44 passed, 3 skipped (Vitest, unchanged)
- [x] `docker compose build api` — image built successfully