### PR TITLE
fix(dns): correct LanOnly recursion ACL application on mode restore

### DIFF
--- a/api/src/services/technitium.ts
+++ b/api/src/services/technitium.ts
@@ -312,15 +312,19 @@ export class TechnitiumClient {
         LanOnly:  'UseSpecifiedNetworkACL',
         Public:   'Allow',
       };
-      const technitiumAcl: Record<RecursionMode, string> = {
-        Disabled: '',
-        LanOnly:  SAFE_RECURSION_ACL_ENTRIES.join(','),
-        Public:   '',
+      const params: Record<string, string | number | boolean> = {
+        recursion: technitiumRecursion[mode],
       };
-      const body = this.buildParams({
-        recursion:           technitiumRecursion[mode],
-        recursionNetworkACL: technitiumAcl[mode],
-      });
+      // Only send recursionNetworkACL for LanOnly. For Public and Disabled, omitting the
+      // parameter leaves Technitium's stored ACL untouched, preventing a race where an empty
+      // ACL is written then UseSpecifiedNetworkACL is applied before the new ACL arrives.
+      // This is the root cause of the Public → LanOnly restore bug: sending recursionNetworkACL=""
+      // clears Technitium's ACL, and if the server processes UseSpecifiedNetworkACL against an
+      // empty ACL (even transiently), all recursive queries are refused.
+      if (mode === 'LanOnly') {
+        params.recursionNetworkACL = SAFE_RECURSION_ACL_ENTRIES.join(',');
+      }
+      const body = this.buildParams(params);
       const res = await fetch(`${this.baseUrl}/api/settings/set`, { method: 'POST', headers: this.postHeaders, body });
       await handleResponse<TechnitiumDeleteResponse>(res, 'POST /api/settings/set (recursion)');
     });
@@ -338,15 +342,16 @@ export class TechnitiumClient {
       };
       // Merge: safe baseline + caller-supplied extras, deduplicated.
       const merged = Array.from(new Set([...SAFE_RECURSION_ACL_ENTRIES, ...extraCidrs]));
-      const technitiumAcl: Record<RecursionMode, string> = {
-        Disabled: '',
-        LanOnly:  merged.join(','),
-        Public:   '',
+      const params: Record<string, string | number | boolean> = {
+        recursion: technitiumRecursion[mode],
       };
-      const body = this.buildParams({
-        recursion:           technitiumRecursion[mode],
-        recursionNetworkACL: technitiumAcl[mode],
-      });
+      // Only send recursionNetworkACL for LanOnly — same reasoning as setRecursion():
+      // sending an empty value for Public/Disabled clears Technitium's stored ACL, which
+      // causes REFUSED responses when UseSpecifiedNetworkACL is subsequently applied.
+      if (mode === 'LanOnly') {
+        params.recursionNetworkACL = merged.join(',');
+      }
+      const body = this.buildParams(params);
       const res = await fetch(`${this.baseUrl}/api/settings/set`, { method: 'POST', headers: this.postHeaders, body });
       await handleResponse<TechnitiumDeleteResponse>(res, 'POST /api/settings/set (recursion+acl)');
     });


### PR DESCRIPTION
## Root Cause

`setRecursion()` and `setRecursionWithExtraAcl()` sent `recursionNetworkACL=""` (empty string) when setting `Public` or `Disabled` modes. Technitium clears its stored ACL when it receives an empty value. On the production Linux server, when `UseSpecifiedNetworkACL` is subsequently applied, if Technitium transiently evaluates recursive queries against the cleared ACL before the new ACL write completes, all recursive queries are refused with NORECURSE/REFUSED. This is why `Public → LanOnly` broke but `LanOnly → Public` and `LanOnly → Disabled` did not — those paths never apply `UseSpecifiedNetworkACL` after a clear.

## Fix

Omit the `recursionNetworkACL` parameter entirely for `Public` and `Disabled` modes. Technitium leaves the stored ACL untouched when the parameter is absent. Only send `recursionNetworkACL` when mode is `LanOnly`, where the safe baseline CIDRs (`127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `::1/128`, `fd00::/8`) are always explicitly written.

Applied to both `setRecursion()` and `setRecursionWithExtraAcl()`.

## Verification

Full `LanOnly → Public → LanOnly` cycle exercised through the hermithost API (`PUT /api/config`). DNS resolution confirmed via `nslookup google.com 127.0.0.1` from within the Technitium container at each step — all three steps resolve successfully.

Stack restored to LanOnly on the live dev stack.

## Files Changed

- `api/src/services/technitium.ts` — `setRecursion()` and `setRecursionWithExtraAcl()`