### PR TITLE
feat(internal-ca): adopt *.hh wildcard cert (DNS-01 Phase 4)

### DIFF
--- a/api/src/integration/dns01-issuance.integration.test.ts
+++ b/api/src/integration/dns01-issuance.integration.test.ts
@@ -134,6 +134,39 @@ describe.runIf(SHOULD_RUN)('Phase 3 — DNS-01 issuance E2E', () => {
     expect(match?.key, 'private key payload non-empty').toBeTruthy();
   }, 15000);
 
+  it('Phase 4 wildcard: leaf cert SAN includes *.hh (single wildcard for all .hh sites)', async () => {
+    // After Phase 4, the served leaf for any .hh site should be a wildcard
+    // cert with SAN "*.hh" — one cert covers every site. This complements
+    // the per-domain SAN check above; both must hold (CN may be the requested
+    // hostname while SAN list contains the wildcard).
+    const cert = await tlsHandshake(TEST_HOST, TEST_PORT, TEST_DOMAIN);
+    expect(cert.sans ?? '').toMatch(/DNS:\*\.hh\b/);
+  }, 15000);
+
+  it('Phase 4 wildcard: internal-acme.json stores a cert whose domain.main is "*.hh"', () => {
+    // The Traefik ACME storage should now hold a wildcard entry. Old
+    // per-host entries may remain until they expire (documented behavior;
+    // no migration required), but at least one entry must be the wildcard.
+    let raw = '';
+    try {
+      raw = execSync(
+        'docker exec hermithost-traefik-1 sh -c "cat /acme/internal-acme.json 2>/dev/null"',
+        { encoding: 'utf8', timeout: 10000 }
+      );
+    } catch {
+      return;
+    }
+    if (!raw) return;
+    const data = JSON.parse(raw) as {
+      'internal-ca'?: {
+        Certificates?: Array<{ domain?: { main?: string; sans?: string[] } }>;
+      };
+    };
+    const certs = data['internal-ca']?.Certificates ?? [];
+    const wildcard = certs.find((c) => c.domain?.main === '*.hh');
+    expect(wildcard, 'expected stored wildcard cert with domain.main = *.hh').toBeDefined();
+  }, 15000);
+
   it('Technitium hh zone has no leftover _acme-challenge TXT records (cleanup)', async () => {
     // Read token from coolify-api-token volume (read-only inspection).
     let token = '';

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -422,6 +422,20 @@ export async function provisionTraefikRoute(
       return { ok: false, reason: `no container for slug ${slug}` };
     }
     const containerName = containers[0].Names[0].replace(/^\//, '');
+    // Phase 4 wildcard adoption: when the resolver is internal-ca the
+    // certificate scope is the *.hh wildcard, so emit tls.domains pinned to
+    // the wildcard. Lego will request a single wildcard cert that serves
+    // every .hh router. Public-mode (letsencrypt) routes keep per-host
+    // issuance with no tls.domains block.
+    // See ADR-007 + security-review-dns01-phase4-wildcard-2026-05-03.md.
+    const tlsBlock =
+      resolver === 'internal-ca'
+        ? `      tls:
+        certResolver: ${resolver}
+        domains:
+          - main: "*.hh"`
+        : `      tls:
+        certResolver: ${resolver}`;
     const yml = `http:
   routers:
     site-${slug}-http:
@@ -436,8 +450,7 @@ export async function provisionTraefikRoute(
       rule: "Host(\`${domain}\`)"
       entryPoints:
         - https
-      tls:
-        certResolver: ${resolver}
+${tlsBlock}
       service: site-${slug}
 
   services:
@@ -447,7 +460,7 @@ export async function provisionTraefikRoute(
           - url: "http://${containerName}:${port}"
 `;
     writeFileSync(filePath, yml, 'utf8');
-    console.log(`[traefik-route] Route written for ${domain} → ${containerName}:${port}`);
+    console.log(`[traefik-route] Route written for ${domain} → ${containerName}:${port} (resolver=${resolver})`);
     return { ok: true };
   } catch (err) {
     const reason = (err as Error).message;
@@ -609,6 +622,15 @@ export async function provisionTraefikRouteForCompose(
     console.log(`[traefik-route-compose] ${containerName} is on coolify network`);
 
     // ── Step 6: Write Traefik yml (same structure as provisionTraefikRoute) ─────
+    // Phase 4 wildcard adoption: see provisionTraefikRoute() comment above.
+    const tlsBlock =
+      resolver === 'internal-ca'
+        ? `      tls:
+        certResolver: ${resolver}
+        domains:
+          - main: "*.hh"`
+        : `      tls:
+        certResolver: ${resolver}`;
     const yml = `http:
   routers:
     site-${slug}-http:
@@ -623,8 +645,7 @@ export async function provisionTraefikRouteForCompose(
       rule: "Host(\`${domain}\`)"
       entryPoints:
         - https
-      tls:
-        certResolver: ${resolver}
+${tlsBlock}
       service: site-${slug}
 
   services:
@@ -634,7 +655,7 @@ export async function provisionTraefikRouteForCompose(
           - url: "http://${containerName}:${port}"
 `;
     writeFileSync(filePath, yml, 'utf8');
-    console.log(`[traefik-route-compose] Route written for ${domain} → ${containerName}:${port}`);
+    console.log(`[traefik-route-compose] Route written for ${domain} → ${containerName}:${port} (resolver=${resolver})`);
     return { ok: true };
   } catch (err) {
     const reason = (err as Error).message;

--- a/scripts/step-ca-init.sh
+++ b/scripts/step-ca-init.sh
@@ -37,6 +37,15 @@ step ca init \
 # ── Add ACME provisioner with 90-day cert lifetime ────────────────────────────
 # The default JWK provisioner stays but is unused; Traefik will use 'acme'.
 # 90 days (2160h) balances security and homelab convenience.
+#
+# Policy block (Phase 4 wildcard adoption — security review §5.1):
+#   - allow.dns: only ".hh" SANs (exact apex + any subdomain via wildcard)
+#   - allowWildcardNames: true to permit "*.hh" SAN
+#   - deny: empty — implicit deny via the allow-list semantics
+# Without this policy, an ACME provisioner with no policy block accepts
+# any SAN. Pinning to .hh defends against mis-issuance even if a downstream
+# component sends a stray order. See:
+#   clients/self/projects/hermithost/specs/security-review-dns01-phase4-wildcard-2026-05-03.md
 jq '.authority.provisioners += [{
   "type": "ACME",
   "name": "acme",
@@ -45,6 +54,14 @@ jq '.authority.provisioners += [{
     "defaultTLSCertDuration": "2160h",
     "maxTLSCertDuration": "8760h",
     "minTLSCertDuration": "5m"
+  },
+  "policy": {
+    "x509": {
+      "allow": {
+        "dns": ["*.hh", "hh"]
+      },
+      "allowWildcardNames": true
+    }
   }
 }]' "$STEPPATH/config/ca.json" > /tmp/ca.json.tmp \
   && mv /tmp/ca.json.tmp "$STEPPATH/config/ca.json"

--- a/traefik/conf.d/wildcard-internal.yml
+++ b/traefik/conf.d/wildcard-internal.yml
@@ -1,0 +1,34 @@
+# Phase 4 — wildcard *.hh cert pre-fetch
+#
+# Declares a stub HTTPS router whose only purpose is to make Traefik request
+# a single *.hh wildcard cert from the internal-ca resolver at startup,
+# even before any per-site router file exists. This guarantees the wildcard
+# is available the moment the first .hh site comes online.
+#
+# - Listens on a Host that will never match real traffic ("wildcard-prefetch.hh")
+#   so this router does not interfere with site routing. Traefik still
+#   triggers an ACME order for the wildcard SAN declared in tls.domains.
+# - Service routes to a non-existent backend; the router exists only for
+#   cert acquisition. No traffic is expected to land here.
+# - Public-mode (letsencrypt) is unaffected: this file's tls.certResolver is
+#   pinned to internal-ca and only matters when that resolver is wired.
+#
+# See ADR-007 (DNS-01 internal CA) + Phase 4 security review.
+
+http:
+  routers:
+    wildcard-internal-prefetch:
+      rule: "Host(`wildcard-prefetch.hh`)"
+      entryPoints:
+        - https
+      tls:
+        certResolver: internal-ca
+        domains:
+          - main: "*.hh"
+      service: wildcard-internal-noop
+
+  services:
+    wildcard-internal-noop:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1:1"


### PR DESCRIPTION
## Summary

Phase 4 of the DNS-01 plan (ADR-007, closes #91). Switches internal-mode
TLS issuance from per-host `.hh` certs to a single `*.hh` wildcard.

- Cert count drops from O(sites) → O(1)
- New `.hh` sites no longer trigger an ACME order on deploy
- Public-mode `letsencrypt` resolver path is unchanged (byte-identical YAML output)

## Gates cleared

- **Security Reviewer — APPROVED with conditions** (LAN-only trust model + explicit step-ca policy). See `clients/self/projects/hermithost/specs/security-review-dns01-phase4-wildcard-2026-05-03.md` in harness.
- **QA Specialist — PASS** (static + opt-in live integration assertions). See `qa-signoff-dns01-phase4-wildcard-2026-05-03.md`.

## Changes

- `api/src/routes/sites.ts` — route YAML emits `tls.domains.main "*.hh"` only when `resolver === 'internal-ca'`
- `traefik/conf.d/wildcard-internal.yml` — stub router pre-fetches wildcard at Traefik start
- `scripts/step-ca-init.sh` — explicit ACME provisioner policy: `allow.dns = ["*.hh", "hh"]`, `allowWildcardNames: true`
- `api/src/integration/dns01-issuance.integration.test.ts` — 2 new assertions gated on `HERMITHOST_DNS01_TEST=1`

## Test plan

- [x] `npm --prefix api run build` — clean
- [x] `npm --prefix api test` — 44 pass / 5 skipped (2 new wildcard assertions added under existing opt-in gate)
- [ ] Operator: `bash scripts/restart.sh` on local LAN-mode stack
- [ ] Operator: `HERMITHOST_DNS01_TEST=1 npm --prefix api test -- dns01-issuance` — expect 5 PASS
- [ ] Operator: open `https://cantaconmigo.hh:8443` in browser; verify cert SAN list contains `*.hh`
- [ ] Operator: confirm `traefik.log` shows zero new ACME orders when adding a second `.hh` site
- [ ] Operator: bring up internet-mode (`HERMITHOST_PORT_MODE=internet ./scripts/start.sh`); confirm `letsencrypt` resolver loads cleanly

## Migration

Pre-existing per-host entries in `internal-acme.json` (e.g. `cantaconmigo.hh`)
are left to expire naturally at 90 days. No manual cleanup needed.

## Refs

- ADR-007 — `clients/self/projects/hermithost/specs/adr-007-dns-01-internal-ca-2026-05-01.md`
- Plan — `clients/self/projects/hermithost/specs/dns-01-implementation-plan-2026-05-01.md` (Phase 4 status: DONE)
- Issue #91