### PR TITLE
fix: re-enable Traefik dashboard on localhost:9080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,6 +257,8 @@ services:
       - "--metrics.prometheus.addEntryPointsLabels=true"
       - "--metrics.prometheus.addRoutersLabels=true"
       - "--metrics.prometheus.addServicesLabels=true"
+      - "--api.dashboard=true"
+      - "--api.insecure=true"
       - "--ping=true"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/ping"]
@@ -281,7 +283,7 @@ services:
     ports:
       - "${TRAEFIK_HTTP_PORT:-8080}:80"
       - "${TRAEFIK_HTTPS_PORT:-8443}:443"
-      - "9080:9080"
+      - "127.0.0.1:9080:9080"
     volumes:
       - ./traefik/conf.d:/etc/traefik/conf.d
       - traefik-acme:/acme

--- a/traefik/conf.d/dashboard.yml
+++ b/traefik/conf.d/dashboard.yml
@@ -1,0 +1,7 @@
+http:
+  routers:
+    traefik-dashboard:
+      rule: "PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
+      service: "api@internal"
+      entryPoints:
+        - admin


### PR DESCRIPTION
Restores Traefik dashboard on the admin entrypoint (9080). Port 9080 was left orphaned after the api.insecure flag was removed in commit 4772c12. Dashboard is localhost-only. Also scopes the port binding to 127.0.0.1:9080 if not already.

## Changes

- `docker-compose.yml`: adds `--api.dashboard=true` and `--api.insecure=true` to Traefik command block; scopes port binding to `127.0.0.1:9080:9080`
- `traefik/conf.d/dashboard.yml`: dynamic router wiring `api@internal` to the `admin` entrypoint for `/api` and `/dashboard` path prefixes

## Verification

- `http://localhost:9080/dashboard/` → 200
- `http://localhost:9080/api/rawdata` → 200 valid JSON