### PR TITLE
fix(traefik): bind admin port 9080 to all interfaces

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,7 +281,7 @@ services:
     ports:
       - "${TRAEFIK_HTTP_PORT:-8080}:80"
       - "${TRAEFIK_HTTPS_PORT:-8443}:443"
-      - "127.0.0.1:9080:9080"
+      - "9080:9080"
     volumes:
       - ./traefik/conf.d:/etc/traefik/conf.d
       - traefik-acme:/acme


### PR DESCRIPTION
## Summary
- `127.0.0.1:9080:9080` causes `ERR_EMPTY_RESPONSE` on macOS Docker Desktop — TCP handshake completes but the host→container data path silently drops
- Changed to `9080:9080` (bind all interfaces), which is correct for a LAN-accessible self-hosted service
- Verified: `curl localhost:9080/` → 200 after Traefik restart

## Test plan
- [ ] `http://localhost:9080` loads HermitHost UI
- [ ] `http://localhost:9080/api/health` returns JSON
- [ ] Public entrypoints (8080/8443) unaffected
- [ ] cantaconmigo.hh still resolves and serves correctly