### PR TITLE
feat: PII-blocking pre-commit hook for OSS readiness

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,76 @@
+#!/bin/sh
+# PII and private-data guard — blocks commits containing known sensitive patterns.
+# Patterns are intentionally specific to avoid false positives on generic terms.
+
+set -e
+
+STAGED=$(git diff --cached --name-only)
+if [ -z "$STAGED" ]; then
+  exit 0
+fi
+
+# Build a list of staged files excluding lockfiles and minified assets for
+# content checks. The base64 pattern in particular produces false positives on
+# package hashes, long CSS strings, etc. File-path checks (below) still apply
+# to the full STAGED list.
+CONTENT_STAGED=$(echo "$STAGED" | grep -vE '(package-lock\.json|yarn\.lock|\.lock$|dist/|\.min\.(js|css)$|^\.githooks/)' || true)
+
+FAIL=0
+
+check() {
+  LABEL="$1"
+  PATTERN="$2"
+  if [ -z "$CONTENT_STAGED" ]; then
+    return
+  fi
+  # Search only staged content for the filtered file set (not the whole working tree)
+  # shellcheck disable=SC2086
+  if git diff --cached -- $CONTENT_STAGED | grep -qE "$PATTERN"; then
+    echo "[pre-commit] BLOCKED: $LABEL"
+    echo "  Pattern: $PATTERN"
+    FAIL=1
+  fi
+}
+
+# Personal identifiers
+check "personal email"            "rdemeritt@gmail\.com"
+check "personal username path"    "/Users/rdemeritt"
+check "personal domain"           "shallowfordroad\.com"
+check "personal LAN subnet"       "192\.168\.3\."
+
+# Infrastructure leaks
+check "self-hosted runner label"  "runs-on:.*\[self-hosted.*hammer"
+check "personal server hostname"  "\bhammer\b.*(runner|runs-on|self-hosted)"
+
+# Credential patterns
+check "hardcoded password var"    "(PASSWORD|SECRET|TOKEN)\s*=\s*['\"][A-Za-z0-9+/]{20,}['\"]"
+check "base64 secret (long)"      "['\"][A-Za-z0-9+/]{40,}={0,2}['\"]"
+check "BEGIN PRIVATE KEY"         "BEGIN (RSA |EC |OPENSSH |DSA )?PRIVATE KEY"
+check "session cookie value"      "hermithost_session=[a-zA-Z0-9%]{20,}"
+
+# Runtime-generated files that must not be committed
+for f in $STAGED; do
+  case "$f" in
+    cookies.txt|*.cookies.txt)
+      echo "[pre-commit] BLOCKED: cookies file staged: $f"
+      FAIL=1
+      ;;
+    traefik/conf.d/site-*.yml)
+      echo "[pre-commit] BLOCKED: runtime site config staged: $f"
+      FAIL=1
+      ;;
+    traefik/conf.d/routes.yml)
+      echo "[pre-commit] BLOCKED: generated routes.yml staged (use routes.yml.example)"
+      FAIL=1
+      ;;
+  esac
+done
+
+if [ "$FAIL" = "1" ]; then
+  echo ""
+  echo "[pre-commit] Commit blocked. Fix the above issues and re-stage."
+  echo "  To bypass in an emergency: git commit --no-verify (use sparingly)"
+  exit 1
+fi
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ cd hermithost
 bash scripts/setup.sh
 ```
 
+`setup.sh` handles first-time git hook activation (`git config core.hooksPath .githooks`) in addition to secrets and config. If you skip `setup.sh`, activate the hooks manually:
+
+```bash
+git config core.hooksPath .githooks
+```
+
 `setup.sh` will:
 - Generate all Coolify internal secrets automatically
 - Prompt for your **ACME email** (Let's Encrypt SSL notifications) — also used as the Coolify admin email

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,6 +17,10 @@ sed_i() {
   fi
 }
 
+# ── Configure git hooks ───────────────────────────────────────────────────────
+git -C "$ROOT" config core.hooksPath .githooks
+echo "[setup] Git hooks configured (.githooks/pre-commit)"
+
 # ── Create .env from template if it doesn't exist ────────────────────────────
 if [ ! -f "$ENV_FILE" ]; then
   cp "$TEMPLATE_FILE" "$ENV_FILE"


### PR DESCRIPTION
## Summary

- Adds `.githooks/pre-commit` — a committable shell hook that blocks staged content containing PII, private infrastructure details, or credential patterns before they reach the remote
- Wires `git config core.hooksPath .githooks` into `scripts/setup.sh` so the hook activates automatically for every contributor who runs setup
- Documents the manual activation one-liner in the Quick Start section of README for contributors who skip `setup.sh`

## Patterns blocked

| Category | What is blocked |
|---|---|
| Personal identifiers | `rdemeritt@gmail.com`, `/Users/rdemeritt`, `shallowfordroad.com`, `192.168.3.*` LAN subnet |
| Infrastructure leaks | Self-hosted runner labels referencing `hammer`, server hostname in CI config |
| Credentials | Hardcoded `PASSWORD=`/`SECRET=`/`TOKEN=` assignments, 40+ char base64 strings in quotes, PEM private key headers, hermithost session cookie values |
| Runtime files | `cookies.txt`, `traefik/conf.d/site-*.yml`, `traefik/conf.d/routes.yml` |

## False positive mitigation

Content checks skip lockfiles (`package-lock.json`, `yarn.lock`, `*.lock`), minified assets (`dist/`, `*.min.js`, `*.min.css`), and the hook file itself (`.githooks/pre-commit`) — since the hook file necessarily contains the literal pattern strings.

## Escape hatch

```bash
git commit --no-verify
```

Use only in genuine emergencies. The hook message prints this reminder on every block.

## Setup wiring

`scripts/setup.sh` now runs `git -C "$ROOT" config core.hooksPath .githooks` near the top, before any Docker operations. Contributors who clone and run `bash scripts/setup.sh` get the hook activated with no additional steps.