### PR TITLE
fix: Phase 4 wildcard routing — site routes must not set certresolver

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -422,18 +422,15 @@ export async function provisionTraefikRoute(
       return { ok: false, reason: `no container for slug ${slug}` };
     }
     const containerName = containers[0].Names[0].replace(/^\//, '');
-    // Phase 4 wildcard adoption: when the resolver is internal-ca the
-    // certificate scope is the *.hh wildcard, so emit tls.domains pinned to
-    // the wildcard. Lego will request a single wildcard cert that serves
-    // every .hh router. Public-mode (letsencrypt) routes keep per-host
-    // issuance with no tls.domains block.
+    // Phase 4 wildcard routing: internal-ca routes must NOT declare certResolver or
+    // tls.domains — wildcard-internal.yml owns the single *.hh cert acquisition via
+    // DNS-01. Individual site routes emit bare `tls: {}` so Traefik matches the
+    // pre-fetched *.hh cert by SNI without triggering a new ACME order per host.
+    // Public-mode (letsencrypt) routes declare their resolver for per-host issuance.
     // See ADR-007 + security-review-dns01-phase4-wildcard-2026-05-03.md.
     const tlsBlock =
       resolver === 'internal-ca'
-        ? `      tls:
-        certResolver: ${resolver}
-        domains:
-          - main: "*.hh"`
+        ? `      tls: {}`
         : `      tls:
         certResolver: ${resolver}`;
     const yml = `http:
@@ -622,13 +619,10 @@ export async function provisionTraefikRouteForCompose(
     console.log(`[traefik-route-compose] ${containerName} is on coolify network`);
 
     // ── Step 6: Write Traefik yml (same structure as provisionTraefikRoute) ─────
-    // Phase 4 wildcard adoption: see provisionTraefikRoute() comment above.
+    // Phase 4 wildcard routing: see provisionTraefikRoute() comment above.
     const tlsBlock =
       resolver === 'internal-ca'
-        ? `      tls:
-        certResolver: ${resolver}
-        domains:
-          - main: "*.hh"`
+        ? `      tls: {}`
         : `      tls:
         certResolver: ${resolver}`;
     const yml = `http:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -23,6 +23,36 @@ if [ -f "$ROOT/.env" ]; then
 fi
 
 PROFILE_ARG=""
+
+# ── Migrate stale per-site Traefik route files (Phase 4 fix) ──────────────────
+# Pre-Phase-4 route files emitted certresolver: internal-ca + domains per host,
+# causing every site router to independently trigger a DNS-01 wildcard challenge.
+# wildcard-internal.yml now owns the single *.hh cert acquisition. Site route
+# files must only carry `tls: {}` so Traefik matches the pre-fetched cert by SNI.
+#
+# This migration is only needed in LAN mode — internet mode uses letsencrypt and
+# never emits tls.domains on site routes.
+if [ "${HERMITHOST_PORT_MODE:-}" = "lan" ]; then
+  TRAEFIK_CONF="${ROOT}/traefik/conf.d"
+  for f in "$TRAEFIK_CONF"/site-*.yml; do
+    [ -f "$f" ] || continue
+    if grep -q 'certResolver\|certresolver' "$f" 2>/dev/null; then
+      echo "[start] Migrating stale wildcard cert config in: $f"
+      # Replace the 3-line tls block (certResolver + domains + main) with bare tls: {}
+      # Pattern covers both Phase-4 and any earlier variant that set certResolver directly.
+      # sed -i '' is required on macOS (BSD sed); -i alone works on GNU sed.
+      sed -i '' \
+        -e '/certResolver:/d' \
+        -e '/certresolver:/d' \
+        -e '/domains:/d' \
+        -e '/- main:/d' \
+        -e 's/^      tls:$/      tls: {}/' \
+        "$f"
+      echo "[start]   Done: $f"
+    fi
+  done
+fi
+
 if [ "${HERMITHOST_PORT_MODE:-}" = "lan" ]; then
   PROFILE_ARG="--profile internal"
   echo "[start] LAN mode detected — activating internal CA profile (step-ca)"


### PR DESCRIPTION
## Problem

Phase 4 introduced wildcard cert support for LAN mode (`.hh` TLD), but the route generation code in `provisionTraefikRoute` and `provisionTraefikRouteForCompose` emitted `certresolver: internal-ca` + `tls.domains[0].main: "*.hh"` on **every individual site router**. This caused every `.hh` site route to independently initiate a DNS-01 wildcard challenge, which races against itself and times out.

## Root Cause

`wildcard-internal.yml` is the designated single acquisition point for the `*.hh` wildcard cert. Site route files should never trigger their own ACME orders — they should rely on Traefik's SNI matching to select the already-fetched wildcard.

## Fix

**`api/src/routes/sites.ts`** — Both `provisionTraefikRoute()` and `provisionTraefikRouteForCompose()`:
- `resolver === 'internal-ca'` now emits `tls: {}` only (no certresolver, no domains)
- `resolver === 'letsencrypt'` (internet mode) is unchanged — still emits `tls.certResolver: letsencrypt`

**`scripts/start.sh`** — Added a startup migration that strips stale `certResolver`/`domains` blocks from any pre-Phase-4 `site-*.yml` files present on disk at boot time. Uses `sed -i ''` (BSD/macOS compatible).

**`traefik/conf.d/wildcard-internal.yml`** — No changes required; already correctly declares `certresolver: internal-ca` + `domains[0].main: "*.hh"` as the sole acquisition router.

## Verification

```bash
# Restart Traefik
docker compose --profile internal restart traefik

# Should see wildcard-internal.yml acquire *.hh once — no per-host DNS-01 attempts
docker compose --profile internal logs traefik --tail=50

# Should return 200
curl -skI https://cantaconmigo.hh

# Should show CN=*.hh, not CN=cantaconmigo.hh
echo | openssl s_client -connect cantaconmigo.hh:443 -servername cantaconmigo.hh 2>/dev/null | openssl x509 -noout -subject
```

## Files Changed

- `api/src/routes/sites.ts` — wildcard TLS block fix in both route provision functions
- `scripts/start.sh` — startup migration for stale per-host certresolver configs

Do NOT merge — awaiting QA sign-off.