### PR TITLE
fix: restore HermitHost UI on localhost:9080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,8 +257,6 @@ services:
       - "--metrics.prometheus.addEntryPointsLabels=true"
       - "--metrics.prometheus.addRoutersLabels=true"
       - "--metrics.prometheus.addServicesLabels=true"
-      - "--api.dashboard=true"
-      - "--api.insecure=true"
       - "--ping=true"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/ping"]

--- a/traefik/conf.d/admin.yml
+++ b/traefik/conf.d/admin.yml
@@ -1,0 +1,24 @@
+http:
+  routers:
+    hermithost-api-admin:
+      rule: "PathPrefix(`/api`)"
+      entryPoints:
+        - admin
+      service: hermithost-api
+
+    hermithost-frontend-admin:
+      rule: "PathPrefix(`/`)"
+      entryPoints:
+        - admin
+      service: hermithost-frontend
+
+  services:
+    hermithost-api:
+      loadBalancer:
+        servers:
+          - url: "http://api:3001"
+
+    hermithost-frontend:
+      loadBalancer:
+        servers:
+          - url: "http://frontend:3000"

--- a/traefik/conf.d/dashboard.yml
+++ b/traefik/conf.d/dashboard.yml
@@ -1,7 +1,0 @@
-http:
-  routers:
-    traefik-dashboard:
-      rule: "PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
-      service: "api@internal"
-      entryPoints:
-        - admin


### PR DESCRIPTION
## Summary
- Reverts PR #109 Traefik dashboard additions (`--api.dashboard=true` and `--api.insecure=true`) from the Traefik command block in `docker-compose.yml`
- Removes `traefik/conf.d/dashboard.yml` which incorrectly routed the admin entrypoint (9080) to the Traefik internal dashboard
- Restores `traefik/conf.d/admin.yml` routing 9080 → HermitHost frontend (`frontend:3000`) and API (`api:3001`)
- Retains the `127.0.0.1:9080:9080` localhost-only port binding from PR #109

## Test plan
- [ ] `curl -sI http://localhost:9080/` returns 200 or login redirect, not Traefik dashboard HTML
- [ ] `curl -sI http://localhost:9080/api/health` returns 200
- [ ] Traefik dashboard is not accessible on any public port