### PR TITLE
fix(network): make all network name references dynamic via COMPOSE_PROJECT_NAME

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,7 +6,7 @@ services:
     command:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
-      - "--providers.docker.network=hermithost-net"
+      - "--providers.docker.network=${COMPOSE_PROJECT_NAME:-hermithost}_hermithost-net"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"

--- a/scripts/conf.d/technitium-tsig-init.sh
+++ b/scripts/conf.d/technitium-tsig-init.sh
@@ -81,7 +81,7 @@ fi
 # The network name in docker compose is hermithost_hermithost-net.
 # We use docker network inspect to get the actual CIDR rather than hardcoding.
 HERMITHOST_NET_SUBNET=""
-for NET_NAME in hermithost_hermithost-net hermithost-net; do
+for NET_NAME in "${COMPOSE_PROJECT_NAME:-hermithost}_hermithost-net" hermithost-net; do
   if docker network inspect "$NET_NAME" --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}' >/dev/null 2>&1; then
     HERMITHOST_NET_SUBNET="$(docker network inspect "$NET_NAME" --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || true)"
     if [ -n "$HERMITHOST_NET_SUBNET" ]; then

--- a/scripts/rotate-tsig.sh
+++ b/scripts/rotate-tsig.sh
@@ -33,15 +33,19 @@ ENV_FILE="$ROOT/.env"
 # ── Resolve required vars ─────────────────────────────────────────────────────
 TECHNITIUM_URL="${TECHNITIUM_URL:-}"
 TECHNITIUM_TOKEN="${TECHNITIUM_TOKEN:-}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-}"
 
-if [ -z "$TECHNITIUM_URL" ] || [ -z "$TECHNITIUM_TOKEN" ]; then
+if [ -z "$TECHNITIUM_URL" ] || [ -z "$TECHNITIUM_TOKEN" ] || [ -z "$COMPOSE_PROJECT_NAME" ]; then
   if [ -f "$ENV_FILE" ]; then
     _URL="$(grep -E '^TECHNITIUM_URL=' "$ENV_FILE" | cut -d'=' -f2- || true)"
     _TOKEN="$(grep -E '^TECHNITIUM_TOKEN=' "$ENV_FILE" | cut -d'=' -f2- || true)"
+    _PROJECT="$(grep -E '^COMPOSE_PROJECT_NAME=' "$ENV_FILE" | cut -d'=' -f2- | tr -d '[:space:]' || true)"
     TECHNITIUM_URL="${TECHNITIUM_URL:-$_URL}"
     TECHNITIUM_TOKEN="${TECHNITIUM_TOKEN:-$_TOKEN}"
+    COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$_PROJECT}"
   fi
 fi
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-hermithost}"
 
 if [ -z "$TECHNITIUM_URL" ]; then
   echo "[rotate-tsig] ERROR: TECHNITIUM_URL is not set." >&2
@@ -65,7 +69,7 @@ NEW_SECRET="$(openssl rand -base64 32 | tr -d '\n')"
 
 # ── Detect hermithost-net subnet ──────────────────────────────────────────────
 HERMITHOST_NET_SUBNET=""
-for NET_NAME in hermithost_hermithost-net hermithost-net; do
+for NET_NAME in "${COMPOSE_PROJECT_NAME:-hermithost}_hermithost-net" hermithost-net; do
   HERMITHOST_NET_SUBNET="$(docker network inspect "$NET_NAME" --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || true)"
   if [ -n "$HERMITHOST_NET_SUBNET" ]; then
     break

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -189,6 +189,7 @@ if [ "${HERMITHOST_PORT_MODE:-}" = "lan" ]; then
       -e TECHNITIUM_URL="${_TECH_URL}" \
       -e HERMITHOST_PORT_MODE="${_PORT_MODE}" \
       -e RFC2136_ZONE="${_RFC2136_ZONE}" \
+      -e COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}" \
       docker:cli sh -c "apk add --no-cache bash openssl curl >/dev/null 2>&1 && bash /scripts/conf.d/technitium-tsig-init.sh"
 
     # Verify secret was written


### PR DESCRIPTION
## Summary

- **Root cause:** Four locations in scripts and compose overrides hardcoded the `hermithost` project name when constructing Docker network names. Multi-stack deployments (e.g. `copper-rabbit`) would resolve the wrong network, causing TSIG subnet detection and Traefik routing to fail.
- **Fix:** All four locations now derive the Docker network name from `${COMPOSE_PROJECT_NAME:-hermithost}_hermithost-net`, consistent with how volumes and coolify network are already handled.

### Files changed

| File | Change |
|------|--------|
| `docker-compose.prod.yml:9` | Traefik `providers.docker.network` now uses `${COMPOSE_PROJECT_NAME:-hermithost}_hermithost-net` |
| `scripts/start.sh` | Added `-e COMPOSE_PROJECT_NAME` to the `docker run` that calls `technitium-tsig-init.sh` |
| `scripts/conf.d/technitium-tsig-init.sh:84` | Subnet detection loop uses env var instead of hardcoded `hermithost` |
| `scripts/rotate-tsig.sh` | Reads `COMPOSE_PROJECT_NAME` from env → `.env` → default `hermithost` (same pattern as `TECHNITIUM_URL`/`TOKEN`); uses it in subnet detection loop |

## Test plan

- [ ] Deploy with `COMPOSE_PROJECT_NAME=hermithost` (default) — network resolves to `hermithost_hermithost-net` ✓
- [ ] Deploy with `COMPOSE_PROJECT_NAME=copper-rabbit` — network resolves to `copper-rabbit_hermithost-net` ✓
- [ ] Confirm `./scripts/rotate-tsig.sh` reads project name from `.env` without requiring env export
- [ ] Confirm Traefik in prod overlay connects to correct network on non-default project name