### PR TITLE
fix(deploy): control char safety, container scoping, port conflict guard, newest-container routing

### DIFF
--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -473,11 +473,12 @@ export async function provisionTraefikRoute(
     // Do NOT use all=true — after a Coolify redeploy the old stopped container still carries
     // the same label and would be returned first, pointing the route at a dead container (502).
     const filter = encodeURIComponent(JSON.stringify({ label: [`coolify.name=${slug}`], status: ['running'] }));
-    const containers = await dockerGet(`/containers/json?filters=${filter}`) as Array<{ Names: string[] }>;
+    const containers = await dockerGet(`/containers/json?filters=${filter}`) as Array<{ Names: string[]; Created: number }>;
     if (!containers.length) {
       console.warn(`[traefik-route] No running container found for slug ${slug} — route not written`);
       return { ok: false, reason: `no running container for slug ${slug}` };
     }
+    containers.sort((a, b) => b.Created - a.Created);
     const containerName = containers[0].Names[0].replace(/^\//, '');
     // Phase 4 wildcard routing: internal-ca routes must NOT declare certResolver or
     // tls.domains — wildcard-internal.yml owns the single *.hh cert acquisition via
@@ -633,6 +634,7 @@ export async function provisionTraefikRouteForCompose(
       );
       return { ok: false, reason: `no running container for project=${slug} service=${primaryService}` };
     }
+    containers.sort((a, b) => b.Created - a.Created);
     const container = containers[0];
     const containerId: string = container.Id as string;
     const containerName: string = (container.Names as string[])[0].replace(/^\//, '');
@@ -1698,6 +1700,47 @@ router.post('/:slug/deploy', async (req: Request, res: Response) => {
       } catch (preflightErr) {
         // Non-fatal: log and continue — don't block deploy on preflight failure
         console.warn(`[deploy-preflight] env check failed for ${req.params.slug}:`, (preflightErr as Error).message);
+      }
+    }
+
+    // ── Deploy preflight: port conflict guard ─────────────────────────────────
+    // Only applies to dockercompose apps with a compose manifest.
+    if (app.build_pack === 'dockercompose' && app.docker_compose_raw) {
+      try {
+        const parsedCompose = yaml.load(app.docker_compose_raw) as Record<string, unknown>;
+        const composeServices = (parsedCompose?.services ?? {}) as Record<string, { ports?: Array<string | number> }>;
+        const hostPorts: string[] = [];
+        for (const svc of Object.values(composeServices)) {
+          for (const entry of svc.ports ?? []) {
+            const raw = String(entry);
+            // Host port is the part before ':', or the whole value if no ':'
+            const hostPart = raw.includes(':') ? raw.split(':')[0] : raw;
+            const portNum = hostPart.replace(/[^0-9]/g, '');
+            if (portNum) hostPorts.push(portNum);
+          }
+        }
+        if (hostPorts.length > 0) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const runningContainers = await dockerGet('/containers/json') as Array<any>;
+          const conflicts: string[] = [];
+          for (const hostPort of hostPorts) {
+            for (const c of runningContainers) {
+              const ports: Array<{ PublicPort?: number }> = c.Ports ?? [];
+              const bound = ports.some((p) => String(p.PublicPort) === hostPort);
+              if (bound) {
+                const name = (c.Names as string[])?.[0]?.replace(/^\//, '') ?? c.Id;
+                conflicts.push(`${hostPort} already allocated by container ${name}`);
+              }
+            }
+          }
+          if (conflicts.length > 0) {
+            res.status(409).json({ error: 'Port conflict detected', conflicts });
+            return;
+          }
+        }
+      } catch (portCheckErr) {
+        // Non-fatal: never block deploy due to port check failure
+        console.warn(`[deploy-preflight] port conflict check failed for ${req.params.slug}:`, (portCheckErr as Error).message);
       }
     }
 

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -1713,10 +1713,11 @@ router.post('/:slug/deploy', async (req: Request, res: Response) => {
         for (const svc of Object.values(composeServices)) {
           for (const entry of svc.ports ?? []) {
             const raw = String(entry);
-            // Host port is the part before ':', or the whole value if no ':'
-            const hostPart = raw.includes(':') ? raw.split(':')[0] : raw;
-            const portNum = hostPart.replace(/[^0-9]/g, '');
-            if (portNum) hostPorts.push(portNum);
+            // Format is [ip:]host:container — host port is second-to-last segment
+            const parts = raw.split(':');
+            const hostPart = parts.length >= 2 ? parts[parts.length - 2] : parts[0];
+            const portNum = parseInt(hostPart.replace(/[^0-9]/g, ''), 10);
+            if (!isNaN(portNum) && portNum > 0) hostPorts.push(String(portNum));
           }
         }
         if (hostPorts.length > 0) {

--- a/api/src/services/coolify.ts
+++ b/api/src/services/coolify.ts
@@ -142,7 +142,9 @@ async function handleResponse<T>(res: Response, context: string): Promise<T> {
     const body = await res.text().catch(() => '(unreadable)');
     throw new Error(`Coolify ${context} failed: HTTP ${res.status} — ${body}`);
   }
-  return res.json() as Promise<T>;
+  const text = await res.text();
+  const sanitized = text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, '');
+  return JSON.parse(sanitized) as T;
 }
 
 export class CoolifyClient {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -347,6 +347,7 @@ services:
       PGPASSWORD: "${COOLIFY_DB_PASSWORD}"
       DOCKER_PROXY_URL: "http://docker-proxy:2375"
       COOLIFY_NETWORK_NAME: "${COMPOSE_PROJECT_NAME:-hermithost}-coolify"
+      COOLIFY_CONTAINER_NAME: "${COMPOSE_PROJECT_NAME:-hermithost}-coolify-1"
     volumes:
       - hermithost-sites:/app/sites
       - coolify-api-token:/coolify-api-token


### PR DESCRIPTION
## Summary

- **Control char sanitization** — `handleResponse` in `coolify.ts` now strips ASCII control characters from Coolify API responses before `JSON.parse`, preventing crashes on ANSI-escaped log output embedded in response bodies
- **COOLIFY_CONTAINER_NAME scoping** — API service in `docker-compose.yml` now gets `COOLIFY_CONTAINER_NAME` derived from `COMPOSE_PROJECT_NAME`, fixing `spawn docker ENOENT` on non-default named instances (e.g. `copper-rabbit`)
- **Pre-deploy port conflict guard** — `POST /:slug/deploy` now parses the compose file, queries Docker for allocated host ports, and returns `409` with a `conflicts` array before triggering a deploy that would fail mid-run; handles IP-bound port syntax (`127.0.0.1:3000:8080`)
- **Newest-container sort** — `provisionTraefikRoute` and `provisionTraefikRouteForCompose` now sort Docker results by `Created` descending before picking the target container, eliminating stale 502s when Coolify rolls a new container in during redeploy

## Test plan

- [x] TypeScript build clean (`tsc` exits 0)
- [x] All 44 unit tests pass (5 skipped)
- [x] QA specialist reviewed — 9/10 pass, 1 medium (IP port parsing) fixed before merge
- [x] VC Specialist signed off — NON-BLOCKING
- [ ] Deploy cantaconmigo on macbeth internal stack after merge and confirm no stale 502 on redeploy
- [ ] Trigger a deploy with a port conflict in compose and confirm 409 response