### PR TITLE
fix(step-ca): prevent PID exhaustion from zombie health check processes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,9 @@ services:
       - ./scripts/step-ca-entrypoint.sh:/scripts/step-ca-entrypoint.sh:ro
     networks:
       - hermithost-net
+    # tini as PID 1 reaps zombie children from health check forks,
+    # preventing PID exhaustion over multi-day uptime.
+    init: true
     restart: unless-stopped
     depends_on:
       step-ca-init:
@@ -137,9 +140,9 @@ services:
       technitium:
         condition: service_healthy
     # step-ca binds :9000; curl is not in the image so we use wget (busybox).
-    # -k: self-signed root during first boot is acceptable here.
+    # CMD (exec) form avoids an intermediate /bin/sh child that could zombie.
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- --no-check-certificate https://localhost:9000/health || exit 1"]
+      test: ["CMD", "wget", "-qO-", "--no-check-certificate", "https://localhost:9000/health"]
       interval: 10s
       retries: 12
       timeout: 5s


### PR DESCRIPTION
## Summary

- **Root cause:** step-ca container accumulates ~14,758 zombie PIDs over ~25 hours of uptime. Health check uses `CMD-SHELL`, which forks `/bin/sh → wget`. Since step-ca Go binary is PID 1 and doesn't reap children, each health check cycle leaves zombie processes. Eventually `fork()` returns `EAGAIN` and the container goes permanently unhealthy.
- **Fix 1 (`init: true`):** Docker injects `tini` as PID 1, which properly reaps all zombie children from health check forks — the permanent fix.
- **Fix 2 (CMD exec form):** Switches healthcheck from `CMD-SHELL` to `CMD` exec form, eliminating the intermediate `/bin/sh` process and halving the fork rate per health check cycle.

**Option A (container restart) was already applied directly on macbeth to restore health immediately.**

## Test plan

- [ ] Deploy to copper-rabbit stack on macbeth: `./scripts/start.sh -d --build`
- [ ] Confirm `copper-rabbit-step-ca-1` shows `(healthy)` in `docker ps`
- [ ] After 30+ minutes, verify pids.current in step-ca cgroup stays low (< 100)
- [ ] Confirm Traefik ACME cert renewal still works (step-ca endpoint reachable)